### PR TITLE
Revert "Rework how we load thumbnails"

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -15,7 +15,7 @@
     "fastclick": "1.0.6",
     "jquery.cookie": "1.4.1",
     "scroll-depth": "https://github.com/nandy-andy/jquery-scrolldepth.git#0.8.3",
-    "vignette": "wikia/vignette-js#2.0.1"
+    "vignette": "wikia/vignette-js#1.0.2"
   },
   "devDependencies": {
     "ember-qunit": "0.1.8",

--- a/front/scripts/main/components/ArticleCommentComponent.ts
+++ b/front/scripts/main/components/ArticleCommentComponent.ts
@@ -68,10 +68,10 @@ App.ArticleCommentComponent = Em.Component.extend({
 		thumbnailsData.forEach((thumbnailData: {name: string; full: string; capt?: string; type?: string}) => {
 			var thumbnailURL = thumbnailer.getThumbURL(
 					thumbnailData.full,
-					{
-						mode: thumbnailer.mode.scaleToWidth,
-						width: this.thumbnailWidth
-					}
+					thumbnailer.mode.scaleToWidth,
+					this.thumbnailWidth,
+					// this is ignored by Vignette, should be optional
+					0
 				),
 				$thumbnail = $('<img/>').attr('src', thumbnailURL),
 				href = '%@%@:%@'.fmt(

--- a/front/scripts/main/components/GalleryMediaComponent.ts
+++ b/front/scripts/main/components/GalleryMediaComponent.ts
@@ -64,10 +64,9 @@ App.GalleryMediaComponent = App.MediaComponent.extend(App.ArticleContentMixin, {
 			image.setProperties({
 				thumbUrl: this.getThumbURL(
 					image.get('url'),
-					Mercury.Modules.Thumbnailer.mode.zoomCropDown,
+					Mercury.Modules.Thumbnailer.mode.topCrop,
 					thumbSize,
-					thumbSize
-				),
+					thumbSize),
 				load: true
 			});
 		}

--- a/front/scripts/main/components/ImageMediaComponent.ts
+++ b/front/scripts/main/components/ImageMediaComponent.ts
@@ -9,7 +9,7 @@ App.ImageMediaComponent = App.MediaComponent.extend(App.ArticleContentMixin, {
 		width: 64
 	},
 	classNames: ['article-image'],
-	classNameBindings: ['hasCaption', 'isSmall'],
+	classNameBindings: ['hasCaption', 'visible', 'isSmall'],
 	layoutName: 'components/image-media',
 
 	imageSrc: Em.computed.oneWay(
@@ -46,7 +46,6 @@ App.ImageMediaComponent = App.MediaComponent.extend(App.ArticleContentMixin, {
 
 	url: function (key: string, value?: string): string {
 		var media: ArticleMedia;
-
 		if (value) {
 			return this.getThumbURL(
 				value,
@@ -76,10 +75,10 @@ App.ImageMediaComponent = App.MediaComponent.extend(App.ArticleContentMixin, {
 	 * so when image loads, browser don't have to resize it
 	 */
 	style: function (): string {
-		return this.get('loaded') ?
+		return this.get('visible') ?
 			'' :
 			'height:%@px;'.fmt(this.get('computedHeight'));
-	}.property('computedHeight', 'loaded'),
+	}.property('computedHeight', 'visible'),
 
 	/**
 	 * load an image and run update function when it is loaded
@@ -108,7 +107,7 @@ App.ImageMediaComponent = App.MediaComponent.extend(App.ArticleContentMixin, {
 	update: function (src: string): void {
 		this.setProperties({
 			imageSrc: src,
-			loaded: true
+			visible: true
 		});
 	}
 });

--- a/front/scripts/main/components/MediaComponent.ts
+++ b/front/scripts/main/components/MediaComponent.ts
@@ -13,7 +13,7 @@ App.MediaComponent = Em.Component.extend(App.VisibleMixin, {
 	height: null,
 	ref: null,
 	emptyGif: 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAQAIBRAA7',
-	loaded: false,
+	visible: false,
 	media: null,
 	thumbnailer: Mercury.Modules.Thumbnailer,
 	limitHeight: false,
@@ -60,11 +60,9 @@ App.MediaComponent = Em.Component.extend(App.VisibleMixin, {
 			height = width;
 		}
 
-		url = this.thumbnailer.getThumbURL(url, {
-			mode: mode,
-			width: width,
-			height: height
-		});
+		if (!this.thumbnailer.isThumbnailerUrl(url)) {
+			url = this.thumbnailer.getThumbURL(url, mode, width, height);
+		}
 
 		return url;
 	},

--- a/front/scripts/main/helpers/thumbnailHelper.ts
+++ b/front/scripts/main/helpers/thumbnailHelper.ts
@@ -8,22 +8,33 @@
  */
 Em.Handlebars.registerBoundHelper('thumbnail', function (url: string, options: any) {
 	var thumbnailer = Mercury.Modules.Thumbnailer,
-		hash: any = options.hash,
-		width: number = hash.width || 100,
-		height: number = hash.height || 100,
+		defaultMode: string = thumbnailer.mode.fixedAspectRatio,
+		defaultWidth: number = 100,
+		defaultHeight: number = 100,
 		mode: string,
-		alt: string = Handlebars.Utils.escapeExpression(hash.alt);
+		width: number,
+		height: number,
+		alt: string;
 
-
-	//If hash.mode is set, check if it is a valid one, use fallback if not
-	//Get keys of thumbnailer.mode, create array with values of that object and check if we have hash.mode in there
-	if (hash.mode && Object.keys(thumbnailer.mode).map(key => thumbnailer.mode[key]).indexOf(hash.mode) > -1) {
-		mode = hash.mode;
-	} else {
-		mode = thumbnailer.mode.fixedAspectRatio;
+	// validate thumbnailer mode
+	if (options.hash.mode) {
+		for (var key in thumbnailer.mode) {
+			if (thumbnailer.mode.hasOwnProperty(key) && thumbnailer.mode[key] === options.hash.mode) {
+				mode = options.hash.mode;
+				break;
+			}
+		}
 	}
 
+	if (typeof mode === 'undefined') {
+		mode = defaultMode;
+	}
+
+	width = Em.getWithDefault(options, 'hash.width', defaultWidth);
+	height = Em.getWithDefault(options, 'hash.height', defaultHeight);
+	alt = Handlebars.Utils.escapeExpression(Em.get(options, 'hash.alt'));
+
 	return new Em.Handlebars.SafeString(
-		'<img src="' + thumbnailer.getThumbURL(url, {mode: mode, width: width, height: height}) + '" alt="' + alt + '">'
+		'<img src="' + thumbnailer.getThumbURL(url, mode, width, height) + '" alt="' + alt + '">'
 	);
 });

--- a/front/styles/module/article/_media.scss
+++ b/front/styles/module/article/_media.scss
@@ -1,8 +1,15 @@
-$gallery-thumb-size: 195px;
-
 .media-component {
 	margin: 40px 0;
 	text-align: center;
+
+	&.visible {
+		img {
+			animation: lazyImage .3s;
+			background: none;
+			height: auto;
+			width: auto;
+		}
+	}
 
 	img {
 		background: {
@@ -14,11 +21,6 @@ $gallery-thumb-size: 195px;
 		}
 		display: inline-block;
 		width: 100%;
-	}
-
-	.loaded {
-		animation: lazyImage .3s;
-		background: none;
 	}
 
 	.chevron {
@@ -73,11 +75,11 @@ figcaption {
 	}
 
 	img {
-		height: $gallery-thumb-size;
+		height: auto;
 		margin-right: 8px;
 		// Fixes iOS Safari repaint bug when scrolling through gallery
 		transform: translate3d(0, 0, 0);
-		width: $gallery-thumb-size;
+		width: 195px;
 	}
 
 	.gallery-video {
@@ -107,8 +109,6 @@ figcaption {
 
 		img {
 			margin-right: 6px;
-			width: auto;
-			height: auto;
 		}
 	}
 }
@@ -144,8 +144,10 @@ figcaption {
 		top: 0;
 	}
 
-	.loaded {
-		width: 100%;
+	&.visible {
+		img {
+			width: 100%;
+		}
 	}
 
 	figcaption {

--- a/front/templates/main/components/image-media.hbs
+++ b/front/templates/main/components/image-media.hbs
@@ -1,10 +1,10 @@
 {{#if link}}
 	<a {{bind-attr href=link}} {{action 'clickLinkedImage'}}>
-		<img {{bind-attr src=imageSrc}} {{bind-attr style=style}} {{bind-attr class=loaded}}>
+		<img {{bind-attr src=imageSrc}} {{bind-attr style=style}}>
 		{{svg 'chevron-linked' viewBox='0 0 20 20' class='chevron'}}
 	</a>
 {{else}}
-	<img {{bind-attr src=imageSrc}} {{bind-attr style=style}} {{bind-attr class=loaded}}>
+	<img {{bind-attr src=imageSrc}} {{bind-attr style=style}}>
 {{/if}}{{!-- these comments prevent polluting HTML with whitespaces that caused positioning problems
 --}}{{yield}}{{!--
 --}}{{#if caption}}

--- a/front/templates/main/components/video-media.hbs
+++ b/front/templates/main/components/video-media.hbs
@@ -1,4 +1,4 @@
-<img {{bind-attr src=imageSrc}} {{bind-attr style=style}} {{bind-attr class=loaded}}>
+<img {{bind-attr src=imageSrc}} {{bind-attr style=style}}>
 <figcaption>
 	<div>{{media.title}}</div>
 	{{{caption}}}

--- a/test/specs/front/scripts/main/helpers/thumbnailHelper.js
+++ b/test/specs/front/scripts/main/helpers/thumbnailHelper.js
@@ -1,7 +1,7 @@
 QUnit.module('Handlebars thumbnail helper', {
 	setup: function () {
-		sinon.stub(Mercury.Modules.Thumbnailer, 'getThumbURL', function (url, options) {
-			return url + '/' + options.mode + '/' + options.width + '/' + options.height;
+		sinon.stub(Mercury.Modules.Thumbnailer, 'getThumbURL', function (url, mode, width, height) {
+			return url + '/' + mode + '/' + width + '/' + height;
 		});
 	},
 	teardown: function () {


### PR DESCRIPTION
Reverts Wikia/mercury#563

Branch `Remove-backround-on-image` introduces some regression and needs more work. Reverting so we can deploy a new release.