### PR TITLE
HG-631 setting and unsetting unencrypted access_token cookie

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -76,7 +76,7 @@ server.register(plugins, (err: any) => {
 	server.auth.strategy('session', 'cookie', 'required', {
 		appendNext     : 'redirect',
 		clearInvalid   : true,
-		cookie         : 'access_token',
+		cookie         : 'sid',
 		isSecure       : false,
 		password       : localSettings.ironSecret,
 		redirectTo     : '/login'
@@ -103,6 +103,12 @@ server.views({
 			getInstance: server.methods.i18n.getInstance
 		}
 	}
+});
+
+// Cookies
+server.state('access_token', {
+	isHttpOnly: true,
+	clearInvalid: true
 });
 
 // instantiate routes

--- a/server/facets/auth/logout.ts
+++ b/server/facets/auth/logout.ts
@@ -1,6 +1,7 @@
 /// <reference path="../../../typings/hapi/hapi.d.ts" />
 function logout (request: Hapi.Request, reply: any): void {
 	request.auth.session.clear();
+	reply.unstate('access_token');
 	reply.redirect('/');
 }
 export = logout;


### PR DESCRIPTION
Previously the access_token cookie's value was encrypted, so MW wouldn't have been able to read it. Now we're setting two cookies, one for hapi to manage an authenticated session, `sid`, and one that tags along and acts as the bridge between MW and Mercury, `access_token`. 

I created https://wikia-inc.atlassian.net/browse/HG-632 to make sure we document which cookies are used where in mercury authentication. 