### PR TITLE
Hg 624 Enable performance monitoring

### DIFF
--- a/config/localSettings.base.ts
+++ b/config/localSettings.base.ts
@@ -78,7 +78,7 @@ var localSettings: LocalSettings = {
 		tv: '#00b7e0'
 	},
 	weppy: {
-		enabled: !!process.env.ENABLE_WEPPY,
+		enabled: process.env.WIKIA_ENVIRONMENT === 'prod',
 		host: 'http://speed.wikia.net/__rum',
 		samplingRate: 0.01,
 		aggregationInterval: 1000

--- a/server/views/_layouts/ember-main.hbs
+++ b/server/views/_layouts/ember-main.hbs
@@ -90,7 +90,7 @@
 			<script src="/front/vendor/ember-hammer/ember-hammer.js"></script>
 			<script src="/front/vendor/i18next/i18next.js"></script>
 			<script src="/front/vendor/vignette/dist/vignette.js"></script>
-			<!-- @ifdef ENABLE_WEPPY -->
+			<!-- @if WIKIA_ENVIRONMENT!='dev' -->
 				<script src="/front/vendor/weppy/dist/weppy.js"></script>
 				<script src="/front/vendor/ember-performance-sender/dist/ember-performance-sender.js"></script>
 			<!-- @endif -->

--- a/server/views/_layouts/ember-main.hbs
+++ b/server/views/_layouts/ember-main.hbs
@@ -90,7 +90,7 @@
 			<script src="/front/vendor/ember-hammer/ember-hammer.js"></script>
 			<script src="/front/vendor/i18next/i18next.js"></script>
 			<script src="/front/vendor/vignette/dist/vignette.js"></script>
-			<!-- @if WIKIA_ENVIRONMENT!='dev' -->
+			<!-- @if WIKIA_ENVIRONMENT='prod' -->
 				<script src="/front/vendor/weppy/dist/weppy.js"></script>
 				<script src="/front/vendor/ember-performance-sender/dist/ember-performance-sender.js"></script>
 			<!-- @endif -->


### PR DESCRIPTION
My previous attempts to enable performance monitoring failed do to use of a custom environment variable that wasn't available at **build time**. I've simplified this by simply binding to the environment instead.