### PR TITLE
Hg 654 remove 'mw-content' from non-mediawiki content wrappers

### DIFF
--- a/front/scripts/main/components/ShareFeatureComponent.ts
+++ b/front/scripts/main/components/ShareFeatureComponent.ts
@@ -6,7 +6,7 @@
 'use strict';
 
 App.ShareFeatureComponent = Em.Component.extend(App.TrackClickMixin, App.LanguagesMixin, {
-	classNames: ['share-feature', 'mw-content'],
+	classNames: ['share-feature'],
 	tagName: 'div',
 	headroom: null,
 

--- a/front/scripts/main/mixins/TrackClickMixin.ts
+++ b/front/scripts/main/mixins/TrackClickMixin.ts
@@ -16,12 +16,21 @@ App.TrackClickMixin = Em.Mixin.create({
 		trackClick: function (category: string, label: string = '', isNonInteractive: boolean = true): void {
 			this.trackClick(category, label, isNonInteractive);
 		},
-		trackClickAndFollow: function (url: string, category: string, label: string = '', isNonInteractive: boolean = true): void {
+		trackClickAndFollow: function (
+			url: string, category: string,
+			label: string = '',
+			isNonInteractive: boolean = true,
+			newTab: boolean = false
+		): void {
 			this.trackClick(category, label, isNonInteractive);
 			if (!url) {
 				throw new Error('trackClickAndFollow needs an href to follow')
 			}
-			window.location.assign(url);
+			if (newTab) {
+				window.open(url);
+			} else {
+				window.location.assign(url);
+			}
 		}
 	}
 });

--- a/front/scripts/main/mixins/TrackClickMixin.ts
+++ b/front/scripts/main/mixins/TrackClickMixin.ts
@@ -15,6 +15,13 @@ App.TrackClickMixin = Em.Mixin.create({
 	actions: {
 		trackClick: function (category: string, label: string = '', isNonInteractive: boolean = true): void {
 			this.trackClick(category, label, isNonInteractive);
+		},
+		trackClickAndFollow: function (url: string, category: string, label: string = '', isNonInteractive: boolean = true): void {
+			this.trackClick(category, label, isNonInteractive);
+			if (!url) {
+				throw new Error('trackClickAndFollow needs an href to follow')
+			}
+			window.location.assign(url);
 		}
 	}
 });

--- a/front/scripts/main/mixins/TrackClickMixin.ts
+++ b/front/scripts/main/mixins/TrackClickMixin.ts
@@ -15,22 +15,6 @@ App.TrackClickMixin = Em.Mixin.create({
 	actions: {
 		trackClick: function (category: string, label: string = '', isNonInteractive: boolean = true): void {
 			this.trackClick(category, label, isNonInteractive);
-		},
-		trackClickAndFollow: function (
-			url: string, category: string,
-			label: string = '',
-			isNonInteractive: boolean = true,
-			newTab: boolean = false
-		): void {
-			this.trackClick(category, label, isNonInteractive);
-			if (!url) {
-				throw new Error('trackClickAndFollow needs an href to follow')
-			}
-			if (newTab) {
-				window.open(url);
-			} else {
-				window.location.assign(url);
-			}
 		}
 	}
 });

--- a/front/templates/main/components/share-feature.hbs
+++ b/front/templates/main/components/share-feature.hbs
@@ -1,8 +1,16 @@
 {{#if isJapaneseBrowser}}
-	<a {{action 'trackClickAndFollow' lineShare 'share' 'line' true true}} href={{lineShare}}>{{svg 'line' role='img' class='icon line'}}</a>
+	<a target="_blank" {{action 'trackClick' 'share' 'line' true preventDefault=false}} href="{{lineShare}}">
+		{{svg 'line' role='img' class='icon line'}}
+	</a>
 {{/if}}
-<a {{action 'trackClickAndFollow' facebookShare 'share' 'fb' true true}} href={{facebookShare}}>{{svg 'fb' role='img' class='icon fb'}}</a>
-<a {{action 'trackClickAndFollow' twitterShare 'share' 'twitter' true true}} href={{twitterShare}}>{{svg 'twitter' role='img' class='icon twitter'}}</a>
+<a target="_blank" {{action 'trackClick' 'share' 'fb' true preventDefault=false}} href="{{facebookShare}}">
+	{{svg 'fb' role='img' class='icon fb'}}
+</a>
+<a target="_blank" {{action 'trackClick' 'share' 'twitter' true preventDefault=false}} href="{{twitterShare}}">
+	{{svg 'twitter' role='img' class='icon twitter'}}
+</a>
 {{#if isJapaneseBrowser}}
-	<a {{action 'trackClickAndFollow' googleShare 'share' 'google' true true}} href={{googleShare}}>{{svg 'google' role='img' class='icon google'}}</a>
+	<a target="_blank" {{action 'trackClick' 'share' 'google' true preventDefault=false}} href="{{googleShare}}">
+		{{svg 'google' role='img' class='icon google'}}
+	</a>
 {{/if}}

--- a/front/templates/main/components/share-feature.hbs
+++ b/front/templates/main/components/share-feature.hbs
@@ -1,16 +1,16 @@
 {{#if isJapaneseBrowser}}
-	<a target="_blank" {{action 'trackClick' 'share' 'line' true preventDefault=false}} href="{{lineShare}}">
+	<a {{action 'trackClick' 'share' 'line' preventDefault=false}} href="{{lineShare}}" target="_blank" >
 		{{svg 'line' role='img' class='icon line'}}
 	</a>
 {{/if}}
-<a target="_blank" {{action 'trackClick' 'share' 'fb' true preventDefault=false}} href="{{facebookShare}}">
+<a {{action 'trackClick' 'share' 'fb' preventDefault=false}} href="{{facebookShare}}" target="_blank">
 	{{svg 'fb' role='img' class='icon fb'}}
 </a>
-<a target="_blank" {{action 'trackClick' 'share' 'twitter' true preventDefault=false}} href="{{twitterShare}}">
+<a {{action 'trackClick' 'share' 'twitter' preventDefault=false}} href="{{twitterShare}}" target="_blank">
 	{{svg 'twitter' role='img' class='icon twitter'}}
 </a>
 {{#if isJapaneseBrowser}}
-	<a target="_blank" {{action 'trackClick' 'share' 'google' true preventDefault=false}} href="{{googleShare}}">
+	<a {{action 'trackClick' 'share' 'google' preventDefault=false}} href="{{googleShare}}" target="_blank">
 		{{svg 'google' role='img' class='icon google'}}
 	</a>
 {{/if}}

--- a/front/templates/main/components/share-feature.hbs
+++ b/front/templates/main/components/share-feature.hbs
@@ -1,8 +1,8 @@
 {{#if isJapaneseBrowser}}
-	<a {{action 'trackClick' 'share' 'line'}} href={{lineShare}}>{{svg 'line' role='img' class='icon line'}}</a>
+	<a {{action 'trackClickAndFollow' lineShare 'share' 'line' true true}} href={{lineShare}}>{{svg 'line' role='img' class='icon line'}}</a>
 {{/if}}
-<a {{action 'trackClick' 'share' 'fb'}} href={{facebookShare}}>{{svg 'fb' role='img' class='icon fb'}}</a>
-<a {{action 'trackClick' 'share' 'twitter'}} href={{twitterShare}}>{{svg 'twitter' role='img' class='icon twitter'}}</a>
+<a {{action 'trackClickAndFollow' facebookShare 'share' 'fb' true true}} href={{facebookShare}}>{{svg 'fb' role='img' class='icon fb'}}</a>
+<a {{action 'trackClickAndFollow' twitterShare 'share' 'twitter' true true}} href={{twitterShare}}>{{svg 'twitter' role='img' class='icon twitter'}}</a>
 {{#if isJapaneseBrowser}}
-	<a {{action 'trackClick' 'share' 'google'}} href={{googleShare}}>{{svg 'google' role='img' class='icon google'}}</a>
+	<a {{action 'trackClickAndFollow' googleShare 'share' 'google' true true}} href={{googleShare}}>{{svg 'google' role='img' class='icon google'}}</a>
 {{/if}}

--- a/front/templates/main/components/wikia-footer.hbs
+++ b/front/templates/main/components/wikia-footer.hbs
@@ -1,8 +1,8 @@
 {{svg 'wikia-logo-white' viewBox='0 0 152 42' role='img' class='logo'}}
-<ul class='footer-links mw-content'>
+<ul class='footer-links'>
 	{{#each link in links}}
 		<li class='{{unbound link.className}}'>
-			<a href='{{unbound link.href}}' {{action 'trackClick' 'footer' link.text}} class='external'>{{i18n 'app' link.text}}</a>
+			<a href='{{unbound link.href}}' {{action 'trackClickAndFollow' link.href 'footer' link.text}} class='external'>{{i18n 'app' link.text}}</a>
 		</li>
 	{{/each}}
 </ul>

--- a/front/templates/main/components/wikia-footer.hbs
+++ b/front/templates/main/components/wikia-footer.hbs
@@ -2,7 +2,7 @@
 <ul class="footer-links">
 	{{#each link in links}}
 		<li class="{{unbound link.className}}">
-			<a {{bind-attr href=link.href}} {{action 'trackClick' 'footer' link.text preventDefault=false}}	class="external">
+			<a href="{{unbound link.href}}" {{action 'trackClick' 'footer' link.text preventDefault=false}}	class="external">
 				{{i18n 'app' link.text}}
 			</a>
 		</li>

--- a/front/templates/main/components/wikia-footer.hbs
+++ b/front/templates/main/components/wikia-footer.hbs
@@ -1,8 +1,10 @@
 {{svg 'wikia-logo-white' viewBox='0 0 152 42' role='img' class='logo'}}
-<ul class='footer-links'>
+<ul class="footer-links">
 	{{#each link in links}}
-		<li class='{{unbound link.className}}'>
-			<a href='{{unbound link.href}}' {{action 'trackClickAndFollow' link.href 'footer' link.text}} class='external'>{{i18n 'app' link.text}}</a>
+		<li class="{{unbound link.className}}">
+			<a {{bind-attr href=link.href}} {{action 'trackClick' 'footer' link.text preventDefault=false}}	class="external">
+				{{i18n 'app' link.text}}
+			</a>
 		</li>
 	{{/each}}
 </ul>


### PR DESCRIPTION
This undoes a hack we were using to make sure links that were not processed by the `ApplicationRoute` `handleLink` action were still followed. Turns out, by default, ember action helpers will prevent the default action of an event, such as click. Adding `preventDefault=false` to the action helper fixes this.  

This PR also ensures the tracking call is still sent properly before navigating to external links, and I updated the hbs to match [new guidelines](https://github.com/Wikia/guidelines/tree/master/Handlebars) re: quotes. 

@inez @rogatty 

I think there's still more work to do to clean up the `handleLink` function, but that can be done in a separate PR. 