### PR TITLE
Downgrade gulp-sass to 1.1.x and revert related changes

### DIFF
--- a/front/styles/common/placeholder/%padding-on-sides.scss
+++ b/front/styles/common/placeholder/%padding-on-sides.scss
@@ -1,3 +1,0 @@
-%padding-on-sides {
-	padding: 0 1.125rem;
-}

--- a/front/styles/common/placeholder/index.scss
+++ b/front/styles/common/placeholder/index.scss
@@ -3,5 +3,4 @@
 @import '%ellipsis';
 @import '%headers';
 @import '%list-reset';
-@import '%padding-on-sides';
 @import '%pointer';

--- a/front/styles/main/layout/_page-wrapper.scss
+++ b/front/styles/main/layout/_page-wrapper.scss
@@ -20,9 +20,9 @@
 	}
 
 	.article-body {
-		@extend %padding-on-sides;
 		@extend .small-12;
 
 		overflow-x: hidden;
+		padding: 0 1.125rem;
 	}
 }

--- a/front/styles/main/module/_comments.scss
+++ b/front/styles/main/module/_comments.scss
@@ -32,7 +32,6 @@
 
 .comments {
 	@extend %list-reset;
-	@extend %padding-on-sides;
 
 	font-size: rem-calc(13);
 }

--- a/front/styles/main/module/_site-footer.scss
+++ b/front/styles/main/module/_site-footer.scss
@@ -1,4 +1,5 @@
 .wikia-footer {
+	@extend .row;
 	background-color: rgb(18, 49, 84);
 	color: white;
 	padding-bottom: 2rem;

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "gulp-replace": "^0.5.2",
     "gulp-rev": "^3.0.1",
     "gulp-rev-replace": "0.x.x",
-    "gulp-sass": "1.3.x",
+    "gulp-sass": "1.1.x",
     "gulp-svg-symbols": "0.x.x",
     "gulp-tslint": "1.x.x",
     "gulp-typedoc": "^1.0.6",


### PR DESCRIPTION
Reverts:
- https://github.com/Wikia/mercury/pull/603 - partially, Foundation 5.5.1 is fine
- https://github.com/Wikia/mercury/pull/625
- https://github.com/Wikia/mercury/pull/639

gulp-sass 1.3.x causes our CSS to break. This is blocking release-51 so I'm downgrading and reverting all the related changes.