### PR TITLE
Upgrade gulp-sass (for real this time)

### DIFF
--- a/front/styles/main/module/_comments.scss
+++ b/front/styles/main/module/_comments.scss
@@ -5,9 +5,12 @@
 
 	background: rgb(250,250,250);
 	color: $anchor-color-normal;
-	margin-bottom: 20px;
 	padding: 10px;
 	width: 100%;
+}
+
+.show-reply-btn {
+	margin-bottom: 20px;
 }
 
 .show-comments-btn {

--- a/front/styles/main/module/_comments.scss
+++ b/front/styles/main/module/_comments.scss
@@ -5,6 +5,7 @@
 
 	background: rgb(250,250,250);
 	color: $anchor-color-normal;
+	margin-bottom: 20px;
 	padding: 10px;
 	width: 100%;
 }

--- a/front/styles/main/module/_comments.scss
+++ b/front/styles/main/module/_comments.scss
@@ -38,6 +38,7 @@
 
 .article-comment {
 	@extend .row;
+	@extend .collapse;
 	margin: rem-calc(20) 0;
 
 	> div {

--- a/front/styles/main/module/_site-footer.scss
+++ b/front/styles/main/module/_site-footer.scss
@@ -1,5 +1,4 @@
 .wikia-footer {
-	@extend .row;
 	background-color: rgb(18, 49, 84);
 	color: white;
 	padding-bottom: 2rem;

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "gulp-replace": "^0.5.2",
     "gulp-rev": "^3.0.1",
     "gulp-rev-replace": "0.x.x",
-    "gulp-sass": "1.1.x",
+    "gulp-sass": "1.3.3",
     "gulp-svg-symbols": "0.x.x",
     "gulp-tslint": "1.x.x",
     "gulp-typedoc": "^1.0.6",


### PR DESCRIPTION
After merging the hapi-auth branch, we noticed that something odd was happening with the sass compilation. The settings file for `styles/main/app.scss` was getting overwritten by another settings file from `styles/auth/`.

To make a long story short, the version of libsass used by the gulp-sass plugin was getting confused when imports with two separate files in different directions with the same name. This was fixed in a later version of libsass so I upgraded our gulp-sass and also fixed all the regressions that resulted from the last time we tried to upgrade. Likely, they weren't regressions in the way we thought, but rather, the libsass version we were using was actually failing to correctly compile the mixins from Foundation. Upgrading gulp-sass revealed our mistakes and this PR fixes those:
* Fixed footer being too wide
* Fixed comments being too wide