### PR TITLE
Move crowdin config to multiple files, for now

### DIFF
--- a/crowdin-auth.conf
+++ b/crowdin-auth.conf
@@ -1,0 +1,7 @@
+[crowdin.project]
+projectid = "mercury"
+repo.branch = "i18n-update"
+source.base = "front/locales"
+source.file = "${source.base}/en/auth.json"
+export.base = "${source.base}"
+export.pattern = "${export.base}/%mediawiki_language_code%/"

--- a/crowdin-main.conf
+++ b/crowdin-main.conf
@@ -5,3 +5,4 @@ source.base = "front/locales"
 source.file = "${source.base}/en/main.json"
 export.base = "${source.base}"
 export.pattern = "${export.base}/%mediawiki_language_code%/"
+

--- a/crowdin-main.conf
+++ b/crowdin-main.conf
@@ -2,6 +2,6 @@
 projectid = "mercury"
 repo.branch = "i18n-update"
 source.base = "front/locales"
-source.file = "${source.base}/en/translation.json"
+source.file = "${source.base}/en/main.json"
 export.base = "${source.base}"
 export.pattern = "${export.base}/%mediawiki_language_code%/"


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/HG-589

The Mercury codebase is changing to use multiple JSON files for localization strings, separated by need and/or feature. However, multiple source files are not supported by the i18n CrowdIn API scripts. Therefore, until that happens, we need to use separate config files, one for each JSON file.