### PR TITLE
upgrading gulp-sass to fix issues with gulp-build

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "gulp-replace": "^0.5.2",
     "gulp-rev": "^3.0.1",
     "gulp-rev-replace": "0.x.x",
-    "gulp-sass": "1.1.x",
+    "gulp-sass": "1.3.x",
     "gulp-svg-symbols": "0.x.x",
     "gulp-tslint": "1.x.x",
     "gulp-typedoc": "^1.0.6",


### PR DESCRIPTION
In [this PR](https://github.com/Wikia/mercury/pull/621/files#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R54) I upgraded `gulp-sass` to fix an issue where running `gulp sass` on it's own would work fine, but running it as part of `gulp build` would return an error. 

Another person ran into the same issue described [here](http://www.expertland.net/question/t82o1l24mby3x9o6q5nb6524mrxa83o5/detail.html) and upgrading fixed their problem too. 

I just want to merge this change into `dev` so it doesn't diverge from the `hapi-auth` branch too much. 