### PR TITLE
ADEN-1834 Interstitial ads on mercury

### DIFF
--- a/front/scripts/main/controllers/AdsLightboxController.ts
+++ b/front/scripts/main/controllers/AdsLightboxController.ts
@@ -11,7 +11,7 @@ App.AdsLightboxController = App.LightboxController.extend({
 
 	footerHidden: true,
 
-	header: 'Advertisment',
+	header: 'Advertisement',
 
 	init: function (): void {
 		this._super();

--- a/front/scripts/main/controllers/AdsLightboxController.ts
+++ b/front/scripts/main/controllers/AdsLightboxController.ts
@@ -4,13 +4,8 @@ App.AdsLightboxController = App.LightboxController.extend({
 	data: {
 		contents: null
 	},
-
-	contents: Em.computed.alias(
-		'data.contents'
-	),
-
+	contents: Em.computed.alias('data.contents'),
 	footerHidden: true,
-
 	header: 'Advertisement',
 
 	init: function (): void {

--- a/front/scripts/main/controllers/AdsLightboxController.ts
+++ b/front/scripts/main/controllers/AdsLightboxController.ts
@@ -1,0 +1,27 @@
+/// <reference path="./LightboxController.ts" />
+
+App.AdsLightboxController = App.LightboxController.extend({
+	data: {
+		contents: null
+	},
+
+	contents: Em.computed.alias(
+		'data.contents'
+	),
+
+	footerHidden: true,
+
+	header: 'Advertisment',
+
+	init: function (): void {
+		this._super();
+	},
+
+	reset: function (): void {
+		this.setProperties({
+			data: {}
+		});
+
+		this._super();
+	}
+});

--- a/front/scripts/main/mixins/LightboxMixin.ts
+++ b/front/scripts/main/mixins/LightboxMixin.ts
@@ -1,0 +1,18 @@
+/// <reference path="../app.ts" />
+'use strict';
+
+App.LightboxMixin = Em.Mixin.create({
+	status: 'opening',
+
+	didInsertElement: function (): void {
+		this.set('status', 'open');
+
+		this._super();
+	},
+
+	willDestroyElement: function (): void {
+		this.get('controller').reset();
+
+		this._super();
+	}
+});

--- a/front/scripts/main/routes/ApplicationRoute.ts
+++ b/front/scripts/main/routes/ApplicationRoute.ts
@@ -8,6 +8,14 @@ App.ApplicationRoute = Em.Route.extend(Em.TargetActionSupport, {
 		return params;
 	},
 
+	activate: function() {
+		window.openMercuryAdLightbox = (content): void => {
+			// TODO: WIP: right now display first media on the page in lightbox but later on we want to display an ad
+			console.log('content: ', content);
+			this.send('openLightbox', 'media-lightbox', {mediaRef: 0});
+		}
+	},
+
 	actions: {
 		loading: function (): void {
 			this.controller.showLoader();

--- a/front/scripts/main/routes/ApplicationRoute.ts
+++ b/front/scripts/main/routes/ApplicationRoute.ts
@@ -15,7 +15,7 @@ App.ApplicationRoute = Em.Route.extend(Em.TargetActionSupport, {
 		 * If there is and it's in a form of prestitial/interstitial the ad server calls our exposed JS function to
 		 * display the ad in a form of modal. The ticket connected to the changes: ADEN-1834.
 		 */
-		window.openMercuryAdLightbox = (contents): void => {
+		window.openMercuryAdLightbox = (contents: any): void => {
 			this.send('openLightbox', 'ads-lightbox', {contents: contents});
 		}
 	},

--- a/front/scripts/main/routes/ApplicationRoute.ts
+++ b/front/scripts/main/routes/ApplicationRoute.ts
@@ -15,7 +15,7 @@ App.ApplicationRoute = Em.Route.extend(Em.TargetActionSupport, {
 		 * If there is and it's in a form of prestitial/interstitial the ad server calls our exposed JS function to
 		 * display the ad in a form of modal. The ticket connected to the changes: ADEN-1834.
 		 */
-		window.openMercuryAdLightbox = (contents: any): void => {
+		Mercury.Modules.Ads.openLightbox = (contents: any): void => {
 			this.send('openLightbox', 'ads-lightbox', {contents: contents});
 		}
 	},

--- a/front/scripts/main/routes/ApplicationRoute.ts
+++ b/front/scripts/main/routes/ApplicationRoute.ts
@@ -9,10 +9,14 @@ App.ApplicationRoute = Em.Route.extend(Em.TargetActionSupport, {
 	},
 
 	activate: function() {
-		window.openMercuryAdLightbox = (content): void => {
-			// TODO: WIP: right now display first media on the page in lightbox but later on we want to display an ad
-			console.log('content: ', content);
-			this.send('openLightbox', 'media-lightbox', {mediaRef: 0});
+		/**
+		 * This global function is being used by our AdEngine code to provide prestitial/interstitial ads
+		 * It works in similar way on Oasis: we call ads server (DFP) to check if there is targeted ad unit for a user.
+		 * If there is and it's in a form of prestitial/interstitial the ad server calls our exposed JS function to
+		 * display the ad in a form of modal. The ticket connected to the changes: ADEN-1834.
+		 */
+		window.openMercuryAdLightbox = (contents): void => {
+			this.send('openLightbox', 'ads-lightbox', {contents: contents});
 		}
 	},
 

--- a/front/scripts/main/routes/ApplicationRoute.ts
+++ b/front/scripts/main/routes/ApplicationRoute.ts
@@ -8,7 +8,7 @@ App.ApplicationRoute = Em.Route.extend(Em.TargetActionSupport, {
 		return params;
 	},
 
-	activate: function() {
+	activate: function (): void {
 		/**
 		 * This global function is being used by our AdEngine code to provide prestitial/interstitial ads
 		 * It works in similar way on Oasis: we call ads server (DFP) to check if there is targeted ad unit for a user.

--- a/front/scripts/main/routes/ApplicationRoute.ts
+++ b/front/scripts/main/routes/ApplicationRoute.ts
@@ -1,4 +1,5 @@
 /// <reference path="../app.ts" />
+/// <reference path="../../mercury/modules/Ads.ts" />
 /// <reference path="../../mercury/utils/articleLink.ts" />
 /// <reference path="../../mercury/utils/variantTesting.ts" />
 'use strict';
@@ -15,7 +16,7 @@ App.ApplicationRoute = Em.Route.extend(Em.TargetActionSupport, {
 		 * If there is and it's in a form of prestitial/interstitial the ad server calls our exposed JS function to
 		 * display the ad in a form of modal. The ticket connected to the changes: ADEN-1834.
 		 */
-		Mercury.Modules.Ads.openLightbox = (contents: any): void => {
+		Mercury.Modules.Ads.getInstance().openLightbox = (contents: any): void => {
 			this.send('openLightbox', 'ads-lightbox', {contents: contents});
 		}
 	},

--- a/front/scripts/main/views/AdsLightboxView.ts
+++ b/front/scripts/main/views/AdsLightboxView.ts
@@ -1,0 +1,20 @@
+/// <reference path="../app.ts" />
+/// <reference path="./LightboxView.ts" />
+'use strict';
+
+App.AdsLightboxView = App.LightboxView.extend({
+	classNames: ['ads-lightbox'],
+	status: 'opening',
+
+	didInsertElement: function (): void {
+		this.set('status', 'open');
+
+		this._super();
+	},
+
+	willDestroyElement: function (): void {
+		this.get('controller').reset();
+
+		this._super();
+	}
+});

--- a/front/scripts/main/views/AdsLightboxView.ts
+++ b/front/scripts/main/views/AdsLightboxView.ts
@@ -1,20 +1,8 @@
 /// <reference path="../app.ts" />
+/// <reference path="../mixins/LightboxMixin.ts" />
 /// <reference path="./LightboxView.ts" />
 'use strict';
 
-App.AdsLightboxView = App.LightboxView.extend({
-	classNames: ['ads-lightbox'],
-	status: 'opening',
-
-	didInsertElement: function (): void {
-		this.set('status', 'open');
-
-		this._super();
-	},
-
-	willDestroyElement: function (): void {
-		this.get('controller').reset();
-
-		this._super();
-	}
+App.AdsLightboxView = App.LightboxView.extend(App.LightboxMixin, {
+	classNames: ['ads-lightbox']
 });

--- a/front/scripts/main/views/MapLightboxView.ts
+++ b/front/scripts/main/views/MapLightboxView.ts
@@ -1,20 +1,8 @@
 /// <reference path="../app.ts" />
+/// <reference path="../mixins/LightboxMixin.ts" />
 /// <reference path="./LightboxView.ts" />
 'use strict';
 
-App.MapLightboxView = App.LightboxView.extend({
-	classNames: ['map-lightbox'],
-	status: 'opening',
-
-	didInsertElement: function (): void {
-		this.set('status', 'open');
-
-		this._super();
-	},
-
-	willDestroyElement: function (): void {
-		this.get('controller').reset();
-
-		this._super();
-	}
+App.MapLightboxView = App.LightboxView.extend(App.LightboxMixin, {
+	classNames: ['map-lightbox']
 });

--- a/front/scripts/main/views/MediaLightboxView.ts
+++ b/front/scripts/main/views/MediaLightboxView.ts
@@ -2,21 +2,19 @@
 /// <reference path="../../../../typings/hammerjs/hammerjs" />
 /// <reference path="../../mercury/modules/VideoLoader.ts" />
 /// <reference path="../mixins/ArticleContentMixin.ts" />
+/// <reference path="../mixins/LightboxMixin.ts" />
 'use strict';
 
 interface Window {
 	scrollY: number;
 }
 
-App.MediaLightboxView = App.LightboxView.extend(App.ArticleContentMixin, {
+App.MediaLightboxView = App.LightboxView.extend(App.ArticleContentMixin, App.LightboxMixin, {
 	classNames: ['media-lightbox'],
 	maxZoom: 5,
 	lastX: 0,
 	lastY: 0,
 	lastScale: 1,
-	//opening, open
-	//before didInsertElement the lightbox is opening
-	status: 'opening',
 	videoPlayer: null,
 
 	isGallery: Em.computed.alias('controller.isGallery'),
@@ -366,7 +364,6 @@ App.MediaLightboxView = App.LightboxView.extend(App.ArticleContentMixin, {
 		var hammerInstance = this.get('_hammerInstance');
 		//disabled for now, we can make it better when we have time
 		//this.animateMedia(this.get('controller').get('element'));
-		this.set('status', 'open');
 		this.resetZoom();
 
 		hammerInstance.get('pinch').set({
@@ -381,7 +378,6 @@ App.MediaLightboxView = App.LightboxView.extend(App.ArticleContentMixin, {
 	},
 
 	willDestroyElement: function (): void {
-		this.get('controller').reset();
 		this.get('_hammerInstance').get('pinch').set({
 			enable: false
 		});

--- a/front/scripts/mercury/modules/Ads.ts
+++ b/front/scripts/mercury/modules/Ads.ts
@@ -54,6 +54,7 @@ module Mercury.Modules {
 						'ext.wikia.adEngine.adContext',
 						'ext.wikia.adEngine.adConfigMobile',
 						'ext.wikia.adEngine.adLogicPageViewCounter',
+						'ext.wikia.adEngine.customAdsLoader',
 						'wikia.krux'
 					], (
 						adEngineModule: any,
@@ -152,6 +153,13 @@ module Mercury.Modules {
 			this.adSlots = $.grep(this.adSlots, (slot) => {
 				return slot[0] && slot[0] === name;
 			}, true);
+		}
+
+		public openLightbox (contents: any): void {
+			/**
+			 * This method is being overwritten in ApplicationRoute for ads needs.
+			 * To learn more check ApplicationRoute.ts file.
+			 */
 		}
 
 		/**

--- a/front/scripts/mercury/modules/Ads.ts
+++ b/front/scripts/mercury/modules/Ads.ts
@@ -54,7 +54,6 @@ module Mercury.Modules {
 						'ext.wikia.adEngine.adContext',
 						'ext.wikia.adEngine.adConfigMobile',
 						'ext.wikia.adEngine.adLogicPageViewCounter',
-						'ext.wikia.adEngine.customAdsLoader',
 						'wikia.krux'
 					], (
 						adEngineModule: any,

--- a/front/scripts/mercury/modules/Ads.ts
+++ b/front/scripts/mercury/modules/Ads.ts
@@ -41,7 +41,7 @@ module Mercury.Modules {
 		 * Initializes the Ad module
 		 *
 		 * @param adsUrl Url for the ads script
-		 * @param callback Callback function to exwecute when the script is loaded
+		 * @param callback Callback function to execute when the script is loaded
 		 */
 		public init (adsUrl: string, callback: () => void): void {
 			//Required by ads tracking code

--- a/front/styles/main/module/_ads.scss
+++ b/front/styles/main/module/_ads.scss
@@ -19,3 +19,7 @@
 .no-ads {
 	height: 0;
 }
+
+.wikia-ad-iframe {
+	border: 0;
+}

--- a/front/templates/main/ads-lightbox.hbs
+++ b/front/templates/main/ads-lightbox.hbs
@@ -1,0 +1,1 @@
+{{contents}}


### PR DESCRIPTION
We implemented interstitial ads on Oasis and we're using there `UiFactory` and its regular modals. We also wanted to have the interstitial product on Mercury and changes below allows us to have it.

The changes includes:
* new simple ads lightbox,
* exposed `openMercuryAdLightbox()` function which opens *only* the ads lightbox.

This pull request is connected to https://github.com/Wikia/app/pull/6758.

To test if it's work open a mercury page in your browser and execute in JavaScript console following code:
```js
window.loadCustomAd && window.loadCustomAd({
  type: 'modal',
  width: 300,
  height: 250,
  code: 'An ad placeholder'
});
```