### PR TITLE
Set API timeout to match MediaWiki app's timeout

### DIFF
--- a/config/localSettings.base.ts
+++ b/config/localSettings.base.ts
@@ -12,7 +12,8 @@ import Utils = require('../server/lib/Utils');
 var localSettings: LocalSettings = {
 	apiBase: '/api/v1',
 	// Default timeout for backend requests
-	backendRequestTimeout: 30000,
+	// This timeout is the same as the MW app timeout
+	backendRequestTimeout: 300000,
 	// Targeted environment [prod|preview|verify|dev|testing]
 	environment: Utils.getEnvironment(process.env.WIKIA_ENVIRONMENT),
 	// NOTE: On your devbox, use your eth0 address in able to bind route to something accessible


### PR DESCRIPTION
NewRelic was throwing errors because of timeouts caused by long parses. Mercury's timeouts were capped at 30s while MW's are capped at 5m. This pull request raises our timeout to match that.