### PR TITLE
Enable suppressImplicitAnyIndexErrors flag

### DIFF
--- a/gulp/options/dev.js
+++ b/gulp/options/dev.js
@@ -16,7 +16,8 @@ module.exports = {
 			noImplicitAny: true,
 			removeComments: false,
 			declarationFiles: false,
-			sortOutput: true
+			sortOutput: true,
+			suppressImplicitAnyIndexErrors: true
 		},
 		server: {
 			module: 'commonjs',
@@ -24,7 +25,8 @@ module.exports = {
 			emitError: false,
 			noImplicitAny: true,
 			declarationFiles: false,
-			removeComments: false
+			removeComments: false,
+			suppressImplicitAnyIndexErrors: true
 		}
 	},
 	doc: {

--- a/gulp/options/prod.js
+++ b/gulp/options/prod.js
@@ -16,7 +16,8 @@ module.exports = {
 			noImplicitAny: true,
 			removeComments: true,
 			declarationFiles: false,
-			sortOutput: true
+			sortOutput: true,
+			suppressImplicitAnyIndexErrors: true
 		},
 		server: {
 			module: 'commonjs',
@@ -25,7 +26,8 @@ module.exports = {
 			outDir: paths.scripts.server.dest,
 			removeComments: true,
 			noImplicitAny: true,
-			declarationFiles: false
+			declarationFiles: false,
+			suppressImplicitAnyIndexErrors: true
 		}
 	},
 	doc: {


### PR DESCRIPTION
This change would enable the ```—suppressImplicitAnyIndexErrors``` flag for ```tsc```. This Github issue provides some background about how that option came to be: https://github.com/Microsoft/TypeScript/issues/1232

I’m encouraging this change because I think in many cases, the types for string indices are obvious to us as developers and are not necessary. And in some cases, providing typing for these can require
rearranging and adding code, making it tedious at least and at worst a waste of time. In other words, a benefit that Typescript provides is actually working against us.

Here’s a real-world example where this would apply.
```
private getCredentials (): LoginCredentials {
    return {
        username: this.form.elements['username'].value,
        password: this.form.elements['password'].value
    };
}
```
This is a member function of a Login class. ```this.form``` has a type of ```HTMLFormElement``` which has the native property ```elements```, which can be accessed by index with an id or name of a form element. Without the ```—suppressImplicitAnyIndexErrors``` flag, you would see compilation warnings like:
```7017 Index signature of object type implicitly has an 'any' type.```
and you’d need to create an interface or do some casting to satisfy the compiler, or (in this case) replace the index access with a function call. With the flag enabled, these kinds of cases are ignored.

@kenkouot @lizlux @rogatty @hakubo