### PR TITLE
Set hammerOptions.cssProps.touchCallout to 'default'

### DIFF
--- a/front/scripts/main/views/ArticleView.ts
+++ b/front/scripts/main/views/ArticleView.ts
@@ -174,7 +174,16 @@ App.ArticleView = Em.View.extend(App.AdsMixin, {
 	},
 
 	hammerOptions: {
-		touchAction: 'auto'
+		touchAction: 'auto',
+		cssProps: {
+			/**
+			 * @see https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-touch-callout
+			 * 'default' displays the callout
+			 * 'none' disables the callout
+			 * hammer.js sets it to 'none' by default so we have to override
+			 */
+			touchCallout: 'default'
+		}
 	},
 
 	gestures: {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CONCF-480

This fixes context menu on iOS 8.3. No idea why it was working in the previous versions, probably some bug in Safari?