### PR TITLE
Reminder about whitespace

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -96,7 +96,7 @@ class App {
 	 * @param isDevbox
 	 * @returns {function (hapi.Request, Function): void}
 	 */
-	private getOnPreResponseHandler(isDevbox: boolean) {
+	private getOnPreResponseHandler (isDevbox: boolean) {
 		return (request: Hapi.Request, reply: any): void => {
 			var response = <Hapi.Response>(request.response),
 				responseTimeSec = (Date.now() - request.info.received) / 1000;
@@ -124,7 +124,7 @@ class App {
 	 *
 	 * @param server
 	 */
-	private setupLogging(server: Hapi.Server): void {
+	private setupLogging (server: Hapi.Server): void {
 		server.on('log', (event: any, tags: Array<string>) => {
 			logger.info({
 				data: event.data,

--- a/server/lib/Caching.ts
+++ b/server/lib/Caching.ts
@@ -49,7 +49,7 @@ module Caching {
 	 * @param response
 	 * @param cachingSettings
 	 */
-	export function setResponseCaching(response: Hapi.Response, cachingSettings: CachingSettings) {
+	export function setResponseCaching (response: Hapi.Response, cachingSettings: CachingSettings) {
 		if (cachingSettings && cachingSettings.enabled && response.statusCode === 200) {
 
 			if (cachingSettings.browserTTL === Interval.default) {
@@ -58,7 +58,7 @@ module Caching {
 			if (cachingSettings.cachingPolicy === Policy.Public) {
 				// Varnish caches for 5 seconds when Apache sends Cache-Control: public, s-maxage=0
 				// perform this logic here
-				if ( cachingSettings.varnishTTL === Interval.disabled ) {
+				if (cachingSettings.varnishTTL === Interval.disabled) {
 					cachingSettings.varnishTTL = 5;
 				}
 				response.header('Cache-Control', 's-maxage=' + cachingSettings.varnishTTL);
@@ -77,7 +77,7 @@ module Caching {
 	 * @param policy
 	 * @returns {string}
 	 */
-	export function policyString(policy: Policy): string {
+	export function policyString (policy: Policy): string {
 		return Policy[policy].toLowerCase();
 	}
 }

--- a/server/lib/Logger.ts
+++ b/server/lib/Logger.ts
@@ -29,7 +29,7 @@ module Logger {
 	 * @param minLogLevel
 	 * @returns {{stream: WritableStream, level: string}}
 	 */
-	function createDefaultLogStream(minLogLevel: string = 'info'): BunyanLoggerStream {
+	function createDefaultLogStream (minLogLevel: string = 'info'): BunyanLoggerStream {
 		return {
 			level: minLogLevel,
 			stream: process.stderr
@@ -42,7 +42,7 @@ module Logger {
 	 * @param minLogLevel
 	 * @returns {{level: string, stream: exports}}
 	 */
-	function createConsoleStream(minLogLevel: string): BunyanLoggerStream {
+	function createConsoleStream (minLogLevel: string): BunyanLoggerStream {
 		var PrettyStream = require('bunyan-prettystream'),
 			prettyStdOut = new PrettyStream();
 		prettyStdOut.pipe(process.stdout);
@@ -58,7 +58,7 @@ module Logger {
 	 * @param minLogLevel
 	 * @returns {{level: string, type: string, stream: any}}
 	 */
-	function createSysLogStream(minLogLevel: string): BunyanLoggerStream {
+	function createSysLogStream (minLogLevel: string): BunyanLoggerStream {
 		var bsyslog = require('bunyan-syslog');
 		return {
 			level: minLogLevel,
@@ -76,7 +76,7 @@ module Logger {
 	 * @param loggerConfig
 	 * @returns {BunyanLogger}
 	 */
-	export function createLogger(loggerConfig: LoggerInterface): BunyanLogger {
+	export function createLogger (loggerConfig: LoggerInterface): BunyanLogger {
 		var streams: Array<BunyanLoggerStream> = [];
 		Object.keys(loggerConfig).forEach((loggerType: string) => {
 			if (!availableTargets.hasOwnProperty(loggerType)) {

--- a/server/lib/Tracking.ts
+++ b/server/lib/Tracking.ts
@@ -8,7 +8,7 @@ module Comscore {
 		return 'wikiacsid_' + vertical.toLowerCase();
 	}
 
-	function getC7ParamAndValue(requestUrl: string, c7Value: string): string {
+	function getC7ParamAndValue (requestUrl: string, c7Value: string): string {
 		var paramAndValue = requestUrl +
 			(requestUrl.indexOf('?') !== -1 ? '&' : '?') +
 			localSettings.tracking.comscore.keyword +

--- a/server/lib/Utils.ts
+++ b/server/lib/Utils.ts
@@ -121,12 +121,12 @@ module Utils {
 	}
 
 	/**
-	* @desc Get vertical color from localSettings
-	*
-	* @param {LocalSettings} localSettings
-	* @param {string} vertical
-	* @return {string}
-	*/
+	 * @desc Get vertical color from localSettings
+	 *
+	 * @param {LocalSettings} localSettings
+	 * @param {string} vertical
+	 * @return {string}
+	 */
 	export function getVerticalColor (localSettings: LocalSettings, vertical: string): string {
 		if (localSettings.verticalColors.hasOwnProperty(vertical)) {
 			return localSettings.verticalColors[vertical];

--- a/server/lib/Utils.ts
+++ b/server/lib/Utils.ts
@@ -22,7 +22,7 @@ module Utils {
 	 * @param {Environment} fallbackEnvironment Fallback environment
 	 * @returns {Environment}
 	 */
-	export function getEnvironment(environment: string, fallbackEnvironment: Environment = Environment.Dev) {
+	export function getEnvironment (environment: string, fallbackEnvironment: Environment = Environment.Dev) {
 		var environments: {[id: string]: Environment} = {
 			// TODO: Remove `production` environment once all changes are propagated
 			production: Environment.Prod,
@@ -46,7 +46,7 @@ module Utils {
 	 * @param {Environment} environment
 	 * @return {string}
 	 */
-	export function getEnvironmentString(environment: Environment): string {
+	export function getEnvironmentString (environment: Environment): string {
 		return Environment[environment].toLowerCase();
 	}
 
@@ -57,7 +57,7 @@ module Utils {
 	 * @param wikiSubDomain
 	 * @returns {string}
 	 */
-	function getDomainName(localSettings: LocalSettings, wikiSubDomain: string): string {
+	function getDomainName (localSettings: LocalSettings, wikiSubDomain: string): string {
 		if (localSettings.environment === Environment.Sandbox) {
 			return localSettings.host + '.' + wikiSubDomain + '.wikia.com';
 		}
@@ -69,7 +69,7 @@ module Utils {
 	 * @desc Get fallback domain
 	 * @returns {string}
 	 */
-	function getFallbackSubDomain(localSettings: LocalSettings): string {
+	function getFallbackSubDomain (localSettings: LocalSettings): string {
 		return (localSettings.wikiFallback || 'community');
 	}
 
@@ -121,12 +121,12 @@ module Utils {
 	}
 
 	/**
-	 * @desc Get vertical color from localSettings
-	 *
-	 * @param {LocalSettings} localSettings
-	 * @param {string} vertical
-	 * @return {string}
-	 */
+	* @desc Get vertical color from localSettings
+	*
+	* @param {LocalSettings} localSettings
+	* @param {string} vertical
+	* @return {string}
+	*/
 	export function getVerticalColor (localSettings: LocalSettings, vertical: string): string {
 		if (localSettings.verticalColors.hasOwnProperty(vertical)) {
 			return localSettings.verticalColors[vertical];

--- a/server/server.ts
+++ b/server/server.ts
@@ -27,14 +27,14 @@ cluster.setupMaster({
  *
  * @returns {number} Current number of workers
  */
-function numWorkers(): number {
+function numWorkers (): number {
 	return Object.keys(cluster.workers).length;
 }
 
 /**
  * Forks off the workers unless the server is stopping
  */
-function forkNewWorkers(): void {
+function forkNewWorkers (): void {
 	if (!isStopping) {
 		for (var i = numWorkers(); i < localSettings.workerCount; i++) {
 			cluster.fork();
@@ -48,7 +48,7 @@ function forkNewWorkers(): void {
  *
  * @param worker
  */
-function stopWorker(worker: cluster.Worker): void {
+function stopWorker (worker: cluster.Worker): void {
 	logger.info('Stopping worker');
 
 	worker.send('shutdown');
@@ -71,7 +71,7 @@ function stopWorker(worker: cluster.Worker): void {
 /**
  * Stops all the workers at once
  */
-function stopAllWorkers(): void {
+function stopAllWorkers (): void {
 	isStopping = true;
 
 	logger.info('Stopping all workers');


### PR DESCRIPTION
Remember to check for style in your code reviews.

Two main whitespace errors here are the:
* space after function name
* no whitespace surrounding arguments/conditions in parens

Remember, our TS guidelines fall back to JS guidelines where applicable. Developers should familiarize themselves with the TS and JS guidelines [here](https://github.com/Wikia/guidelines).