### PR TITLE
ADEN-1946 Paid Asset Drops for Mercury

### DIFF
--- a/front/templates/main/article.hbs
+++ b/front/templates/main/article.hbs
@@ -3,6 +3,7 @@
 {{else}}
 	<section class='article-body'>
 		<h1 class='article-title'>{{model.cleanTitle}}</h1>
+		{{ad-slot name='NATIVE_PAID_ASSET_DROP' noAds=noAds}}
 		{{#if model.sections.length}}
 			{{#collapsible-menu
 				showMenuIcon=true


### PR DESCRIPTION
Adding another ad slot to Mercury, just under the article title.

The purpose of the slot is to serve Paid Asset Drops in it. PADs are highly polished per wiki campaigns running with knowledge and acceptance of the communities.