### PR TITLE
Fixed variable clobbering and use Boom to create error object

### DIFF
--- a/server/facets/editorPreview.ts
+++ b/server/facets/editorPreview.ts
@@ -1,6 +1,9 @@
 /// <reference path="../../typings/hapi/hapi.d.ts" />
+/// <reference path="../../typings/boom/boom.d.ts" />
+/// <reference path="../lib/Utils.ts" />
 
 import Article = require('../lib/Article');
+import Boom = require('boom');
 import Utils = require('../lib/Utils');
 import localSettings = require('../../config/localSettings');
 import verifyMWHash = require('./operations/verifyMWHash');
@@ -13,13 +16,14 @@ function editorPreview (request: Hapi.Request, reply: Hapi.Response): void {
 
 	Article.getWikiVariables(wikiDomain, (error: any, wikiVariables: any) => {
 		var article: any = {},
-			result: any = {},
-			error: any;
+			result: any = {};
 
-		if (verifyMWHash(parserOutput, mwHash)) {
-			article = JSON.parse(parserOutput);
-		} else {
-			error = true;
+		if (!error) {
+			if (verifyMWHash(parserOutput, mwHash)) {
+				article = JSON.parse(parserOutput);
+			} else {
+				error = Boom.forbidden('Failed to verify source');
+			}
 		}
 
 		result = {

--- a/typings/boom/boom.d.ts
+++ b/typings/boom/boom.d.ts
@@ -24,6 +24,7 @@ declare module Boom {
 	export function wrap(error: Error, statusCode?: number, message?: string): BoomError;
 	export function create(statusCode: number, message?: string, data?: any): BoomError;
 
+	export function forbidden(message?: string, data?: any): BoomError;
 	export function badRequest(message?: string, data?: any): BoomError;
 }
 


### PR DESCRIPTION
This fixes a tslint warning that was introduced with merging #618. This fixes the variable clobbering and handles the error from the getWikiVariables request.