### PR TITLE
Make footer not overlap content for small viewports

### DIFF
--- a/front/styles/auth/layout/_body.scss
+++ b/front/styles/auth/layout/_body.scss
@@ -2,6 +2,6 @@ body {
 	color: $body-text-color;
 	display: flex;
 	flex-direction: column;
-	justify-content: flex-end;
+	justify-content: flex-start;
 	margin: auto;
 }

--- a/front/styles/auth/layout/_content.scss
+++ b/front/styles/auth/layout/_content.scss
@@ -1,6 +1,7 @@
 .auth-content {
 	background-color: $auth-content-background-color;
 	// stick the footer to the bottom
-	flex: 1;
+	flex-grow: 1;
+	flex-shrink: 0;
 	padding: 18px;
 }

--- a/front/styles/auth/theme/_auth-footer.scss
+++ b/front/styles/auth/theme/_auth-footer.scss
@@ -1,5 +1,7 @@
 .auth-footer {
 	color: $footer-text-color;
+	flex-grow: 0;
+	flex-shrink: 0;
 
 	a {
 		color: inherit;

--- a/front/styles/auth/theme/_auth-header.scss
+++ b/front/styles/auth/theme/_auth-header.scss
@@ -1,3 +1,5 @@
 .auth-header {
 	color: $header-text-color;
+	flex-grow: 0;
+	flex-shrink: 0;
 }


### PR DESCRIPTION
@lizlux @rogatty This just makes sure footer will not overlap form fields when the form is long / keyboard appears.