### PR TITLE
Fixing forgot-password link

### DIFF
--- a/server/lib/AuthUtils.ts
+++ b/server/lib/AuthUtils.ts
@@ -7,8 +7,8 @@
 import url = require('url');
 import querystring = require('querystring');
 
-var wikiaSignupPathname: string = '/Special:UserSignup',
-	wikiaLoginPathname: string = '/Special:UserLogin',
+var wikiaSignupPathname: string = 'wiki/Special:UserSignup',
+	wikiaLoginPathname: string = 'wiki/Special:UserLogin',
 	forgotPasswordSearch: string = '?recover=1';
 
 export function getSignupUrlFromRedirect(redirect: string): string {

--- a/server/lib/AuthUtils.ts
+++ b/server/lib/AuthUtils.ts
@@ -7,8 +7,8 @@
 import url = require('url');
 import querystring = require('querystring');
 
-var wikiaSignupPathname: string = 'wiki/Special:UserSignup',
-	wikiaLoginPathname: string = 'wiki/Special:UserLogin',
+var wikiaSignupPathname: string = '/wiki/Special:UserSignup',
+	wikiaLoginPathname: string = '/wiki/Special:UserLogin',
 	forgotPasswordSearch: string = '?recover=1';
 
 export function getSignupUrlFromRedirect(redirect: string): string {


### PR DESCRIPTION
Turns out Mercury supports only wikias with /wiki/ in the article path. This should be safe this way, tested on sandbox.

@mklucsarits 