### PR TITLE
Enable Optimizely

### DIFF
--- a/config/localSettings.base.ts
+++ b/config/localSettings.base.ts
@@ -26,7 +26,7 @@ var localSettings: LocalSettings = {
 	devboxDomain: Utils.stripDevboxDomain(process.env.HOST || process.env.LOGNAME),
 	maxRequestsPerChild: parseInt(process.env.MAX_REQUEST_PER_CHILD, 10) || 50000,
 	optimizely: {
-		enabled: false,
+		enabled: true,
 		scriptPath: '//cdn.optimizely.com/js/',
 		devAccount: '2441440871',
 		account: '2449650414'

--- a/config/localSettings.base.ts
+++ b/config/localSettings.base.ts
@@ -26,7 +26,7 @@ var localSettings: LocalSettings = {
 	devboxDomain: Utils.stripDevboxDomain(process.env.HOST || process.env.LOGNAME),
 	maxRequestsPerChild: parseInt(process.env.MAX_REQUEST_PER_CHILD, 10) || 50000,
 	optimizely: {
-		enabled: true,
+		enabled: !!process.env.ENABLE_OPTIMIZELY,
 		scriptPath: '//cdn.optimizely.com/js/',
 		devAccount: '2441440871',
 		account: '2449650414'


### PR DESCRIPTION
We don't yet have a hot-swappable configuration tool in place, and we need to enable Optimizely this week for an experiment that was expected to run two weeks ago, so this seems like the only thing to do. Alternative suggestions to enable this on production are welcome.

This change will result in the Optimizely JS snippet being loaded for every Mercury user.