### PR TITLE
Call event.preventDefault directly

### DIFF
--- a/front/scripts/main/views/ApplicationView.ts
+++ b/front/scripts/main/views/ApplicationView.ts
@@ -116,10 +116,10 @@ App.ApplicationView = Em.View.extend({
 
 			if (tagName === 'a') {
 				this.handleLink(<HTMLAnchorElement>target);
-				this.preventDefault(event);
+				event.preventDefault();
 			} else if (this.shouldHandleMedia(target, tagName)) {
 				this.handleMedia(<HTMLElement>target);
-				this.preventDefault(event);
+				event.preventDefault();
 			}
 		}
 	},
@@ -133,10 +133,6 @@ App.ApplicationView = Em.View.extend({
 	shouldHandleMedia: function(target: EventTarget, tagName: string): boolean {
 		return tagName === 'img' || tagName === 'figure'
 			&& $(target).children('a').length === 0;
-	},
-
-	preventDefault: function (event: Event): void {
-		event.preventDefault();
 	},
 
 	sideNavCollapsedObserver: function (): void {


### PR DESCRIPTION
This change removes some outdated and unnecessary code, which was
introduced with
https://github.com/Wikia/mercury/commit/53d14ee7c0fa9f37527734230244a02c
7ea471b4

The ```setScrollable``` and ```setUnscrollable``` actions no longer
exist, so this work-around for ```event.preventDefault()``` is not
needed.