### PR TITLE
Render not-found template when we have 404

### DIFF
--- a/front/scripts/main/models/ArticleModel.ts
+++ b/front/scripts/main/models/ArticleModel.ts
@@ -78,7 +78,9 @@ App.ArticleModel.reopenClass({
 				},
 				error: (err): void => {
 					if (err.status === 404) {
-						this.setArticle(model, err.responseJSON);
+						this.setArticle(model, {
+							error: err.responseJSON
+						});
 						resolve(model);
 					} else {
 						// TODO we currently abort transition when there was an error other than 404

--- a/front/templates/main/article.hbs
+++ b/front/templates/main/article.hbs
@@ -1,4 +1,4 @@
-{{#if error}}
+{{#if model.error}}
 	{{render 'not-found'}}
 {{else}}
 	<section class='article-body'>


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CONCF-466

1. Fix for displaying not-found template after transition to non-existent article
2. Fix for a regression created when upgrading to Ember 1.11