### PR TITLE
Fix curated content invalid typing

### DIFF
--- a/front/scripts/main/components/CuratedContentComponent.ts
+++ b/front/scripts/main/components/CuratedContentComponent.ts
@@ -52,7 +52,8 @@ App.CuratedContentComponent = Em.Component.extend(App.LoadingSpinnerMixin, App.T
 		});
 
 		topLevelSection = {
-			items: topLevelSectionItems
+			items: topLevelSectionItems,
+			isTopSection: true
 		};
 
 		this.sectionsStack.pushObject(topLevelSection);
@@ -87,7 +88,8 @@ App.CuratedContentComponent = Em.Component.extend(App.LoadingSpinnerMixin, App.T
 	onSectionLoaded: function (items: CuratedContentItem[], parent: CuratedContentItem): void {
 		var section: CuratedContentSection = {
 			label: parent.label,
-			items: items
+			items: items,
+			isTopSection: false
 		};
 
 		this.sectionsStack.pushObject(section);

--- a/front/scripts/main/components/CuratedContentComponent.ts
+++ b/front/scripts/main/components/CuratedContentComponent.ts
@@ -52,8 +52,7 @@ App.CuratedContentComponent = Em.Component.extend(App.LoadingSpinnerMixin, App.T
 		});
 
 		topLevelSection = {
-			items: topLevelSectionItems,
-			isTopSection: true
+			items: topLevelSectionItems
 		};
 
 		this.sectionsStack.pushObject(topLevelSection);
@@ -88,8 +87,7 @@ App.CuratedContentComponent = Em.Component.extend(App.LoadingSpinnerMixin, App.T
 	onSectionLoaded: function (items: CuratedContentItem[], parent: CuratedContentItem): void {
 		var section: CuratedContentSection = {
 			label: parent.label,
-			items: items,
-			isTopSection: false
+			items: items
 		};
 
 		this.sectionsStack.pushObject(section);

--- a/front/scripts/main/models/CuratedContentModel.ts
+++ b/front/scripts/main/models/CuratedContentModel.ts
@@ -2,8 +2,9 @@
 'use strict';
 
 interface CuratedContentSection {
-	label?: string;
 	items: CuratedContentItem[];
+	isTopSection?: boolean;
+	label?: string;
 }
 
 interface CuratedContentItem {


### PR DESCRIPTION
`isTopSection` property was missing from the `CuratedContentSection` type.

https://github.com/Wikia/mercury/blob/dev/front/scripts/main/components/CuratedContentComponent.ts#L56 and https://github.com/Wikia/mercury/blob/dev/front/scripts/main/components/CuratedContentComponent.ts#L92 were highligthed by WebStorm because of invalid type.

/cc @Warkot @vforge 