### PR TITLE
Do not try to access value on null

### DIFF
--- a/front/scripts/main/components/ArticleCommentComponent.ts
+++ b/front/scripts/main/components/ArticleCommentComponent.ts
@@ -23,8 +23,9 @@ App.ArticleCommentComponent = Em.Component.extend({
 
 	user: function () {
 		var users = this.get('users');
-
-		return users[this.get('comment.userName')] || {};
+		if (users) {
+			return users[this.get('comment.userName')] || {};
+		}
 	}.property('users'),
 
 	userName: function () {


### PR DESCRIPTION
@mklucsarits found a bug where if you opened up comments on a page with comments, and tried to transition using a `{{link-to}}` helper, like in the content recommendation area at the foot of an article, you would fail the transition because of trying to access a value on a null object. This adds a check that prevents that and allows the transition to proceed safely.