### PR TITLE
HG-595 fixing access_token cookie setting and removing unused cookie

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -76,7 +76,7 @@ server.register(plugins, (err: any) => {
 	server.auth.strategy('session', 'cookie', 'required', {
 		appendNext     : 'redirect',
 		clearInvalid   : true,
-		cookie         : 'sid',
+		cookie         : 'access_token',
 		isSecure       : false,
 		password       : localSettings.ironSecret,
 		redirectTo     : '/login'

--- a/server/facets/auth/login.ts
+++ b/server/facets/auth/login.ts
@@ -129,7 +129,6 @@ export function post (request: Hapi.Request, reply: any): void {
 		}
 
 		request.auth.session.set({
-			'user_id'       : response.user_id,
 			'access_token'  : response.access_token
 		});
 


### PR DESCRIPTION
The `access_token` cookie wasn't actually being set upon login. Now it is. 