### PR TITLE
Hg 612 fixing jump-to links in TOC with cb param in query string

### DIFF
--- a/front/scripts/main/components/ArticleCommentsComponent.ts
+++ b/front/scripts/main/components/ArticleCommentsComponent.ts
@@ -6,7 +6,7 @@ App.ArticleCommentsComponent = Em.Component.extend({
 	page: null,
 	articleId: null,
 	commentsCount: null,
-	classNames: ['article-comments'],
+	classNames: ['article-comments', 'mw-content'],
 	model: null,
 	isCollapsed: true,
 

--- a/front/scripts/main/components/LocalNavMenuComponent.ts
+++ b/front/scripts/main/components/LocalNavMenuComponent.ts
@@ -27,7 +27,7 @@ interface NavItem extends RootNavItem {
 
 App.LocalNavMenuComponent = Em.Component.extend({
 	tagName: 'ul',
-	classNames: ['local-nav-menu'],
+	classNames: ['local-nav-menu', 'mw-content'],
 
 	/**
 	 * Note: this means that the model is stored directly

--- a/front/scripts/main/components/LocalNavMenuComponent.ts
+++ b/front/scripts/main/components/LocalNavMenuComponent.ts
@@ -27,7 +27,7 @@ interface NavItem extends RootNavItem {
 
 App.LocalNavMenuComponent = Em.Component.extend({
 	tagName: 'ul',
-	classNames: ['local-nav-menu', 'mw-content'],
+	classNames: ['local-nav-menu'],
 
 	/**
 	 * Note: this means that the model is stored directly

--- a/front/scripts/main/views/ApplicationView.ts
+++ b/front/scripts/main/views/ApplicationView.ts
@@ -107,11 +107,12 @@ App.ApplicationView = Em.View.extend({
 		 * because if the user clicks the part of the link in the <i></i> then
 		 * target.tagName will register as 'I' and not 'A'.
 		 */
-		var $closest = Em.$(event.target).closest('a'),
-			target: EventTarget = $closest.length ? $closest[0] : event.target,
+		var $anchor = Em.$(event.target).closest('a'),
+			target: EventTarget = $anchor.length ? $anchor[0] : event.target,
 			tagName: string;
 
-		if (target) {
+		if (target && this.isMWContent(target)) {
+			console.log('apply logic');
 			tagName = target.tagName.toLowerCase();
 
 			if (tagName === 'a') {
@@ -121,6 +122,8 @@ App.ApplicationView = Em.View.extend({
 				this.handleMedia(<HTMLElement>target);
 				event.preventDefault();
 			}
+		} else {
+			console.log('don\'t apply logic');
 		}
 	},
 
@@ -133,6 +136,13 @@ App.ApplicationView = Em.View.extend({
 	shouldHandleMedia: function (target: EventTarget, tagName: string): boolean {
 		return tagName === 'img' || tagName === 'figure'
 			&& $(target).children('a').length === 0;
+	},
+
+	/**
+	 * Determine if we have to apply special logic to the click handler for MediaWiki / UGC content
+	 */
+	isMWContent: function (target: EventTarget): boolean {
+		return !!$(target).closest('.mw-content').length;
 	},
 
 	sideNavCollapsedObserver: Em.observer('sideNavCollapsed', function (): void {

--- a/front/scripts/main/views/ApplicationView.ts
+++ b/front/scripts/main/views/ApplicationView.ts
@@ -112,7 +112,6 @@ App.ApplicationView = Em.View.extend({
 			tagName: string;
 
 		if (target && this.isMWContent(target)) {
-			console.log('apply logic');
 			tagName = target.tagName.toLowerCase();
 
 			if (tagName === 'a') {
@@ -122,8 +121,6 @@ App.ApplicationView = Em.View.extend({
 				this.handleMedia(<HTMLElement>target);
 				event.preventDefault();
 			}
-		} else {
-			console.log('don\'t apply logic');
 		}
 	},
 

--- a/front/templates/main/article.hbs
+++ b/front/templates/main/article.hbs
@@ -23,7 +23,7 @@
 				{{/each}}
 			{{/collapsible-menu}}
 		{{/if}}
-		{{#view 'article-content'}}
+		{{#view 'article-content' class='mw-content'}}
 			{{#if model.article}}
 				{{{model.article}}}
 			{{else}}

--- a/front/templates/main/components/content-recommendations.hbs
+++ b/front/templates/main/components/content-recommendations.hbs
@@ -1,7 +1,7 @@
 {{#if pages.length}}
 	<section class="content-recommendations">
 		<h1>{{i18n 'app.article-suggestions-label'}}</h1>
-		<ul>
+		<ul class="mw-content">
 			{{#each page in pages}}
 				<li>
 					{{#link-to 'article' page.title bubbles=false data-tracking-category='related'}}

--- a/front/templates/main/components/local-nav-menu.hbs
+++ b/front/templates/main/components/local-nav-menu.hbs
@@ -26,7 +26,7 @@
 			</div>
 		</li>
 	{{else}}
-        <li>
+        <li class="mw-content">
 			<a {{action 'collapseSideNav'}} href='{{unbound child.href}}'>{{unbound child.text}}</a>
 		</li>
 	{{/if}}

--- a/front/templates/main/components/local-wikia-search.hbs
+++ b/front/templates/main/components/local-wikia-search.hbs
@@ -1,6 +1,6 @@
 <ul>
 	{{#each suggestion in suggestions}}
-		<li>
+		<li class="mw-content">
 		{{#link-to 'article' suggestion.uri action='collapseSideNav'}}
 			{{suggestion.title}}
 		{{/link-to}}

--- a/test/specs/front/scripts/main/views/ApplicationView.js
+++ b/test/specs/front/scripts/main/views/ApplicationView.js
@@ -39,3 +39,21 @@ test('shouldHandleMedia returns correct value', function () {
 		equal(appViewMock.shouldHandleMedia(testCase.target, testCase.tagName), testCase.expected);
 	});
 });
+
+test('isMWContent returns correct value', function () {
+	var appViewMock = this.subject(),
+		testCases = [
+			{
+				target: '<li class="mw-content"></li>',
+				expected: true
+			},
+			{
+				target: '<li></li>',
+				expected: false
+			}
+		];
+
+	testCases.forEach(function(testCase) {
+		equal(appViewMock.isMWContent(testCase.target), testCase.expected);
+	});
+});


### PR DESCRIPTION
This PR designates which content we need to apply special click logic to and which content we can let Ember handle on it's own. This should help simplify click handler logic by isolating it to only UGC. 

To do: 
- [ ] document this new convention in the github wiki pages. 
- [ ] run selenium tests