### PR TITLE
Set auth mode to false for unauthenticated routes

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -21,10 +21,7 @@ var routes: RouteDefinition[],
 				privacy: Caching.policyString(Caching.Policy.Public),
 				expiresIn: 60000
 			},
-			auth: {
-				mode: 'try',
-				strategy: 'session'
-			},
+			auth: false,
 			plugins: {
 				'hapi-auth-cookie': {
 					redirectTo: false


### PR DESCRIPTION
Simply turns auth mode to false for unauthenticated routes, squelching errors from Kibana.