### PR TITLE
CONCF-81 fix M.prop instead of Mercury.__state

### DIFF
--- a/front/scripts/mercury/modules/Trackers/Krux.ts
+++ b/front/scripts/mercury/modules/Trackers/Krux.ts
@@ -43,7 +43,7 @@ module Mercury.Modules.Trackers {
 
 		loadKrux (): void {
 			if (typeof window.Krux.load === 'function') {
-				window.Krux.load(Mercury.tracking.krux.mobileId);
+				window.Krux.load(M.prop('tracking.krux.mobileId'));
 				window.Krux.isLoaded = true;
 			}
 		}


### PR DESCRIPTION
Small fix necessary after deprecating Mercury.__state.