### PR TITLE
ADEN-1918 change the name of module to correct one

### DIFF
--- a/front/scripts/mercury/modules/Ads.ts
+++ b/front/scripts/mercury/modules/Ads.ts
@@ -52,7 +52,7 @@ module Mercury.Modules {
 					require([
 						'ext.wikia.adEngine.adEngine',
 						'ext.wikia.adEngine.adContext',
-						'ext.wikia.adEngine.adConfigMobile',
+						'ext.wikia.adEngine.config.mobile',
 						'ext.wikia.adEngine.adLogicPageViewCounter',
 						'wikia.krux'
 					], (


### PR DESCRIPTION
**DO NOT MERGE TILL MONDAY AFTER MERCURY RELEASE!!!**

While cleaning done in [ADEN-1785](https://wikia-inc.atlassian.net/browse/ADEN-1785) we renamed `ext.wikia.adEngine.adConfigMobile` module to `ext.wikia.adEngine.config.mobile`. Unfortunately, Mercury uses `ext.wikia.adEngine.adConfigMobile` and we didn't change it while cleaning up. The result was no ads in Mercury and JavaScript error in a browser console:
`Uncaught Module ext.wikia.adEngine.adConfigMobile is not defined.`

The small change below fix the issues.

**RELEASE NOTES:**
The idea is to release Mercury on Monday and it'd be safe release because `Wikia/app` release-286 won't be live yet. On Monday after release I'll merge it and it should be released on Tuesday after `Wikia/app` release-286 has been released.