### PR TITLE
Allowing i18n helper to accept inline params

### DIFF
--- a/server/views/_helpers/i18n.ts
+++ b/server/views/_helpers/i18n.ts
@@ -2,13 +2,15 @@ function i18nHelper (key: string, options: any): string {
 	var translateWithCache: Function = this.i18n.translateWithCache,
 		params: {[key: string]: string} = {},
 		namespace = '',
-		instance = this.i18n.getInstance();
+		instance = this.i18n.getInstance(),
+		// Hash object is created from parameters passed into i18n tag (i.e. foo=bar or template context).
+		hash = options.hash;
 
-	Object.keys(options.hash).forEach((key: string) => {
+	Object.keys(hash).forEach((key: string) => {
 		if (key === 'ns') {
-			namespace = options.hash[key] + ':';
-		} else if (options.hasOwnProperty(key)) {
-			params[key] = String(options.hash[key]);
+			namespace = hash[key] + ':';
+		} else {
+			params[key] = String(hash[key]);
 		}
 	});
 


### PR DESCRIPTION
Previously, `{{i18n 'my-key' foo='bar'}}` wouldn't work b/c `options.hasOwnProperty(key)` was always evaluating to `false`. One fix would have been to change it to `options.hash.hasOwnProperty(key)`, but `Objects.keys` already filters out inherited properties so I removed that check altogether. 

I also added a comment and tried to make the code a bit easier to read for someone new to handlebars helpers. 