### PR TITLE
HG-648 temporary fix for footer links

### DIFF
--- a/front/templates/main/components/wikia-footer.hbs
+++ b/front/templates/main/components/wikia-footer.hbs
@@ -1,5 +1,5 @@
 {{svg 'wikia-logo-white' viewBox='0 0 152 42' role='img' class='logo'}}
-<ul class='footer-links'>
+<ul class='footer-links mw-content'>
 	{{#each link in links}}
 		<li class='{{unbound link.className}}'>
 			<a href='{{unbound link.href}}' {{action 'trackClick' 'footer' link.text}} class='external'>{{i18n 'app' link.text}}</a>


### PR DESCRIPTION
This is a temporary fix to include footer links in the list of content areas that should be given special link handling. I'm going to keep this ticket open (or maybe open a new one) so we can find a better solution. For now we just need to unblock the release. 