### PR TITLE
Don't use the TrackClick mixin to send an action, but actually use it to...

### DIFF
--- a/front/scripts/main/mixins/TrackClickMixin.ts
+++ b/front/scripts/main/mixins/TrackClickMixin.ts
@@ -1,10 +1,15 @@
 /// <reference path="../app.ts" />
+/// <reference path="../../mercury/utils/track.ts" />
 'use strict';
 
 App.TrackClickMixin = Em.Mixin.create({
 	actions: {
 		trackClick: function (category: string, label: string = ''): void {
-			this.sendAction('trackClick', category, label);
+			M.track({
+				action: M.trackActions.click,
+				category: category,
+				label: label
+			});
 		}
 	}
 });

--- a/front/scripts/main/routes/ApplicationRoute.ts
+++ b/front/scripts/main/routes/ApplicationRoute.ts
@@ -4,7 +4,7 @@
 /// <reference path="../../mercury/utils/variantTesting.ts" />
 'use strict';
 
-App.ApplicationRoute = Em.Route.extend(Em.TargetActionSupport, {
+App.ApplicationRoute = Em.Route.extend(Em.TargetActionSupport, App.TrackClickMixin, {
 	model: function <T>(params: T): T {
 		return params;
 	},
@@ -130,14 +130,6 @@ App.ApplicationRoute = Em.Route.extend(Em.TargetActionSupport, {
 		// This is used only in not-found.hbs template
 		expandSideNav: function (): void {
 			this.get('controller').set('sideNavCollapsed', false);
-		},
-
-		trackClick: function (category: string, label: string = ''): void {
-			M.track({
-				action: M.trackActions.click,
-				category: category,
-				label: label
-			});
 		}
 	}
 });


### PR DESCRIPTION
... track a click. @inez was having some issues with GA tracking and while looking into it, I discovered that TrackClickMixin was actually just a global proxy for ApplicationRoute's trackClick action. This seemed roundabout and confusing to me so I moved the tracking into TrackClickMixin and simply made ApplicationRoute a consumer of that mixin as well.