### PR TITLE
Add a rootElement for Ember to render into

### DIFF
--- a/front/scripts/main/app.ts
+++ b/front/scripts/main/app.ts
@@ -14,7 +14,11 @@ interface Window {
 
 declare var i18n: I18nextStatic;
 
-var App: any = Em.Application.create();
+var App: any = Em.Application.create({
+	// We specify a rooElement, otherwise Ember appends to the <body> element and Google PageSpeed thinks we are
+	// putting blocking scripts before our content
+	rootElement: '#ember-container'
+});
 
 window.emberHammerOptions = {
 	hammerOptions: {

--- a/front/scripts/main/app.ts
+++ b/front/scripts/main/app.ts
@@ -15,7 +15,7 @@ interface Window {
 declare var i18n: I18nextStatic;
 
 var App: any = Em.Application.create({
-	// We specify a rooElement, otherwise Ember appends to the <body> element and Google PageSpeed thinks we are
+	// We specify a rootElement, otherwise Ember appends to the <body> element and Google PageSpeed thinks we are
 	// putting blocking scripts before our content
 	rootElement: '#ember-container'
 });

--- a/server/views/layout.hbs
+++ b/server/views/layout.hbs
@@ -67,6 +67,13 @@
 			{{{content}}}
 		</div>
 
+        <!--
+        Ember must render out to a specific div above the scripts, otherwise
+        Google PageSpeed will mistakenly believe that we have scripts loading and blocking content
+        DO NOT REMOVE THE FOLLOWING LINE:
+        -->
+        <div id="ember-container"></div>
+
 		<!-- build:js /front/vendor/main.js -->
 			<script src="/front/vendor/script.js/dist/script.js"></script>
 			<script src="/front/vendor/fastclick/lib/fastclick.js"></script>


### PR DESCRIPTION
Without a specified root element, Ember defaults it's root element to render into to the `body` tag. This is confusing to the [Google PageSpeed](https://developers.google.com/speed/pagespeed/insights/) which sees that we have page content after scripts in the body even though we in fact loaded the scripts after the content.

This fixes that issue by explicitly setting rootElement to a node that is inserted before those scripts and should increase our PageSpeed score.

New mobile algorithms from Google take into effect 4/21.

@tedgill  @hobbs 