### PR TITLE
Set the auth cookie TTL

### DIFF
--- a/server/facets/auth/login.ts
+++ b/server/facets/auth/login.ts
@@ -134,6 +134,10 @@ export function post (request: Hapi.Request, reply: any): void {
 			'refresh_token' : response.refresh_token
 		});
 
+		// Set cookie TTL for "remember me" period of 6 months
+		// TODO: Helios service should control the length of auth session
+		request.auth.session.ttl(1.57785e10);
+
 		if (isAJAX) {
 			return reply({redirect: redirect});
 		}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SOC-657

Even though the UI option for "remember me" was removed, we still need to set the cookie expiration.