### PR TITLE
Add check for GA special wiki

### DIFF
--- a/config/localSettings.base.ts
+++ b/config/localSettings.base.ts
@@ -63,6 +63,11 @@ var localSettings: LocalSettings = {
 				prefix: 'ads',
 				id: 'UA-32129071-1',
 				sampleRate: 100
+			},
+			special: {
+				prefix: 'special',
+				id: 'UA-32132943-1',
+				sampleRate: 100
 			}
 		},
 		quantserve: 'p-8bG6eLqkH6Avk',

--- a/front/scripts/mercury/modules/Trackers/UniversalAnalytics.ts
+++ b/front/scripts/mercury/modules/Trackers/UniversalAnalytics.ts
@@ -13,9 +13,10 @@ module Mercury.Modules.Trackers {
 		static dimensions: (string|Function)[] = [];
 		accounts: GAAccountMap;
 		accountPrimary = 'primary';
+		accountSpecial = 'special';
 		accountAds = 'ads';
 
-		constructor () {
+		constructor (isSpecialWiki = false) {
 			if (!UniversalAnalytics.dimensions.length) {
 				throw new Error(
 					'Cannot instantiate UA tracker: please provide dimensions using UniversalAnalytics#setDimensions'
@@ -37,6 +38,10 @@ module Mercury.Modules.Trackers {
 			this.initAccount(this.accountPrimary, domain);
 
 			this.initAccount(this.accountAds, domain);
+
+			if (isSpecialWiki) {
+				this.initAccount(this.accountSpecial, domain);
+			}
 		}
 
 

--- a/front/scripts/mercury/modules/Trackers/UniversalAnalytics.ts
+++ b/front/scripts/mercury/modules/Trackers/UniversalAnalytics.ts
@@ -11,6 +11,7 @@ interface TrackerOptions {
 module Mercury.Modules.Trackers {
 	export class UniversalAnalytics {
 		static dimensions: (string|Function)[] = [];
+		tracked: GAAccount[] = [];
 		accounts: GAAccountMap;
 		accountPrimary = 'primary';
 		accountSpecial = 'special';
@@ -113,6 +114,8 @@ module Mercury.Modules.Trackers {
 
 			UniversalAnalytics.dimensions.forEach((dimension: string|Function, idx: number) =>
 				ga(`${prefix}set`, `dimension${idx}`, this.getDimension(idx)));
+
+			this.tracked.push(this.accounts[trackerName]);
 		}
 
 		/**
@@ -172,11 +175,12 @@ module Mercury.Modules.Trackers {
 				throw new Error('missing page type dimension (#8)');
 			}
 
-			ga('set', 'dimension8', pageType, 3);
-			// Set custom var in ad account as well
-			ga(this.accounts[this.accountAds].prefix + '.set', pageType, 3);
+			this.tracked.forEach((account) => {
+				var prefix = account.prefix ? account.prefix + '.' : '';
+				ga(`${prefix}set`, 'dimension8', pageType, 3);
+				ga(`${prefix}send`, 'pageview');
+			});
 
-			ga('send', 'pageview');
 		}
 	}
 }

--- a/front/scripts/mercury/modules/Trackers/UniversalAnalytics.ts
+++ b/front/scripts/mercury/modules/Trackers/UniversalAnalytics.ts
@@ -175,7 +175,7 @@ module Mercury.Modules.Trackers {
 				throw new Error('missing page type dimension (#8)');
 			}
 
-			this.tracked.forEach((account) => {
+			this.tracked.forEach((account: GAAccount) => {
 				var prefix = account.prefix ? account.prefix + '.' : '';
 				ga(`${prefix}set`, 'dimension8', pageType, 3);
 				ga(`${prefix}send`, 'pageview');

--- a/front/scripts/mercury/utils/track.ts
+++ b/front/scripts/mercury/utils/track.ts
@@ -175,7 +175,7 @@ module Mercury.Utils {
 				instance: TrackerInstance;
 
 			if (typeof Tracker.prototype.trackPageView === 'function') {
-				instance = new Tracker();
+				instance = new Tracker(isSpecialWiki());
 				console.info('Track pageView:', tracker);
 				instance.trackPageView(instance.usesAdsContext ? adsContext : context);
 			}

--- a/front/scripts/mercury/utils/track.ts
+++ b/front/scripts/mercury/utils/track.ts
@@ -107,7 +107,7 @@ module Mercury.Utils {
 
 	function isSpecialWiki () {
 		try {
-			return Mercury.wiki.isGASpecialWiki;
+			return !!(M.prop('isGASpecialWiki') || Mercury.wiki.isGASpecialWiki);
 		} catch (e) {
 			// Property doesn't exist
 			return false;

--- a/front/scripts/mercury/utils/track.ts
+++ b/front/scripts/mercury/utils/track.ts
@@ -105,6 +105,15 @@ module Mercury.Utils {
 		delete params.isNonInteractive;
 	}
 
+	function isSpecialWiki () {
+		try {
+			return Mercury.wiki.isGASpecialWiki;
+		} catch (e) {
+			// Property doesn't exist
+			return false;
+		}
+	}
+
 	export function track (params: TrackingParams): void {
 		var trackingMethod: string = params.trackingMethod || 'both',
 			action: string = params.action,
@@ -136,7 +145,7 @@ module Mercury.Utils {
 				throw new Error('missing required GA params');
 			}
 
-			uaTracker = new trackers.UniversalAnalytics();
+			uaTracker = new trackers.UniversalAnalytics(isSpecialWiki());
 			uaTracker.track(category, actions[action], label, value, isNonInteractive);
 		}
 


### PR DESCRIPTION
Adds a check for `isGASpecialWiki`. This can be defined in two places, `Mercury.wiki.isGASpecialWiki` or `M.prop('isGASpecialWiki')`. The preferred place to declare values as these is in `M.prop`, but the Mercury app currently still has legacy coupling with the globals, `Mercury.wiki`.