### PR TITLE
SOC-850 & SOC-845 New Login Fixes to cooperate with autofill

### DIFF
--- a/front/scripts/auth/common/Form.ts
+++ b/front/scripts/auth/common/Form.ts
@@ -3,9 +3,11 @@
  */
 class Form {
 	form: HTMLFormElement;
+	inputs: NodeList;
 
 	constructor (form: Element) {
 		this.form = <HTMLFormElement> form;
+		this.inputs = this.form.querySelectorAll('input[type=text], input[type=password], input[type=email]');
 	}
 
 	private onFocus (event: Event): void {
@@ -19,13 +21,13 @@ class Form {
 	}
 
 	private onBlur (event: Event): void {
-		var input = <HTMLInputElement> event.target,
-			label = <HTMLElement> input.nextElementSibling,
-			wrapper = <HTMLElement> input.parentElement;
-
-		if (input.tagName.toLowerCase() === 'input' && wrapper.className.match('input-container') && !input.value) {
-			label.classList.remove('active');
-		}
+		Array.prototype.forEach.call(this.inputs, function (input: HTMLInputElement): void {
+			var label = <HTMLElement> input.nextElementSibling,
+				wrapper = <HTMLElement> input.parentElement;
+			if (wrapper.className.match('input-container') && !input.value) {
+				label.classList.remove('active');
+			}
+		});
 	}
 
 	private togglePasswordInput (input: HTMLInputElement, toggler: HTMLElement): void {
@@ -55,9 +57,9 @@ class Form {
 	/**
 	 * Moves labels up if they were filled by the browser's autofill
 	 */
-	private activateLabels(): void {
+	private onChange(): void {
 		Array.prototype.forEach.call(
-			this.form.querySelectorAll('input[type=text], input[type=password], input[type=email]'),
+			this.inputs,
 			function (input: HTMLInputElement): void {
 				var label = <HTMLLabelElement> input.nextElementSibling,
 					wrapper = <HTMLElement> input.parentElement;
@@ -72,9 +74,10 @@ class Form {
 	 * Starts continuous checking for new input
 	 */
 	public watch (): void {
-		this.activateLabels();
+		this.onChange();
 		this.form.addEventListener('focus', this.onFocus.bind(this), true);
 		this.form.addEventListener('blur', this.onBlur.bind(this), true);
+		this.form.addEventListener('change', this.onChange.bind(this), true);
 		this.form.addEventListener('click', this.onClick.bind(this));
 	}
 }

--- a/front/scripts/auth/login/SubmitValidator.ts
+++ b/front/scripts/auth/login/SubmitValidator.ts
@@ -16,7 +16,7 @@ class SubmitValidator {
 	/**
 	 * Activates / deactivates submit button in the login form
 	 */
-	private onInput ():void {
+	private onChange ():void {
 		if (this.areAllFieldsFilled()) {
 			this.activateSubmit();
 		} else {
@@ -52,8 +52,8 @@ class SubmitValidator {
 	 * Starts continuous checking for new input
 	 */
 	public watch (): void {
-		this.onInput();
-		this.form.addEventListener('input', this.onInput.bind(this));
-		this.form.addEventListener('blur', this.onInput.bind(this), true);
+		this.onChange();
+		this.form.addEventListener('change', this.onChange.bind(this));
+		this.form.addEventListener('input', this.onChange.bind(this));
 	}
 }

--- a/front/scripts/auth/login/SubmitValidator.ts
+++ b/front/scripts/auth/login/SubmitValidator.ts
@@ -53,7 +53,7 @@ class SubmitValidator {
 	 */
 	public watch (): void {
 		this.onChange();
-		this.form.addEventListener('change', this.onChange.bind(this));
+		this.form.addEventListener('change', this.onChange.bind(this), true);
 		this.form.addEventListener('input', this.onChange.bind(this));
 	}
 }

--- a/front/scripts/auth/login/SubmitValidator.ts
+++ b/front/scripts/auth/login/SubmitValidator.ts
@@ -54,5 +54,6 @@ class SubmitValidator {
 	public watch (): void {
 		this.onInput();
 		this.form.addEventListener('input', this.onInput.bind(this));
+		this.form.addEventListener('blur', this.onInput.bind(this), true);
 	}
 }


### PR DESCRIPTION
Both Android and iOS have different autofill mechanisms. We need to gear up as much as we can to let them do their work, not affecting our validation. 

 - iOS has a "Password autofill" feature on login input that will autofill the password and login for the user, not "input" or "focus/blur" events on the way. We only have the "change" event on the whole form )with capturing flag switched on) to intercept that

 - Android's Chrome will autofill the fields after DOMContentLoaded handlers finish executing and it will spontaneously trigger "change" event for either one or more fields (not deterministically)

 - Both autofill mechanisms can be used "on the fly" as the user types in and selects username from a dropdown / clicks "password autofill" above the keyboard

 - Password in Android's Chrome will dissapear when a username that it was associated with changes in the username field and it will not fire a "change" event

This all means we need to iterate through fields to see what's the actual state of the values whenever one of the fields changes.