### PR TITLE
Update ember-performance-sender version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "jquery.cookie": "1.4.1",
     "scroll-depth": "https://github.com/nandy-andy/jquery-scrolldepth.git#0.8.3",
     "weppy": "Wikia/weppy",
-    "ember-performance-sender": "1.0.0",
+    "ember-performance-sender": "1.1.0",
     "vignette": "wikia/vignette-js#2.1.1",
     "wikia-style-guide": "Wikia/style-guide#~0.2.3"
   },


### PR DESCRIPTION
Discovered a bug today that was revealed (but not necessarily caused) by the recent Ember upgrade. It was fixed here: https://github.com/Wikia/ember-performance-sender/pull/3 and this updates our packages to reflect it. It was never on production because we haven't pushed the chef changes to run EPS/Weppy yet.