### PR TITLE
ADEN-2065 Fix styling for Floor Adhesion unit with transparency image

### DIFF
--- a/front/styles/main/module/_ads-floor.scss
+++ b/front/styles/main/module/_ads-floor.scss
@@ -23,7 +23,7 @@
 		right: 0;
 		width: 30px;
 
-	  .ads-floor-close-button {
+		.ads-floor-close-button {
 			fill: white;
 			height: 12px;
 			outline: none;

--- a/front/styles/main/module/_ads-floor.scss
+++ b/front/styles/main/module/_ads-floor.scss
@@ -18,35 +18,34 @@
 		background-color: #000;
 		bottom: 0;
 		display: block;
-		padding: 5px 9px;
+		padding: 13px 9px;
 		position: absolute;
-		width: 30px;
-		height: 100%;
 		right: 0;
+		width: 30px;
 
-		.ads-floor-close-button {
+	  .ads-floor-close-button {
 			fill: white;
-			position: relative;
 			height: 12px;
 			outline: none;
+			position: relative;
+			top: 0;
 			width: 12px;
-			top: 10px;
 		}
 	}
 
 	.ad {
 		padding-right: 30px;
-	}
 
-	.ad iframe {
-		border: 0;
-		display: block;
-		margin: 0 auto;
-		position: relative;
+		 iframe {
+			border: 0;
+			display: block;
+			margin: 0 auto;
+			position: relative;
+			}
 	}
 
 	.background {
-		background: rgba(0, 0, 0, 0.4);
+		background: rgba(0, 0, 0, .4);
 		bottom: 0;
 		height: 50px;
 		position: absolute;


### PR DESCRIPTION
When an ad in Floor Adhesion unit uses image with transparency with `height` bigger than the unit's background the close button of the unit is displayed wrongly. This is because of incorrect styling and using `height: 100%` for the close button.

Changes below fixes the issue and address some issues found by scss-lint tool.