### PR TITLE
Remove Foundation's .row styles from footer

### DIFF
--- a/front/styles/main/module/_site-footer.scss
+++ b/front/styles/main/module/_site-footer.scss
@@ -1,6 +1,4 @@
 .wikia-footer {
-	@extend %padding-on-sides;
-	@extend .row;
 	background-color: rgb(18, 49, 84);
 	color: white;
 	padding-bottom: 2rem;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CONCF-369

Styles removed in this PR caused the footer to be too wide (horizontal scrollbar was visible).