### PR TITLE
ADEN-2030 Fix ads on Mercury

### DIFF
--- a/front/scripts/main/models/ArticleModel.ts
+++ b/front/scripts/main/models/ArticleModel.ts
@@ -185,7 +185,7 @@ App.ArticleModel.reopenClass({
 				data.relatedPages = source.relatedPages;
 			}
 
-			if (source.adsContext && source.adsContext.length) {
+			if (source.adsContext) {
 				data.adsContext = source.adsContext;
 			}
 


### PR DESCRIPTION
Reverted condition since it broke ads on consecutive pageviews.

The condition wasn't good enough since when Ad Engine was enabled the `adsContext` instance didn't have `length` property (because it was an object).

Related pull request: Wikia/app#7236