### PR TITLE
Fixed unhandled TypeError when no title is given

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -73,6 +73,9 @@ function beforeArticleRender (request: Hapi.Request, result: any): void {
 		title = articleDetails.cleanTitle ? articleDetails.cleanTitle : articleDetails.title;
 	} else if (request.params.title) {
 		title = request.params.title.replace(/_/g, ' ');
+	} else {
+		title = result.wiki.mainPageTitle.replace(/_/g, ' ');
+		result.isMainPage = true;
 	}
 
 	if (result.article.article) {
@@ -87,7 +90,6 @@ function beforeArticleRender (request: Hapi.Request, result: any): void {
 	}
 
 	result.displayTitle = title;
-	result.isMainPage = (title === result.wiki.mainPageTitle.replace(/_/g, ' '));
 	result.canonicalUrl = result.wiki.basePath + result.wiki.articlePath + title.replace(/ /g, '_');
 	result.themeColor = Utils.getVerticalColor(localSettings, result.wiki.vertical);
 	result.query = {


### PR DESCRIPTION
Get rid of error:
```
Possibly unhandled TypeError: Cannot call method 'replace' of undefined
    at beforeArticleRender (/home/igor/workspace/mercury/www/server/routes.js:77:82)
    at onArticleResponse (/home/igor/workspace/mercury/www/server/routes.js:104:9)
    at /home/igor/workspace/mercury/www/server/routes.js:150:33
    at /home/igor/workspace/mercury/www/server/controllers/article/index.js:105:9
    at /home/igor/workspace/mercury/www/server/controllers/article/index.js:61:9
    at tryCatch1 (/home/igor/workspace/mercury/www/node_modules/bluebird/js/main/util.js:21:21)
    at Promise._settlePromiseFromHandler (/home/igor/workspace/mercury/www/node_modules/bluebird/js/main/promise.js:591:13)
    at Promise._settlePromiseAt (/home/igor/workspace/mercury/www/node_modules/bluebird/js/main/promise.js:755:18)
    at Promise._settlePromises (/home/igor/workspace/mercury/www/node_modules/bluebird/js/main/promise.js:872:14)
    at Async._drainQueue (/home/igor/workspace/mercury/www/node_modules/bluebird/js/main/async.js:78:16)
```