### PR TITLE
variable name change

### DIFF
--- a/server/views/_helpers/translations.js
+++ b/server/views/_helpers/translations.js
@@ -6,7 +6,7 @@ module.exports = function (language) {
 		fallbackLanguage = language.split('-')[0],
 		defaultLanguage = 'en',
 		foundLanguage = '',
-		response = {};
+		wrapper = {};
 
 	[language, fallbackLanguage, defaultLanguage].some(function (lang) {
 		foundLanguage = lang;
@@ -24,6 +24,6 @@ module.exports = function (language) {
 		}
 	});
 
-	response[foundLanguage] = translations;
-	return response;
+	wrapper[foundLanguage] = translations;
+	return wrapper;
 };


### PR DESCRIPTION
The variable name is changed because we want to reserve 'response' only for server responses.

It's the fix for this PR https://github.com/Wikia/mercury/pull/587/files