### PR TITLE
Use the returned value from wrapResult method

### DIFF
--- a/server/facets/api/article.ts
+++ b/server/facets/api/article.ts
@@ -34,8 +34,8 @@ export function get (request: Hapi.Request,  reply: any): void {
 
 	if (isRequestForRandomTitle(request.query)) {
 		Article.getArticleRandomTitle(wikiDomain, (error: any, result: any): void => {
-			wrapResult(error, result);
-			Caching.setResponseCaching(reply(result), randomTitleCachingTimes);
+			var wrappedResult = wrapResult(error, result);
+			Caching.setResponseCaching(reply(wrappedResult), randomTitleCachingTimes);
 		});
 		return;
 	}
@@ -46,7 +46,7 @@ export function get (request: Hapi.Request,  reply: any): void {
 		redirect: request.params.redirect
 	}, (error: any, result: any): void => {
 		// TODO: Consider normalizing all error handling to Boom
-		wrapResult(error, result);
-		Caching.setResponseCaching(reply(result).code(result.status), cachingTimes);
+		var wrappedResult = wrapResult(error, result);
+		Caching.setResponseCaching(reply(wrappedResult).code(wrappedResult.status), cachingTimes);
 	});
 }

--- a/server/facets/api/articleComments.ts
+++ b/server/facets/api/articleComments.ts
@@ -95,8 +95,8 @@ export function get (request: Hapi.Request, reply: any): void {
 			reply(transformResponse(response));
 			Caching.setResponseCaching(response, cachingTimes);
 		}, (error: any) => {
-			var preparedResult: any = wrapResult(error, {});
-			reply(preparedResult).code(preparedResult.status);
+			var wrappedResult = wrapResult(error, {});
+			reply(wrappedResult).code(wrappedResult.status);
 		});
 	}
 }

--- a/server/facets/api/curatedContent.ts
+++ b/server/facets/api/curatedContent.ts
@@ -41,8 +41,8 @@ export function get (request: Hapi.Request, reply: any): void {
 			reply(response);
 			Caching.setResponseCaching(response, cachingTimes);
 		}, (error: any): void => {
-			var preparedResult: any = wrapResult(error, {});
-			reply(preparedResult).code(preparedResult.status);
+			var wrappedResult = wrapResult(error, {});
+			reply(wrappedResult).code(wrappedResult.status);
 		});
 	}
 }

--- a/server/facets/api/search.ts
+++ b/server/facets/api/search.ts
@@ -22,8 +22,9 @@ export function get (request: Hapi.Request, reply: any): void {
 		})
 		.searchForQuery(params.query)
 		.then((result: any) => {
-			var error = result.exception || null;
-			Caching.setResponseCaching(reply(wrapResult(error, result)), cachingTimes);
+			var error = result.exception || null,
+				wrappedResult = wrapResult(error, result);
+			Caching.setResponseCaching(reply(wrappedResult), cachingTimes);
 		})
 		.catch((err: any) => {
 			reply(err).code(err.exception.code || 500);


### PR DESCRIPTION
Using `wrapResult` without using the value it returns caused exceptions when there was no `result`. For me it happened when MW returned 503 error.

This is the fix and a naming clean up.