### PR TITLE
INT-73: Apply 'mw-content' class to share feature component so it goes through proper click handler

### DIFF
--- a/front/scripts/main/components/ShareFeatureComponent.ts
+++ b/front/scripts/main/components/ShareFeatureComponent.ts
@@ -6,7 +6,7 @@
 'use strict';
 
 App.ShareFeatureComponent = Em.Component.extend(App.TrackClickMixin, App.LanguagesMixin, {
-	classNames: ['share-feature'],
+	classNames: ['share-feature', 'mw-content'],
 	tagName: 'div',
 	headroom: null,
 


### PR DESCRIPTION
This is quick and dirty solution to a problem introduced as a regression of https://github.com/Wikia/mercury/commit/3885edc49508aa5868e7b9e0a736f45037939ae2
@rogatty and @lizlux recommended this as a good temporary solution - temporary cause Mercury team is going to work on a proper solution as a part of https://wikia-inc.atlassian.net/browse/HG-654 