### PR TITLE
HG-616 Use style guide package with icons removed

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,7 +17,7 @@
     "weppy": "Wikia/weppy",
     "ember-performance-sender": "1.1.0",
     "vignette": "wikia/vignette-js#2.1.1",
-    "wikia-style-guide": "Wikia/style-guide#~1.0.0"
+    "wikia-style-guide": "Wikia/style-guide#1.0.1"
   },
   "devDependencies": {
     "ember-qunit": "0.3.0",


### PR DESCRIPTION
This implements a patched version of the style guide package temporarily removing icon backgrounds using url() paths which caused 404 errors in Mercury. See https://github.com/Wikia/style-guide/commit/86c398a324aa0e6177b44c7acd75307824801e99 for the change to wikia/style-guide for the 1.0.1 release.

https://wikia-inc.atlassian.net/browse/HG-616

@rogatty