### PR TITLE
DAT-2788: For TOC creation only select H2s that have section attribute specified

### DIFF
--- a/front/scripts/main/views/ArticleView.ts
+++ b/front/scripts/main/views/ArticleView.ts
@@ -106,7 +106,7 @@ App.ArticleView = Em.View.extend(App.AdsMixin, App.ViewportMixin, {
 	 * ToC data from server and render view based on that.
 	 */
 	loadTableOfContentsData: function () {
-		var headers: HeadersFromDom[] = this.$('h2').map((i: number, elem: HTMLElement): HeadersFromDom => {
+		var headers: HeadersFromDom[] = this.$('h2[section]').map((i: number, elem: HTMLElement): HeadersFromDom => {
 			if (elem.textContent) {
 				return {
 					level: elem.tagName,


### PR DESCRIPTION
In article HTML H2s (and other header tags) can comeout from various of wikitext - not only wikitext sections - as a part of INT-58 I modified ArticleAsJson to add section attrbiute to all header tags which are actually wikitext sections. More info: https://wikia-inc.atlassian.net/browse/HG-600