### PR TITLE
CE-1431 Added /editorPreview/ route to preview given HTML in Mercury skin

### DIFF
--- a/config/localSettings.base.ts
+++ b/config/localSettings.base.ts
@@ -18,6 +18,8 @@ var localSettings: LocalSettings = {
 	environment: Utils.getEnvironment(process.env.WIKIA_ENVIRONMENT),
 	// NOTE: On your devbox, use your eth0 address in able to bind route to something accessible
 	host: process.env.HOST,
+	// Special salt for accepting HTML from MediaWiki for /editor_preview/
+	mwPreviewSalt: process.env.MW_PREVIEW_SALT,
 	// By default send logs to local syslog only. Possible targets are [syslog, console, default]
 	// The value represent the minimum logging level
 	loggers: {

--- a/config/localSettings.d.ts
+++ b/config/localSettings.d.ts
@@ -22,6 +22,7 @@ interface LocalSettings {
 	devboxDomain?: string;
 	environment: any;
 	host: any;
+	mwPreviewSalt: string;
 	loggers: LoggerInterface;
 	maxRequestsPerChild: number;
 	optimizely?: {

--- a/front/scripts/main/controllers/ApplicationController.ts
+++ b/front/scripts/main/controllers/ApplicationController.ts
@@ -16,7 +16,8 @@ App.ApplicationController = Em.Controller.extend({
 			domain: Em.get(Mercury, 'wiki.dbName') || window.location.href.match(/^https?:\/\/(.*?)\./)[1],
 			language: Em.get(Mercury, 'wiki.language'),
 			mainPageTitle: Em.get(Mercury, 'wiki.mainPageTitle'),
-			siteName: Em.getWithDefault(Mercury, 'wiki.siteName', 'Wikia')
+			siteName: Em.getWithDefault(Mercury, 'wiki.siteName', 'Wikia'),
+			editorPreview: Em.get(Mercury, 'article.preview')
 		});
 
 		// This event is for tracking mobile sessions between Mercury and WikiaMobile

--- a/front/styles/main/layout/_page-wrapper.scss
+++ b/front/styles/main/layout/_page-wrapper.scss
@@ -3,6 +3,18 @@
 
 	margin-top: 50px;
 
+	&.editor-preview {
+		margin-top: 0;
+
+		> .wiki-container {
+			margin-top: 0;
+		}
+
+		footer.wikia-footer {
+			display: none;
+		}
+	}
+
 	.mobile-top-leaderboard ~ & {
 		margin-top: 0;
 	}

--- a/front/templates/main/application.hbs
+++ b/front/templates/main/application.hbs
@@ -4,6 +4,8 @@
 			{{outlet}}
 		</section>
 	</div>
+	{{loading-spinner active=isLoading}}
+	{{outlet 'lightbox'}}
 {{else}}
 	{{smart-banner isVisible=view.smartBannerVisible}}
 	{{site-head smartBannerVisible=view.smartBannerVisible sideNavCollapsed=view.sideNavCollapsed trackClick='trackClick'}}

--- a/front/templates/main/application.hbs
+++ b/front/templates/main/application.hbs
@@ -11,9 +11,7 @@
 	{{ad-slot name='MOBILE_TOP_LEADERBOARD' noAds=noAds}}
 	<div class='page-wrapper' {{bind-attr lang=language.content}} {{bind-attr dir=language.contentDir}}>
 		<section class='wiki-container'>
-			{{#unless editorPreview}}
-				<h2 class='wiki-title' {{action 'trackClick' 'wikiname'}}>{{#link-to 'article' mainPageTitle alt=siteName}}{{siteName}}{{/link-to}}</h2>
-			{{/unless}}
+			<h2 class='wiki-title' {{action 'trackClick' 'wikiname'}}>{{#link-to 'article' mainPageTitle alt=siteName}}{{siteName}}{{/link-to}}</h2>
 			{{outlet}}
 		</section>
 	</div>

--- a/front/templates/main/application.hbs
+++ b/front/templates/main/application.hbs
@@ -1,12 +1,22 @@
-{{smart-banner isVisible=view.smartBannerVisible}}
-{{site-head smartBannerVisible=view.smartBannerVisible sideNavCollapsed=view.sideNavCollapsed trackClick='trackClick'}}
-{{side-nav isCollapsed=view.sideNavCollapsed loadRandomArticle='loadRandomArticle'}}
-{{ad-slot name='MOBILE_TOP_LEADERBOARD' noAds=noAds}}
-<div class='page-wrapper' {{bind-attr lang=language.content}} {{bind-attr dir=language.contentDir}}>
-	<section class='wiki-container'>
-		<h2 class='wiki-title' {{action 'trackClick' 'wikiname'}}>{{#link-to 'article' mainPageTitle alt=siteName}}{{siteName}}{{/link-to}}</h2>
-		{{outlet}}
-	</section>
-</div>
-{{loading-spinner active=isLoading}}
-{{outlet 'lightbox'}}
+{{#if editorPreview}}
+	<div class="page-wrapper editor-preview" {{bind-attr lang=language.content}} {{bind-attr dir=language.contentDir}}>
+		<section class='wiki-container'>
+			{{outlet}}
+		</section>
+	</div>
+{{else}}
+	{{smart-banner isVisible=view.smartBannerVisible}}
+	{{site-head smartBannerVisible=view.smartBannerVisible sideNavCollapsed=view.sideNavCollapsed trackClick='trackClick'}}
+	{{side-nav isCollapsed=view.sideNavCollapsed loadRandomArticle='loadRandomArticle'}}
+	{{ad-slot name='MOBILE_TOP_LEADERBOARD' noAds=noAds}}
+	<div class='page-wrapper' {{bind-attr lang=language.content}} {{bind-attr dir=language.contentDir}}>
+		<section class='wiki-container'>
+			{{#unless editorPreview}}
+				<h2 class='wiki-title' {{action 'trackClick' 'wikiname'}}>{{#link-to 'article' mainPageTitle alt=siteName}}{{siteName}}{{/link-to}}</h2>
+			{{/unless}}
+			{{outlet}}
+		</section>
+	</div>
+	{{loading-spinner active=isLoading}}
+	{{outlet 'lightbox'}}
+{{/if}}

--- a/server/facets/editorPreview.ts
+++ b/server/facets/editorPreview.ts
@@ -1,0 +1,50 @@
+/// <reference path="../../typings/hapi/hapi.d.ts" />
+
+import Article = require('../lib/Article');
+import Utils = require('../lib/Utils');
+import localSettings = require('../../config/localSettings');
+import verifyMWHash = require('./operations/verifyMWHash');
+import prepareArticleData = require('./operations/prepareArticleData');
+
+function editorPreview (request: Hapi.Request, reply: Hapi.Response): void {
+	var wikiDomain: string = Utils.getCachedWikiDomainName(localSettings, request.headers.host),
+		parserOutput: string = request.payload.parserOutput,
+		mwHash: string = request.payload.mwHash;
+
+	Article.getWikiVariables(wikiDomain, (error: any, wikiVariables: any) => {
+		var article: any = {},
+			result: any = {},
+			error: any;
+
+		if (verifyMWHash(parserOutput, mwHash)) {
+			article = JSON.parse(parserOutput);
+		} else {
+			error = true;
+		}
+
+		result = {
+			article: {
+				article: article,
+				adsContext: {},
+				details: {
+					id: 0,
+					title: '',
+					revision: {},
+					type: 'article'
+				},
+				preview: true
+			},
+			wiki: wikiVariables || {},
+			error: error
+		};
+
+		prepareArticleData(request, result);
+
+		// TODO: why is this needed for the images to load?
+		result.tracking = localSettings.tracking;
+
+		reply.view('application', result);
+	});
+}
+
+export = editorPreview;

--- a/server/facets/operations/prepareArticleData.ts
+++ b/server/facets/operations/prepareArticleData.ts
@@ -1,0 +1,45 @@
+/// <reference path="../../../typings/hapi/hapi.d.ts" />
+
+import Utils = require('../../lib/Utils');
+import localSettings = require('../../../config/localSettings');
+
+/**
+ * Prepares article data to be rendered
+ * TODO: clean up this function
+ *
+ * @param {Hapi.Request} request
+ * @param result
+ */
+function prepareArticleData (request: Hapi.Request, result: any): void {
+	var title: string,
+		articleDetails: any,
+		userDir = 'ltr';
+
+	if (result.article.details) {
+		articleDetails = result.article.details;
+		title = articleDetails.cleanTitle ? articleDetails.cleanTitle : articleDetails.title;
+	} else if (request.params.title) {
+		title = request.params.title.replace(/_/g, ' ');
+	} else {
+		title = result.wiki.mainPageTitle.replace(/_/g, ' ');
+	}
+
+	if (result.article.article) {
+		// we want to return the article content only once - as HTML and not JS variable
+		result.articleContent = result.article.article.content;
+		delete result.article.article.content;
+	}
+
+	if (result.wiki.language) {
+		userDir = result.wiki.language.userDir;
+		result.isRtl = (userDir === 'rtl');
+	}
+
+	result.displayTitle = title;
+	result.isMainPage = (title === result.wiki.mainPageTitle.replace(/_/g, ' '));
+	result.canonicalUrl = result.wiki.basePath + result.wiki.articlePath + title.replace(/ /g, '_');
+	result.themeColor = Utils.getVerticalColor(localSettings, result.wiki.vertical);
+	result.queryParams = Utils.parseQueryParams(request.query);
+}
+
+export = prepareArticleData;

--- a/server/facets/operations/verifyMWHash.ts
+++ b/server/facets/operations/verifyMWHash.ts
@@ -2,7 +2,7 @@ import localSettings = require('../../../config/localSettings');
 import crypto = require('crypto');
 
 function verifyMWHash (parserOutput: string, mwHash: string) {
-	var hmac = crypto.createHmac('sha1', localSettings.mwPreviewSalt),
+	var hmac = crypto.createHmac('sha1', localSettings.mwPreviewSalt || ''),
 		computedHash = hmac.update(parserOutput).digest('hex');
 
 	return (computedHash === mwHash);

--- a/server/facets/operations/verifyMWHash.ts
+++ b/server/facets/operations/verifyMWHash.ts
@@ -1,0 +1,11 @@
+import localSettings = require('../../../config/localSettings');
+import crypto = require('crypto');
+
+function verifyMWHash (parserOutput: string, mwHash: string) {
+	var hmac = crypto.createHmac('sha1', localSettings.mwPreviewSalt),
+		computedHash = hmac.update(parserOutput).digest('hex');
+
+	return (computedHash === mwHash);
+}
+
+export = verifyMWHash;

--- a/server/lib/Article.ts
+++ b/server/lib/Article.ts
@@ -74,7 +74,7 @@ export function getData (params: ArticleRequestParams, callback: Function, getWi
 				article: any,
 				wikiVariables: any = {};
 
-			// if promise is fullfilled - use resolved value, if it's not - use rejection reason
+			// if promise is fulfilled - use resolved value, if it's not - use rejection reason
 			article = articlePromise.isFulfilled() ?
 				articlePromise.value() :
 				articlePromise.reason();
@@ -102,6 +102,33 @@ export function getFull (params: ArticleRequestParams, next: Function): void {
 			article: article || {}
 		});
 	}, true);
+}
+
+/**
+ * Handle preview page data generation
+ * @param {ArticleRequestParams} params
+ * @param {string} parserOutput
+ * @param {Function} next
+ */
+export function getPreview (params: ArticleRequestParams, parserOutput: any, next: Function): void {
+	getWikiVariables(params.wikiDomain, (error: any, wikiVariables: any) => {
+		var article = {
+			article: parserOutput,
+			adsContext: {},
+			details: {
+				id: 0,
+				title: params.title, //TODO: encode!!!!
+				revision: {},
+				type: 'article'
+			}
+		};
+
+		next(error, {
+			server: createServerData(),
+			wiki: wikiVariables || {},
+			article: article
+		});
+	});
 }
 
 /**

--- a/server/lib/Article.ts
+++ b/server/lib/Article.ts
@@ -105,33 +105,6 @@ export function getFull (params: ArticleRequestParams, next: Function): void {
 }
 
 /**
- * Handle preview page data generation
- * @param {ArticleRequestParams} params
- * @param {string} parserOutput
- * @param {Function} next
- */
-export function getPreview (params: ArticleRequestParams, parserOutput: any, next: Function): void {
-	getWikiVariables(params.wikiDomain, (error: any, wikiVariables: any) => {
-		var article = {
-			article: parserOutput,
-			adsContext: {},
-			details: {
-				id: 0,
-				title: params.title, //TODO: encode!!!!
-				revision: {},
-				type: 'article'
-			}
-		};
-
-		next(error, {
-			server: createServerData(),
-			wiki: wikiVariables || {},
-			article: article
-		});
-	});
-}
-
-/**
  * Get WikiVariables
  * @param {string} wikiDomain
  * @param {Function} next

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -61,7 +61,7 @@ unauthenticatedRoutes = [
 	{
 		method: 'POST',
 		path: '/editor_preview/',
-		handler: require('./facets/showArticle')
+		handler: require('./facets/editorPreview')
 	}
 ];
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -60,7 +60,7 @@ unauthenticatedRoutes = [
 	},
 	{
 		method: 'POST',
-		path: '/editor_preview/',
+		path: '/editorPreview/',
 		handler: require('./facets/editorPreview')
 	}
 ];

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -57,6 +57,11 @@ unauthenticatedRoutes = [
 		method: 'GET',
 		path: localSettings.apiBase + '/search/{query}',
 		handler: require('./facets/api/search').get
+	},
+	{
+		method: 'POST',
+		path: '/editor_preview/',
+		handler: require('./facets/showArticle')
 	}
 ];
 

--- a/typings/hapi/hapi.d.ts
+++ b/typings/hapi/hapi.d.ts
@@ -440,6 +440,7 @@ declare module Hapi {
 		replacer (method: Function): void;
 		replacer (method: Array<Function>): void;
 		spaces (count: number): void;
+		view (template: string, context?: any, options?: any): Response;
 
 		temporary (isTemporary: boolean): void;
 		permanent (isPermanent: boolean): void;


### PR DESCRIPTION
This pull requests adds capability to preview an HTML in a Mercury skin.

The API is: POST /editor_preview/ the POST params are:

* parserOutput: JSON as returned by ArticleApi (article as JSON)
* title: article title
* mwHash: sha1 hash with salt to prove the parserOutput was indeed generated by MediaWiki

This commit reveals an issue of not properly encoding article title passed by MediaWiki API in https://github.com/Wikia/mercury/pull/618/files#diff-5a151be511cd8e3c3d6a4e795aad8d46R120 . We chose to fix this issue on the MediaWiki side https://wikia-inc.atlassian.net/browse/HG-564, but I would like us to revisit this issue and move the fix to Mercury, so everything works as expected.

The salt for recomputing mwHash is expected to appear as an environmental variable MW_PREVIEW_SALT.

At one point, we might want to simplify the whole flow by making /editor_preview/ accepting wiki text to parse instead of parsed HTML, but now it would mean crossing multiple layers between Mercury and MW Parser (the mwHash becomes useless then).