### PR TITLE
HG-615 adding properties to the list-reset scss placeholder to override ...

### DIFF
--- a/front/styles/common/placeholder/%list-reset.scss
+++ b/front/styles/common/placeholder/%list-reset.scss
@@ -1,4 +1,6 @@
 %list-reset {
+	font-size: inherit;
+	line-height: inherit;
 	list-style: none;
 	margin: 0;
 	padding: 0;


### PR DESCRIPTION
...those set with style guide lists

This mixin is also used in the contributors list and recommendations ("read more") list, both of which look fine after the change.