### PR TITLE
Cleanup: scripts/mercury

### DIFF
--- a/front/scripts/mercury/modules/Ads.ts
+++ b/front/scripts/mercury/modules/Ads.ts
@@ -1,5 +1,9 @@
-/// <reference path="../../../../typings/jquery/jquery.d.ts" />
-/// <reference path="../../baseline/mercury.d.ts" />
+/// <reference path='../../../../typings/jquery/jquery.d.ts' />
+/// <reference path='../../baseline/mercury.d.ts' />
+/// <reference path='trackers/Krux.ts' />
+/// <reference path='trackers/GoogleAnalytics.ts' />
+/// <reference path='../../baseline/mercury.ts' />
+/// <reference path='../utils/load.ts' />
 
 'use strict';
 
@@ -68,7 +72,7 @@ module Mercury.Modules {
 						this.kruxTrackFirstPage();
 					});
 				} else {
-					Em.Logger.error('Looks like ads asset has not been loaded');
+					console.error('Looks like ads asset has not been loaded');
 				}
 			});
 		}

--- a/front/scripts/mercury/modules/Ads.ts
+++ b/front/scripts/mercury/modules/Ads.ts
@@ -1,7 +1,7 @@
 /// <reference path='../../../../typings/jquery/jquery.d.ts' />
 /// <reference path='../../baseline/mercury.d.ts' />
-/// <reference path='./trackers/Krux.ts' />
-/// <reference path='./trackers/GoogleAnalytics.ts' />
+/// <reference path='./Trackers/Krux.ts' />
+/// <reference path='./Trackers/GoogleAnalytics.ts' />
 /// <reference path='../../baseline/mercury.ts' />
 /// <reference path='../utils/load.ts' />
 

--- a/front/scripts/mercury/modules/Ads.ts
+++ b/front/scripts/mercury/modules/Ads.ts
@@ -1,7 +1,7 @@
 /// <reference path='../../../../typings/jquery/jquery.d.ts' />
 /// <reference path='../../baseline/mercury.d.ts' />
-/// <reference path='trackers/Krux.ts' />
-/// <reference path='trackers/GoogleAnalytics.ts' />
+/// <reference path='./trackers/Krux.ts' />
+/// <reference path='./trackers/GoogleAnalytics.ts' />
 /// <reference path='../../baseline/mercury.ts' />
 /// <reference path='../utils/load.ts' />
 

--- a/front/scripts/mercury/modules/Trackers/ScrollDepthTracker.ts
+++ b/front/scripts/mercury/modules/Trackers/ScrollDepthTracker.ts
@@ -47,7 +47,7 @@ module Mercury.Modules.Trackers {
 				threshold: 500,
 				eventHandler: (data: ScrollDepthEventData): void => {
 					if (Math.random() * 100 <= this.scrollDepthSample) {
-						Em.Logger.info('Sending scroll depth tracking');
+						console.info('Sending scroll depth tracking');
 						this.gaTracker.trackAds.apply(this.gaTracker, [
 							data.eventCategory,
 							data.eventAction,

--- a/front/scripts/mercury/utils/track.ts
+++ b/front/scripts/mercury/utils/track.ts
@@ -153,17 +153,17 @@ module Mercury.Utils {
 	 * trackPageView is called in ArticleView.onArticleChange
 	 */
 	export function trackPageView (adsContext: any) {
-		var trackers: {[name: string]: TrackerInstance} = Em.get('Mercury.Modules.Trackers');
+		var trackers: any = Mercury.Modules.Trackers;
 
 		if (M.prop('queryParams.noexternals')) {
 			return;
 		}
 
 		Object.keys(trackers).forEach(function (tracker: string) {
-			var trackerInstance = new trackers[tracker]();
+			var trackerInstance: TrackerInstance = new trackers[tracker]();
 
 			if (trackerInstance && trackerInstance.trackPageView) {
-				Em.Logger.info('Track pageView:', tracker);
+				console.info('Track pageView:', tracker);
 				trackerInstance.trackPageView(trackerInstance.usesAdsContext ? adsContext : context);
 			}
 		});


### PR DESCRIPTION
Hello all, this PR fixes a few TS errors introduced with Krux integration. In addition, this PR removes all dependencies on Ember in `scripts/mercury`. Scripts in `scripts/mercury` are meant to be able to be used in contexts beyond the Ember application. I initially created this separation between the Ember scripts and the Mercury scripts because I noticed that certain modules didn't require coupling or wrapping into Ember's ecosystem and would better serve us to write them generically. So I created `scripts/mercury` with a `modules` and `utils` folder. The goal of this folder is to remain loosely coupled. So in this PR, I've removed unnecessary coupling in the `scripts/mercury` directory, specifically instances of `Em.get` and `Em.Logger.*`.

Additionally, both of those functions are really part of Ember's private API, and aren't intended to be used externally like such. (Em.Logger is meant to be used inside ember-metal, and overridden with our own methods if required, not the other way around). `Em.get` is simply a wrapper for traditional object accessors, Em.logger literally wraps `window.console` and is meant to be overwritten. **When writing code, consider the abstractions you're using and whether or not they're worth the additional cognitive load on new developers.**

To make a further case for the loose coupling of `scripts/mercury`, we've already seen that loose coupling here has allowed us to share and abstract code in a much more fluid way. We were able to copypasta our [vignette-js npm library](https://github.com/Wikia/vignette-js) right out of `scripts/mercury` because of that coupling and we should be able to do the same for tracking code that the new login pages will need. 