### PR TITLE
(INT-82) Don't display edit buttons on main pages or non-Japanese wikias

### DIFF
--- a/front/scripts/main/mixins/LanguagesMixin.ts
+++ b/front/scripts/main/mixins/LanguagesMixin.ts
@@ -2,13 +2,17 @@
 'use strict';
 
 App.LanguagesMixin = Em.Mixin.create({
-	isJapanese: Ember.computed(function (): boolean {
+	isJapaneseBrowser: Ember.computed(function (): boolean {
 		var lang = navigator.language || navigator.browserLanguage;
 		if (lang) {
 			lang = lang.substr(0, 2);
 		} else {
-			lang = this.get('language.content');
+			lang = Em.get(Mercury, 'wiki.language.content');
 		}
 		return lang === 'ja';
+	}),
+
+	isJapaneseWikia: Ember.computed(function (): boolean {
+		return Em.get(Mercury, 'wiki.language.content') === 'ja';
 	})
 });

--- a/front/scripts/main/models/ArticleModel.ts
+++ b/front/scripts/main/models/ArticleModel.ts
@@ -194,6 +194,8 @@ App.ArticleModel.reopenClass({
 				data.topContributors = source.topContributors;
 			}
 
+			data.isMainPage = (model.title === Mercury.wiki.mainPageTitle);
+
 			if (source.mainPageData && M.prop('optimizelyCuratedMainPage')) {
 				data.mainPageData = source.mainPageData;
 				data.isCuratedMainPage = true;

--- a/front/scripts/main/models/ArticleModel.ts
+++ b/front/scripts/main/models/ArticleModel.ts
@@ -194,7 +194,9 @@ App.ArticleModel.reopenClass({
 				data.topContributors = source.topContributors;
 			}
 
-			data.isMainPage = (model.title === Mercury.wiki.mainPageTitle);
+			if (source.isMainPage) {
+				data.isMainPage = source.isMainPage;
+			}
 
 			if (source.mainPageData && M.prop('optimizelyCuratedMainPage')) {
 				data.mainPageData = source.mainPageData;

--- a/front/scripts/main/models/ArticleModel.ts
+++ b/front/scripts/main/models/ArticleModel.ts
@@ -28,6 +28,7 @@ interface Response {
 			users: any;
 			categories: any[];
 		};
+		isMainPage: boolean;
 		mainPageData: any[];
 		relatedPages: any[];
 		topContributors: any[];
@@ -41,6 +42,7 @@ App.ArticleModel = Em.Object.extend({
 	categories: [],
 	cleanTitle: null,
 	comments: 0,
+	isMainPage: false,
 	mainPageData: null,
 	media: [],
 	mediaUsers: [],

--- a/front/scripts/main/views/ArticleView.ts
+++ b/front/scripts/main/views/ArticleView.ts
@@ -16,12 +16,11 @@ interface HTMLElement {
 	scrollIntoViewIfNeeded: () => void
 }
 
-App.ArticleView = Em.View.extend(App.AdsMixin, App.ViewportMixin, {
+App.ArticleView = Em.View.extend(App.AdsMixin, App.ViewportMixin, App.LanguagesMixin, {
 	classNames: ['article-wrapper'],
 
 	editButtonsVisible: Em.computed('controller.model.isMainPage', function (): boolean {
-		var contentLanguage: string = Em.get(Mercury, 'wiki.language.content');
-		return !this.get('controller.model.isMainPage') && contentLanguage === 'ja';
+		return !this.get('controller.model.isMainPage') && this.get('isJapaneseWikia');
 	}),
 
 	/**

--- a/front/scripts/main/views/ArticleView.ts
+++ b/front/scripts/main/views/ArticleView.ts
@@ -19,6 +19,11 @@ interface HTMLElement {
 App.ArticleView = Em.View.extend(App.AdsMixin, App.ViewportMixin, {
 	classNames: ['article-wrapper'],
 
+	editButtonsVisible: Em.computed('controller.model.isMainPage', function (): boolean {
+		var contentLanguage: string = Em.get(Mercury, 'wiki.language.content');
+		return !this.get('controller.model.isMainPage') && contentLanguage === 'ja';
+	}),
+
 	/**
 	 * willInsertElement
 	 * @description The article view is only inserted once, and then refreshed on new models. Use this hook to bind
@@ -62,7 +67,9 @@ App.ArticleView = Em.View.extend(App.AdsMixin, App.ViewportMixin, {
 			M.trackPageView(model.get('adsContext.targeting'));
 
 		} else if (article && article.length > 0) {
-			this.setupEditButtons();
+			if (this.get('editButtonsVisible')) {
+				this.setupEditButtons();
+			}
 			this.loadTableOfContentsData();
 			this.handleInfoboxes();
 			this.handlePortableInfoboxes();

--- a/front/templates/main/article.hbs
+++ b/front/templates/main/article.hbs
@@ -11,9 +11,11 @@
 	{{#if model.isCuratedMainPage}}
 		{{main-page model=model.mainPageData}}
 	{{else}}
-		{{#link-to 'edit' model.title '0' bubbles=false}}
-			{{svg 'pencil' role='img' class='icon pencil zero'}}
-		{{/link-to}}
+		{{#if view.editButtonsVisible}}
+			{{#link-to 'edit' model.title '0' bubbles=false}}
+				{{svg 'pencil' role='img' class='icon pencil zero'}}
+			{{/link-to}}
+		{{/if}}
 		<section class='article-body'>
 			<h1 class='article-title'>{{model.cleanTitle}}</h1>
 			{{ad-slot name='NATIVE_PAID_ASSET_DROP' noAds=noAds}}

--- a/front/templates/main/components/share-feature.hbs
+++ b/front/templates/main/components/share-feature.hbs
@@ -1,8 +1,8 @@
-{{#if isJapanese}}
+{{#if isJapaneseBrowser}}
 	<a {{action 'trackClick' 'share' 'line'}} href={{lineShare}}>{{svg 'line' role='img' class='icon line'}}</a>
 {{/if}}
 <a {{action 'trackClick' 'share' 'fb'}} href={{facebookShare}}>{{svg 'fb' role='img' class='icon fb'}}</a>
 <a {{action 'trackClick' 'share' 'twitter'}} href={{twitterShare}}>{{svg 'twitter' role='img' class='icon twitter'}}</a>
-{{#if isJapanese}}
+{{#if isJapaneseBrowser}}
 	<a {{action 'trackClick' 'share' 'google'}} href={{googleShare}}>{{svg 'google' role='img' class='icon google'}}</a>
 {{/if}}


### PR DESCRIPTION
For the MVP, we don't want the edit buttons to show on main pages, and to
only display them on Japanese-language wikias.

/cc @inez 