### PR TITLE
Fix for chevron position on single linked image with caption

### DIFF
--- a/front/styles/module/article/_media.scss
+++ b/front/styles/module/article/_media.scss
@@ -33,6 +33,8 @@
 		z-index: $z-1;
 	}
 
+	//First line is for single images
+	//Second is for galleries that have multiple figure tags
   	&.has-caption .chevron,
 	.has-caption .chevron {
 		margin-bottom: 50px;

--- a/front/styles/module/article/_media.scss
+++ b/front/styles/module/article/_media.scss
@@ -33,6 +33,7 @@
 		z-index: $z-1;
 	}
 
+  	&.has-caption .chevron,
 	.has-caption .chevron {
 		margin-bottom: 50px;
 	}


### PR DESCRIPTION
Single linked image with caption generates following element:
`<figure class="ember-view media-component article-image has-caption visible" data-ref="4">`.

I've created `MercuryLinkedImagesNew` article on mediawiki119@devbox to test it (http://mediawiki119.wikia.com/wiki/MercuryLinkedImages on production). During QA, please check if all possible cases are there.

/cc @vforge 
