### PR TITLE
Stop escaping already escaped captions

### DIFF
--- a/front/templates/main/components/video-media.hbs
+++ b/front/templates/main/components/video-media.hbs
@@ -1,5 +1,5 @@
 <img {{bind-attr src=imageSrc}} {{bind-attr style=style}}>
 <figcaption>
 	<div>{{media.title}}</div>
-	{{caption}}
+	{{{caption}}}
 </figcaption>


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CONCF-111

We don't escape captions in `image-media.hbs` and shouldn't do it in `video-media.hbs`. They're escaped in MW already.