### PR TITLE
Check for error before trying to access response which can be undefined

### DIFF
--- a/server/lib/MediaWiki.ts
+++ b/server/lib/MediaWiki.ts
@@ -137,15 +137,15 @@ export function fetch (url: string, host: string = '', redirects: number = 1): P
 			timeout: localSettings.backendRequestTimeout,
 			json: true
 		}, (err: any, response: any, payload: any): void => {
-			if (response.statusCode === 200) {
-				resolve(payload);
-			} else if (err) {
+			if (err) {
 				Logger.error({
 					url: url,
 					error: err
 				}, 'Error fetching url');
 
 				reject(err);
+			} else if (response.statusCode === 200) {
+				resolve(payload);
 			} else {
 				// When an empty response comes (for example 503 from Varnish) make it look same as the MediaWiki one
 				if (payload === null) {


### PR DESCRIPTION
This fixes `TypeError: Cannot read property 'statusCode' of undefined` reported by New Relic.