### PR TITLE
Redirect to / when URI is malformed

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -62,7 +62,23 @@ class App {
 
 		server.ext('onPreResponse', this.getOnPreResponseHandler(this.isDevbox));
 
-		/*
+		/**
+		 * This is the earliest place where we can detect that the request URI was malformed
+		 * (decodeURIComponent failed in hapijs/call lib and 'badrequest' method was set as a special route handler).
+		 *
+		 * When MediaWiki gets request like that it redirects to the main page with code 301.
+		 *
+		 * For now we don't want to send additional request to get title of the main page
+		 * and are redirecting to / which causes user to get the main page eventually.
+		 */
+		server.ext('onPreAuth', (request: Hapi.Request, reply: any): any => {
+			if (request.route.method === 'badrequest') {
+				return reply.redirect('/').permanent(true);
+			}
+			return reply.continue();
+		});
+
+		/**
 		 * Routes
 		 */
 		require('./routes')(server);

--- a/typings/hapi/hapi.d.ts
+++ b/typings/hapi/hapi.d.ts
@@ -379,7 +379,13 @@ declare module Hapi {
 			req: any; //http.ClientRequest
 			res: any; //http.ClientResponse
 		};
-		route: string;
+		route: {
+			method: string;
+			path: string;
+			vhost: string;
+			realm: any;
+			settings: any;
+		};
 		server: Server;
 		session: any;
 		state: any;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CONCF-70

`onPreResponse` event is the earliest place where we can detect that the request URI was malformed (`decodeURIComponent` failed in hapijs/call lib and `badrequest` method was set as a special route handler).
When MediaWiki gets request like that it redirects to the main page with code 301.
For now we don't want to send additional request to get title of the main page and are redirecting to / which causes user to get the main page eventually.