### PR TITLE
Enable Optimizely in localSettings

### DIFF
--- a/config/localSettings.base.ts
+++ b/config/localSettings.base.ts
@@ -26,7 +26,7 @@ var localSettings: LocalSettings = {
 	devboxDomain: Utils.stripDevboxDomain(process.env.HOST || process.env.LOGNAME),
 	maxRequestsPerChild: parseInt(process.env.MAX_REQUEST_PER_CHILD, 10) || 50000,
 	optimizely: {
-		enabled: !!process.env.ENABLE_OPTIMIZELY,
+		enabled: true,
 		scriptPath: '//cdn.optimizely.com/js/',
 		devAccount: '2441440871',
 		account: '2449650414'


### PR DESCRIPTION
This is temporary, to enable Optimizely experiments for the next few weeks in Mercury. This has been changed back from an environment variable, because I thought a feature-level switch does not belong in configuration at the environment deployment level. Either way, this config value would have been hard-coded in either place. We should change this to go through Consul soon though.

@hakubo FYI