### PR TITLE
Use https instead of ssh to get jquery-scrolldepth

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
     "headroom.js": "0.7.0",
     "fastclick": "1.0.6",
     "jquery.cookie": "1.4.1",
-    "scroll-depth": "git@github.com:nandy-andy/jquery-scrolldepth.git#0.8.3",
+    "scroll-depth": "https://github.com/nandy-andy/jquery-scrolldepth.git#0.8.3",
     "vignette": "wikia/vignette-js#1.0.2"
   },
   "devDependencies": {


### PR DESCRIPTION
Fix for error that was happening for people with misconfigured ssh keys (like me):

```
bower install
bower scroll-depth#0.8.3    not-cached git@github.com:nandy-andy/jquery-scrolldepth.git#0.8.3
bower scroll-depth#0.8.3       resolve git@github.com:nandy-andy/jquery-scrolldepth.git#0.8.3
bower scroll-depth#0.8.3       ECMDERR Failed to execute "git ls-remote --tags --heads git@github.com:nandy-andy/jquery-scrolldepth.git", exit code of #128

Additional error details:
Permission denied (publickey).
fatal: The remote end hung up unexpectedly
```