### PR TITLE
HG-625 setting helios config vars

### DIFF
--- a/config/localSettings.base.ts
+++ b/config/localSettings.base.ts
@@ -19,9 +19,9 @@ var localSettings: LocalSettings = {
 	environment: Utils.getEnvironment(process.env.WIKIA_ENVIRONMENT),
 	helios: {
 		// Never add the host, secret or key here directly, only specify in your localSettings.ts (.gitignored)
-		host: 'SENSITIVE, DO NOT ADD HERE',
-		secret: 'SENSITIVE, DO NOT ADD HERE',
-		id: 'SENSITIVE, DO NOT ADD HERE'
+		host: process.env.HELIOS_HOST,
+		secret: process.env.HELIOS_SECRET,
+		id: process.env.HELIOS_ID
 	},
 	ironSecret: 'TEST_SECRET_REPLACE_THIS',
 	// NOTE: On your devbox, use your eth0 address in able to bind route to something accessible


### PR DESCRIPTION
We need the private helios config values to be available to mercury settings. Previously, we were overriding these vars in our local settings, but that solution doesn't work for production environments. 

Corresponding chef PR to make these vars available to the mercury environment: https://github.com/Wikia/chef-repo/pull/5065.

@kenkouot 
