### PR TITLE
ADEN-1993 Fixed ads lightbox styling in Mercury

### DIFF
--- a/front/templates/main/ads-lightbox.hbs
+++ b/front/templates/main/ads-lightbox.hbs
@@ -1,1 +1,3 @@
-{{contents}}
+<div class="lightbox-content-inner">
+	{{contents}}
+</div>


### PR DESCRIPTION
After recent lightbox refactoring the ads lightbox styling got broken.

As a quick fix and workaround I've added a new wrapper in ads lightbox so the styling is not broken.