### PR TITLE
SOC-826 Disable browser caching for HTML documents

### DIFF
--- a/server/facets/api/article.ts
+++ b/server/facets/api/article.ts
@@ -8,7 +8,7 @@ var cachingTimes = {
 		enabled: true,
 		cachingPolicy: Caching.Policy.Public,
 		varnishTTL: Caching.Interval.standard,
-		browserTTL: Caching.Interval.default
+		browserTTL: Caching.Interval.disabled
 	},
 	randomTitleCachingTimes = {
 		enabled: false,

--- a/server/facets/showArticle.ts
+++ b/server/facets/showArticle.ts
@@ -11,7 +11,7 @@ var cachingTimes = {
 	enabled: true,
 	cachingPolicy: Caching.Policy.Public,
 	varnishTTL: Caching.Interval.standard,
-	browserTTL: Caching.Interval.default
+	browserTTL: Caching.Interval.disabled
 };
 
 function showArticle (request: Hapi.Request, reply: Hapi.Response): void {


### PR DESCRIPTION
Caching HTML in browser has 2 downsides:

 - If a user visited Mercury page and then logs in, he'll get Mercury after clicking a link toa previously visited article

 - If a user visited a page on Mercury and then this page got edited by someone else, he'll not be able to see the new contents for 24 hours.

This also breaks new login behavior as we don't handle logged-in state in Mercury yet.

@rogatty @kvas-damian @lizlux @kenkouot 