### PR TITLE
Fix label on comment replies

### DIFF
--- a/front/scripts/main/helpers/i18nHelper.ts
+++ b/front/scripts/main/helpers/i18nHelper.ts
@@ -10,7 +10,7 @@ Em.Handlebars.registerBoundHelper('i18n', function (value: string, options: any)
 		if (key === 'ns') {
 			namespace = options.hash[key];
 		} else if (key !== 'boundOptions' && options.hash[key]) {
-			params[key] = this[String(options.hash[key])];
+			params[key] = this.get(String(options.hash[key]));
 		}
 	});
 


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/HG-540

This code was trying to access `this['comment.comments.length']` instead of `this.comment.comments.length`