### PR TITLE
Feature/hg 656 tracking

### DIFF
--- a/front/scripts/main/app.ts
+++ b/front/scripts/main/app.ts
@@ -2,6 +2,7 @@
 /// <reference path="../../../typings/ember/ember.d.ts" />
 /// <reference path="../../../typings/i18next/i18next.d.ts" />
 /// <reference path="../baseline/mercury.ts" />
+/// <reference path="../mercury/modules/Trackers/UniversalAnalytics.ts" />
 /// <reference path="../mercury/utils/track.ts" />
 /// <reference path="../mercury/utils/trackPerf.ts" />
 
@@ -104,7 +105,7 @@ App.initializer({
 			$(() => {
 				events = [
 					['domContentLoaded', times.domContentLoadedEventStart - times.domLoading],
-					['domComplete', times.domContentLoadedEventStart - times.domLoading],
+					['domCompvare', times.domContentLoadedEventStart - times.domLoading],
 					['domInteractive', times.domInteractive - times.domLoading]
 				].map((item: PerfTrackerParams) => createEvent.apply(null, item));
 
@@ -134,6 +135,47 @@ App.initializer({
 	initialize: (container: any, application: any): void => {
 		application.register('currentUser:main', App.CurrentUser);
 		application.inject('controller', 'currentUser', 'currentUser:main');
+	}
+});
+
+App.initializer({
+	name: 'setupTracking',
+	initialize (container: any, application: typeof App): void {
+		var UA = Mercury.Modules.Trackers.UniversalAnalytics,
+			dimensions: (string|Function)[] = [],
+			adsContext = Mercury.Modules.Ads.getInstance().getContext();
+
+		function getPageType () {
+			var mainPageTitle = Mercury.wiki.mainPageTitle,
+				isMainPage = window.location.pathname.split('/').indexOf(mainPageTitle);
+
+			return isMainPage >= 0 ? 'home' : 'article';
+		}
+
+		/**** High-Priority Custom Dimensions ****/
+		dimensions[1] = Mercury.wiki.dbName;								 // dbName
+		dimensions[2] = Mercury.wiki.language.content;                    // ContentLanguage
+		dimensions[4] = 'mercury';                                        // Skin
+		// TODO: Currently the only login status is 'anon', in the future 'user' may be an option
+		dimensions[5] = 'anon';                                           // LoginStatus
+		dimensions[9] = String(Mercury.wiki.id);                          // CityId
+		dimensions[8] = getPageType;
+		dimensions[15] = 'No';    // IsCorporatePage
+		// TODO: Krux segmenting not implemented in Mercury https://wikia-inc.atlassian.net/browse/HG-456
+		// ga(prefix + 'set', 'dimension16', getKruxSegment());                             // Krux Segment
+		dimensions[17] = Mercury.wiki.vertical;                           // Vertical
+		dimensions[19] = M.prop('article.type');                          // ArticleType
+
+		if (adsContext) {
+			dimensions[3] = adsContext.targeting.wikiVertical;            // Hub
+			dimensions[14] = adsContext.opts.showAds ? 'Yes' : 'No';      // HasAds
+		}
+
+		if (Mercury.wiki.wikiCategories instanceof Array) {
+			dimensions[18] = Mercury.wiki.wikiCategories.join(',');       // Categories
+		}
+
+		UA.setDimensions(dimensions);
 	}
 });
 

--- a/front/scripts/main/app.ts
+++ b/front/scripts/main/app.ts
@@ -2,6 +2,7 @@
 /// <reference path="../../../typings/ember/ember.d.ts" />
 /// <reference path="../../../typings/i18next/i18next.d.ts" />
 /// <reference path="../baseline/mercury.ts" />
+/// <reference path="../mercury/modules/Ads.ts" />
 /// <reference path="../mercury/modules/Trackers/UniversalAnalytics.ts" />
 /// <reference path="../mercury/utils/track.ts" />
 /// <reference path="../mercury/utils/trackPerf.ts" />

--- a/front/scripts/main/app.ts
+++ b/front/scripts/main/app.ts
@@ -141,6 +141,7 @@ App.initializer({
 
 App.initializer({
 	name: 'setupTracking',
+	after: 'currentUser',
 	initialize (container: any, application: typeof App): void {
 		var UA = Mercury.Modules.Trackers.UniversalAnalytics,
 			dimensions: (string|Function)[] = [],

--- a/front/scripts/main/app.ts
+++ b/front/scripts/main/app.ts
@@ -105,7 +105,7 @@ App.initializer({
 			$(() => {
 				events = [
 					['domContentLoaded', times.domContentLoadedEventStart - times.domLoading],
-					['domCompvare', times.domContentLoadedEventStart - times.domLoading],
+					['domComplete', times.domContentLoadedEventStart - times.domLoading],
 					['domInteractive', times.domInteractive - times.domLoading]
 				].map((item: PerfTrackerParams) => createEvent.apply(null, item));
 

--- a/front/scripts/mercury/modules/Trackers/UniversalAnalytics.ts
+++ b/front/scripts/mercury/modules/Trackers/UniversalAnalytics.ts
@@ -43,8 +43,8 @@ module Mercury.Modules.Trackers {
 		/**
 		 * @static
 		 * @description Synchronously sets the UA dimensional context
-		 * @param dimensions {Array} array of dimensions to set, may be strings or functions
-		 * @param overwrite {boolean} set to true to overwrite all preexisting dimensions and unset ones not declared
+		 * @param {Array} dimensions  array of dimensions to set, may be strings or functions
+		 * @param {boolean} overwrite  set to true to overwrite all preexisting dimensions and unset ones not declared
 		 * @returns {boolean} true if dimensions were successfully set
 		 */
 		public static setDimensions (dimensions: typeof UniversalAnalytics.dimensions, overwrite?: boolean): boolean {
@@ -63,6 +63,7 @@ module Mercury.Modules.Trackers {
 
 		/**
 		 * @private
+		 * @param {number} index of dimension
 		 * @description Retrieves string value or invokes function for value
 		 * @returns {string}
 		 */
@@ -163,7 +164,7 @@ module Mercury.Modules.Trackers {
 			var pageType = this.getDimension(8);
 
 			if (!pageType) {
-				throw new Error('mission page type dimension (#8)');
+				throw new Error('missing page type dimension (#8)');
 			}
 
 			ga('set', 'dimension8', pageType, 3);

--- a/front/scripts/mercury/modules/Trackers/UniversalAnalytics.ts
+++ b/front/scripts/mercury/modules/Trackers/UniversalAnalytics.ts
@@ -1,6 +1,6 @@
 /// <reference path="../../../../../typings/google.analytics/ga.d.ts" />
-/// <reference path="../../modules/Ads.ts" />
 /// <reference path="../../../baseline/mercury.ts" />
+/// <reference path="../../../baseline/mercury.d.ts" />
 
 interface TrackerOptions {
 	name: string;
@@ -22,11 +22,10 @@ module Mercury.Modules.Trackers {
 				);
 			}
 
-			var adsContext = Mercury.Modules.Ads.getInstance().getContext(),
 				// All domains that host content for Wikia
 				// Use one of the domains below. If none matches, the tag will fall back to
 				// the default which is 'auto', probably good enough in edge cases.
-				domain: string = [
+			var domain: string = [
 					'wikia.com', 'ffxiclopedia.org', 'jedipedia.de',
 					'marveldatabase.com', 'memory-alpha.org', 'uncyclopedia.org',
 					'websitewiki.de', 'wowwiki.com', 'yoyowiki.org'
@@ -35,9 +34,9 @@ module Mercury.Modules.Trackers {
 			this.accounts = M.prop('tracking.ua');
 
 			// Primary account
-			this.initAccount(this.accountPrimary, adsContext, domain);
+			this.initAccount(this.accountPrimary, domain);
 
-			this.initAccount(this.accountAds, adsContext, domain);
+			this.initAccount(this.accountAds, domain);
 		}
 
 
@@ -76,10 +75,9 @@ module Mercury.Modules.Trackers {
 		 * Initialize an additional account or property
 		 *
 		 * @param {string} name The name of the account as specified in localSettings
-		 * @param {object} adsContext
 		 * @param {string} domain
 		 */
-		initAccount (trackerName: string, adsContext: any, domain: string): void {
+		initAccount (trackerName: string, domain: string): void {
 			var options: TrackerOptions, prefix: string,
 				dimensionNum: string;
 

--- a/test/helpers/baseline.js
+++ b/test/helpers/baseline.js
@@ -39,6 +39,10 @@ function resetMercuryBaseline () {
 			content: 'en'
 		}
 	});
+
+	var dimensions = [];
+	dimensions[8] = 'test/article';
+	Mercury.Modules.Trackers.UniversalAnalytics.setDimensions(dimensions);
 }
 
 resetMercuryBaseline();

--- a/test/specs/front/scripts/main/models/ArticleModel.js
+++ b/test/specs/front/scripts/main/models/ArticleModel.js
@@ -23,7 +23,10 @@ moduleFor('model:article', 'Article Model', {
 			});
 
 		this.wikiExample = {
-			siteName: 'test'
+			siteName: 'test',
+			language: {
+				content: 'en'
+			}
 		};
 
 		// Preload data into Mercury.article


### PR DESCRIPTION
Abstracts UA dimensions from the class declaration and moves it to a developer controlled initialization. The only prerequisite is tracking dimensions must be set before any invocations of the tracking function.

Adds a new static function `UniversalAnalytics#setDimensions` with a signature of `(dimensions: typeof UniversalAnalytics.dimensions, overwrite?: boolean): boolean`. Properly invoke this function before using `M.track` anywhere or you will have a bad time.

@bkoval 