### PR TITLE
CONCF-374 disable cache on random article inside jquery.ajax

### DIFF
--- a/front/scripts/main/models/ArticleModel.ts
+++ b/front/scripts/main/models/ArticleModel.ts
@@ -93,6 +93,7 @@ App.ArticleModel.reopenClass({
 		return new Em.RSVP.Promise((resolve: Function, reject: Function): void => {
 			Em.$.ajax({
 				url: App.get('apiBase') + '/article?random&titleOnly',
+				cache: false,
 				dataType: 'json',
 				success: (data): void => {
 					if (data.title) {


### PR DESCRIPTION
Response from /api/v1/article?random&titleOnly was cached for 60s on Varnish even though max-age and s-maxage are set to 0.

I decided to use $.ajax({cache:false}) which appends timestamp to URL.

ping @Warkot @rogatty 