### PR TITLE
add build task to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "rm -rf www && gulp",
     "start": "rm -rf www && gulp build --type prod --nosync && node www/server/server.js",
     "test": "rm -rf www && gulp build --type prod --nosync --testing && gulp karma && gulp node-test",
-    "coverage": "rm -rf www && gulp build --nosync --testing && gulp karma && gulp node-test"
+    "coverage": "rm -rf www && gulp build --nosync --testing && gulp karma && gulp node-test",
+    "build": "gulp build --type prod --nosync"
   },
   "repository": "git://github.com/Wikia/mercury.git",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "server.js",
   "scripts": {
     "dev": "rm -rf www && gulp",
-    "start": "rm -rf www && gulp build --type prod --nosync && node www/server/server.js",
+    "start": "rm -rf www && npm run build && node www/server/server.js",
     "test": "rm -rf www && gulp build --type prod --nosync --testing && gulp karma && gulp node-test",
     "coverage": "rm -rf www && gulp build --nosync --testing && gulp karma && gulp node-test",
     "build": "gulp build --type prod --nosync"


### PR DESCRIPTION
Having this script
we can teach DTools to run
`npm run build`
instead of
`gulp build --type prod`

so it does not have to know the 'internals' of the service

It is mostly 1:1 mapping to what DT used to do
having it here will free us to tweak what build do, without having to deploy DT