### PR TITLE
HG-736 Add in support for forwarding headers

### DIFF
--- a/server/facets/api/article.ts
+++ b/server/facets/api/article.ts
@@ -30,21 +30,23 @@ function isRequestForRandomTitle (query: any): boolean {
  * @param result
  */
 export function get (request: Hapi.Request,  reply: any): void {
-	var wikiDomain = Utils.getCachedWikiDomainName(localSettings, request.headers.host);
+	var wikiDomain = Utils.getCachedWikiDomainName(localSettings, request.headers.host),
+		params = {
+			wikiDomain: wikiDomain,
+			title: request.params.articleTitle,
+			redirect: request.params.redirect
+		},
+		article = new Article.ArticleRequestHelper(params);
 
 	if (isRequestForRandomTitle(request.query)) {
-		Article.getArticleRandomTitle(wikiDomain, (error: any, result: any): void => {
+		article.getArticleRandomTitle((error: any, result: any): void => {
 			var wrappedResult = wrapResult(error, result);
 			Caching.setResponseCaching(reply(wrappedResult), randomTitleCachingTimes);
 		});
 		return;
 	}
 
-	Article.getData({
-		wikiDomain: wikiDomain,
-		title: request.params.articleTitle,
-		redirect: request.params.redirect
-	}, (error: any, result: any): void => {
+	article.getData((error: any, result: any): void => {
 		// TODO: Consider normalizing all error handling to Boom
 		var wrappedResult = wrapResult(error, result);
 		Caching.setResponseCaching(reply(wrappedResult).code(wrappedResult.status), cachingTimes);

--- a/server/facets/api/article.ts
+++ b/server/facets/api/article.ts
@@ -38,9 +38,9 @@ export function get (request: Hapi.Request,  reply: any): void {
 		},
 		article: Article.ArticleRequestHelper;
 
-		if (request.state['wikicities_session']) {
+		if (request.state.wikicities_session) {
 			params.headers = {
-				'wikicities_session': request.state['wikicities_session']
+				'Cookie': `wikicities_session=${request.state.wikicities_session}`
 			};
 		}
 

--- a/server/facets/api/article.ts
+++ b/server/facets/api/article.ts
@@ -38,13 +38,13 @@ export function get (request: Hapi.Request,  reply: any): void {
 		},
 		article: Article.ArticleRequestHelper;
 
-		if (request.state.wikicities_session) {
-			params.headers = {
-				'Cookie': `wikicities_session=${request.state.wikicities_session}`
-			};
-		}
+	if (request.state.wikicities_session) {
+		params.headers = {
+			'Cookie': `wikicities_session=${request.state.wikicities_session}`
+		};
+	}
 
-		article = new Article.ArticleRequestHelper(params);
+	article = new Article.ArticleRequestHelper(params);
 
 	if (isRequestForRandomTitle(request.query)) {
 		article.getArticleRandomTitle((error: any, result: any): void => {

--- a/server/facets/api/article.ts
+++ b/server/facets/api/article.ts
@@ -31,11 +31,19 @@ function isRequestForRandomTitle (query: any): boolean {
  */
 export function get (request: Hapi.Request,  reply: any): void {
 	var wikiDomain = Utils.getCachedWikiDomainName(localSettings, request.headers.host),
-		params = {
+		params: ArticleRequestParams = {
 			wikiDomain: wikiDomain,
 			title: request.params.articleTitle,
 			redirect: request.params.redirect
 		},
+		article: Article.ArticleRequestHelper;
+
+		if (request.state['wikicities_session']) {
+			params.headers = {
+				'wikicities_session': request.state['wikicities_session']
+			};
+		}
+
 		article = new Article.ArticleRequestHelper(params);
 
 	if (isRequestForRandomTitle(request.query)) {

--- a/server/facets/api/articleComments.ts
+++ b/server/facets/api/articleComments.ts
@@ -87,7 +87,7 @@ export function get (request: Hapi.Request, reply: any): void {
 		// TODO: ad hoc error handling, use Boom everywhere?
 		reply(Boom.badRequest('Invalid articleId'));
 	} else {
-		new MW.ArticleRequest(params.wikiDomain).comments(
+		new MW.ArticleRequest(params).comments(
 			params.articleId,
 			params.page
 		)

--- a/server/facets/api/category.ts
+++ b/server/facets/api/category.ts
@@ -27,7 +27,7 @@ export function get (request: Hapi.Request, reply: any): void {
 	if (params.categoryName === null) {
 		reply(Boom.badRequest('Category not provided'));
 	} else {
-		new MW.ArticleRequest(params.wikiDomain)
+		new MW.ArticleRequest(params)
 			.category(params.categoryName, params.thumbSize)
 			.then((response: any): void => {
 				reply(response);

--- a/server/facets/api/curatedContent.ts
+++ b/server/facets/api/curatedContent.ts
@@ -36,7 +36,7 @@ export function get (request: Hapi.Request, reply: any): void {
 		// TODO: ad hoc error handling, use Boom everywhere?
 		reply(Boom.badRequest('Section not provided'));
 	} else {
-		new MW.ArticleRequest(params.wikiDomain).curatedContentSection(params.sectionName)
+		new MW.ArticleRequest(params).curatedContentSection(params.sectionName)
 		.then((response: any): void => {
 			reply(response);
 			Caching.setResponseCaching(response, cachingTimes);

--- a/server/facets/editorPreview.ts
+++ b/server/facets/editorPreview.ts
@@ -12,9 +12,10 @@ import prepareArticleData = require('./operations/prepareArticleData');
 function editorPreview (request: Hapi.Request, reply: Hapi.Response): void {
 	var wikiDomain: string = Utils.getCachedWikiDomainName(localSettings, request.headers.host),
 		parserOutput: string = request.payload.parserOutput,
-		mwHash: string = request.payload.mwHash;
+		mwHash: string = request.payload.mwHash,
+		article = new Article.ArticleRequestHelper({wikiDomain: wikiDomain});
 
-	Article.getWikiVariables(wikiDomain, (error: any, wikiVariables: any) => {
+	article.getWikiVariables((error: any, wikiVariables: any) => {
 		var article: any = {},
 			result: any = {};
 

--- a/server/facets/showArticle.ts
+++ b/server/facets/showArticle.ts
@@ -24,9 +24,9 @@ function showArticle (request: Hapi.Request, reply: Hapi.Response): void {
 		},
 		article: Article.ArticleRequestHelper;
 
-	if (request.state['wikicities_session']) {
+	if (request.state.wikicities_session) {
 		params.headers = {
-			'wikicities_session': request.state['wikicities_session']
+			'Cookie': `wikicities_session=${request.state.wikicities_session}`
 		};
 	}
 

--- a/server/facets/showArticle.ts
+++ b/server/facets/showArticle.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../typings/hapi/hapi.d.ts" />
+/// <reference path="../lib/Article.ts" />
 
 import Article = require('../lib/Article');
 import Utils = require('../lib/Utils');
@@ -17,12 +18,19 @@ var cachingTimes = {
 function showArticle (request: Hapi.Request, reply: Hapi.Response): void {
 	var path: string = request.path,
 		wikiDomain: string = Utils.getCachedWikiDomainName(localSettings, request.headers.host),
-		params = {
+		params: ArticleRequestParams = {
 			wikiDomain: wikiDomain,
 			redirect: request.query.redirect
 		},
-		article = new Article.ArticleRequestHelper(params);
+		article: Article.ArticleRequestHelper;
 
+	if (request.state['wikicities_session']) {
+		params.headers = {
+			'wikicities_session': request.state['wikicities_session']
+		};
+	}
+
+	article = new Article.ArticleRequestHelper(params);
 
 	if (path === '/' || path === '/wiki/') {
 		article.getWikiVariables((error: any, wikiVariables: any) => {
@@ -37,6 +45,7 @@ function showArticle (request: Hapi.Request, reply: Hapi.Response): void {
 			}
 		});
 	} else  {
+		article.setTitle(request.params.title);
 		article.getFull((error: any, result: any = {}) => {
 			onArticleResponse(request, reply, error, result);
 		});

--- a/server/facets/showArticle.ts
+++ b/server/facets/showArticle.ts
@@ -16,29 +16,28 @@ var cachingTimes = {
 
 function showArticle (request: Hapi.Request, reply: Hapi.Response): void {
 	var path: string = request.path,
-		wikiDomain: string = Utils.getCachedWikiDomainName(localSettings, request.headers.host);
+		wikiDomain: string = Utils.getCachedWikiDomainName(localSettings, request.headers.host),
+		params = {
+			wikiDomain: wikiDomain,
+			redirect: request.query.redirect
+		},
+		article = new Article.ArticleRequestHelper(params);
+
 
 	if (path === '/' || path === '/wiki/') {
-		Article.getWikiVariables(wikiDomain, (error: any, wikiVariables: any) => {
+		article.getWikiVariables((error: any, wikiVariables: any) => {
 			if (error) {
 				// TODO check error.statusCode and react accordingly
 				reply.redirect(localSettings.redirectUrlOnNoData);
 			} else {
-				Article.getArticle({
-					wikiDomain: wikiDomain,
-					title: wikiVariables.mainPageTitle,
-					redirect: request.query.redirect
-				}, wikiVariables, (error: any, result: any = {}) => {
+				article.setTitle(wikiVariables.mainPageTitle);
+				article.getArticle(wikiVariables, (error: any, result: any = {}) => {
 					onArticleResponse(request, reply, error, result);
 				});
 			}
 		});
 	} else  {
-		Article.getFull({
-			wikiDomain: wikiDomain,
-			title: request.params.title,
-			redirect: request.query.redirect
-		}, (error: any, result: any = {}) => {
+		article.getFull((error: any, result: any = {}) => {
 			onArticleResponse(request, reply, error, result);
 		});
 	}

--- a/server/lib/Article.ts
+++ b/server/lib/Article.ts
@@ -1,6 +1,7 @@
 /// <reference path="../../typings/hapi/hapi.d.ts" />
 /// <reference path="../../typings/bluebird/bluebird.d.ts" />
 /// <reference path="../../typings/mercury/mercury-server.d.ts" />
+/// <reference path="../lib/Utils.ts" />
 
 /**
  * @description Article controller
@@ -18,149 +19,155 @@ interface ServerData {
 	environment: string;
 }
 
-/**
- * Create server data
- *
- * @returns ServerData
- */
-function createServerData (wikiDomain: string = ''): ServerData {
-	return {
-		mediawikiDomain: Utils.getWikiDomainName(localSettings, wikiDomain),
-		apiBase: localSettings.apiBase,
-		environment: Utils.getEnvironmentString(localSettings.environment),
-		cdnBaseUrl: localSettings.environment === Utils.Environment.Prod ? localSettings.cdnBaseUrl : ''
-	};
-}
+export class ArticleRequestHelper {
+	params: ArticleRequestParams;
 
-/**
- * Handler for /article/{wiki}/{articleId} -- Currently calls to Wikia public JSON api for article:
- * http://www.wikia.com/api/v1/#!/Articles
- * This API is really not sufficient for semantic routes, so we'll need some what of retrieving articles by using the
- * article slug name
- *
- * @param {ArticleRequestParams} params
- * @param {Function} callback
- * @param {boolean} getWikiVariables whether or not to make a WikiRequest to get information about the wiki
- */
-export function getData (params: ArticleRequestParams, callback: Function, getWikiVariables: boolean = false): void {
-	var requests = [
-			new MediaWiki.ArticleRequest(params.wikiDomain).article(params.title, params.redirect)
-		];
+	constructor(params: ArticleRequestParams) {
+		this.params = params;
+	}
 
-	logger.debug(params, 'Fetching article');
-
-	if (getWikiVariables) {
-		logger.debug({wiki: params.wikiDomain}, 'Fetching wiki variables');
-
-		requests.push(new MediaWiki.WikiRequest({
-			wikiDomain: params.wikiDomain
-		}).getWikiVariables());
+	setTitle(title: string): void {
+		this.params.title = title;
 	}
 
 	/**
-	 * @see https://github.com/petkaantonov/bluebird/blob/master/API.md#settle---promise
+	 * Create server data
 	 *
-	 * From Promise.settle documentation:
-	 * Given an array, or a promise of an array, which contains promises (or a mix of promises and values)
-	 * return a promise that is fulfilled when all the items in the array are either fulfilled or rejected.
-	 * The fulfillment value is an array of PromiseInspection instances at respective positions in relation
-	 * to the input array. This method is useful for when you have an array of promises and you'd like to know
-	 * when all of them resolve - either by fulfilling of rejecting.
+	 * @returns ServerData
 	 */
-	Promise.settle(requests)
-		.then((results: Promise.Inspection<Promise<any>>[]) => {
-			var articlePromise: Promise.Inspection<Promise<any>> = results[0],
-				wikiPromise: Promise.Inspection<Promise<any>> = results[1],
-				article: any,
-				wikiVariables: any = {};
+	private createServerData(wikiDomain: string = ''): ServerData {
+		return {
+			mediawikiDomain: Utils.getWikiDomainName(localSettings, wikiDomain),
+			apiBase: localSettings.apiBase,
+			environment: Utils.getEnvironmentString(localSettings.environment),
+			cdnBaseUrl: localSettings.environment === Utils.Environment.Prod ? localSettings.cdnBaseUrl : ''
+		};
+	}
 
-			// if promise is fulfilled - use resolved value, if it's not - use rejection reason
-			article = articlePromise.isFulfilled() ?
-				articlePromise.value() :
-				articlePromise.reason();
+	/**
+	 * Handler for /article/{wiki}/{articleId} -- Currently calls to Wikia public JSON api for article:
+	 * http://www.wikia.com/api/v1/#!/Articles
+	 * This API is really not sufficient for semantic routes, so we'll need some what of retrieving articles by using the
+	 * article slug name
+	 *
+	 * @param {Function} callback
+	 * @param {boolean} getWikiVariables whether or not to make a WikiRequest to get information about the wiki
+	 */
+	getData(callback: Function, getWikiVariables: boolean = false): void {
+		var requests = [
+				new MediaWiki.ArticleRequest(this.params).article(this.params.title, this.params.redirect)
+			];
 
-			if (getWikiVariables) {
-				wikiVariables = wikiPromise.isFulfilled() ?
-					wikiPromise.value() :
-					wikiPromise.reason();
-			}
+		logger.debug(this.params, 'Fetching article');
 
-			callback(article.exception, article.data, wikiVariables.data);
-		});
-}
+		if (getWikiVariables) {
+			logger.debug({wiki: this.params.wikiDomain}, 'Fetching wiki variables');
 
-/**
- * Handle full page data generation
- * @param {ArticleRequestParams} params
- * @param {Function} next
- */
-export function getFull (params: ArticleRequestParams, next: Function): void {
-	getData(params, (error: any, article: any, wikiVariables: any) => {
-		next(error, {
-			server: createServerData(params.wikiDomain),
-			wiki: wikiVariables || {},
-			article: article || {}
-		});
-	}, true);
-}
+			requests.push(new MediaWiki.WikiRequest({
+				wikiDomain: this.params.wikiDomain
+			}).getWikiVariables());
+		}
 
-/**
- * Get WikiVariables
- * @param {string} wikiDomain
- * @param {Function} next
- */
-export function getWikiVariables (wikiDomain: string, next: Function): void {
-	var wikiRequest = new MediaWiki.WikiRequest({
-		wikiDomain: wikiDomain
-	});
+		/**
+		 * @see https://github.com/petkaantonov/bluebird/blob/master/API.md#settle---promise
+		 *
+		 * From Promise.settle documentation:
+		 * Given an array, or a promise of an array, which contains promises (or a mix of promises and values)
+		 * return a promise that is fulfilled when all the items in the array are either fulfilled or rejected.
+		 * The fulfillment value is an array of PromiseInspection instances at respective positions in relation
+		 * to the input array. This method is useful for when you have an array of promises and you'd like to know
+		 * when all of them resolve - either by fulfilling of rejecting.
+		 */
+		Promise.settle(requests)
+			.then((results: Promise.Inspection<Promise<any>>[]) => {
+				var articlePromise: Promise.Inspection<Promise<any>> = results[0],
+					wikiPromise: Promise.Inspection<Promise<any>> = results[1],
+					article: any,
+					wikiVariables: any = {};
 
-	logger.debug({wiki: wikiDomain}, 'Fetching wiki variables');
+				// if promise is fulfilled - use resolved value, if it's not - use rejection reason
+				article = articlePromise.isFulfilled() ?
+					articlePromise.value() :
+					articlePromise.reason();
 
-	wikiRequest
-		.getWikiVariables()
-		.then((wikiVariables: any) => {
-			next(null, wikiVariables.data);
-		}, (error: any) => {
-			next(error, null);
-		});
-}
+				if (getWikiVariables) {
+					wikiVariables = wikiPromise.isFulfilled() ?
+						wikiPromise.value() :
+						wikiPromise.reason();
+				}
 
-/**
- * Handle article page data generation, no need for WikiVariables
- * @param {ArticleRequestParams} params
- * @param {*} wikiVariables
- * @param {Function} next
- */
-export function getArticle (params: ArticleRequestParams, wikiVariables: any, next: Function): void {
-	getData(params, (error: any, article: any) => {
-		next(error, {
-			server: createServerData(params.wikiDomain),
-			wiki: wikiVariables || {},
-			article: article || {}
-		});
-	}, false);
-}
+				callback(article.exception, article.data, wikiVariables.data);
+			});
+	}
 
-export function getArticleRandomTitle (wikiDomain: string, next: Function): void {
-	var articleRequest = new MediaWiki.ArticleRequest(wikiDomain);
+	/**
+	 * Handle full page data generation
+	 * @param {Function} next
+	 */
+	getFull(next: Function): void {
+		this.getData((error: any, article: any, wikiVariables: any) => {
+			next(error, {
+				server: this.createServerData(this.params.wikiDomain),
+				wiki: wikiVariables || {},
+				article: article || {}
+			});
+		}, true);
+	}
 
-	articleRequest
-		.randomTitle()
-		.then((result: any): void => {
-			var articleId: string,
-				pageData: { pageid: number; ns: number; title: string };
+	/**
+	 * Get WikiVariables
+	 * @param {Function} next
+	 */
+	getWikiVariables(next: Function): void {
+		var wikiRequest = new MediaWiki.WikiRequest(this.params);
 
-			if (result.query && result.query.pages) {
-				articleId = Object.keys(result.query.pages)[0];
-				pageData = result.query.pages[articleId];
+		logger.debug(this.params, 'Fetching wiki variables');
 
-				next(null, {
-					title: pageData.title
-				});
-			} else {
-				next(result.error, null);
-			}
-		}, (error: any): void => {
-			next(error, null);
-		});
+		wikiRequest
+			.getWikiVariables()
+			.then((wikiVariables: any) => {
+				next(null, wikiVariables.data);
+			}, (error: any) => {
+				next(error, null);
+			});
+	}
+
+	/**
+	 * Handle article page data generation, no need for WikiVariables
+	 * @param {*} wikiVariables
+	 * @param {Function} next
+	 */
+	getArticle(wikiVariables: any, next: Function): void {
+		this.getData((error: any, article: any) => {
+			next(error, {
+				server: this.createServerData(this.params.wikiDomain),
+				wiki: wikiVariables || {},
+				article: article || {}
+			});
+		}, false);
+	}
+
+	getArticleRandomTitle(next: Function): void {
+		var articleRequest = new MediaWiki.ArticleRequest(this.params);
+
+		articleRequest
+			.randomTitle()
+			.then((result: any): void => {
+				var articleId: string,
+					pageData: { pageid: number; ns: number; title: string };
+
+				if (result.query && result.query.pages) {
+					articleId = Object.keys(result.query.pages)[0];
+					pageData = result.query.pages[articleId];
+
+					next(null, {
+						title: pageData.title
+					});
+				} else {
+					next(result.error, null);
+				}
+			}, (error: any): void => {
+				next(error, null);
+			});
+	}
 }

--- a/server/lib/Article.ts
+++ b/server/lib/Article.ts
@@ -3,6 +3,13 @@
 /// <reference path="../../typings/mercury/mercury-server.d.ts" />
 /// <reference path="../lib/Utils.ts" />
 
+export interface ArticleRequestParams {
+	wikiDomain: string;
+	title?: string;
+	redirect?: any;
+	headers?: any;
+}
+
 /**
  * @description Article controller
  */

--- a/server/lib/Article.ts
+++ b/server/lib/Article.ts
@@ -3,13 +3,6 @@
 /// <reference path="../../typings/mercury/mercury-server.d.ts" />
 /// <reference path="../lib/Utils.ts" />
 
-export interface ArticleRequestParams {
-	wikiDomain: string;
-	title?: string;
-	redirect?: any;
-	headers?: any;
-}
-
 /**
  * @description Article controller
  */

--- a/server/lib/MediaWiki.ts
+++ b/server/lib/MediaWiki.ts
@@ -14,11 +14,13 @@ import Promise = require('bluebird');
 interface MWRequestParams {
 	wikiDomain: string;
 	headers?: any;
+	redirects?: number;
 }
 
 class BaseRequest {
 	wikiDomain: string;
 	headers: any;
+	redirects: any;
 
 	/**
 	 * Search request constructor
@@ -31,7 +33,7 @@ class BaseRequest {
 	}
 
 	fetch(url: string): any {
-		return fetch(url, this.wikiDomain, this.headers);
+		return fetch(url, this.wikiDomain, this.redirects, this.headers);
 	}
 }
 
@@ -120,7 +122,7 @@ export class ArticleRequest extends BaseRequest {
 			section: sectionName
 		});
 
-		return fetch(url, this.wikiDomain);
+		return this.fetch(url);
 	}
 
 	category (categoryName: string, thumbSize: { width: number; height: number }): Promise<any> {
@@ -152,7 +154,7 @@ export class ArticleRequest extends BaseRequest {
 			format: 'json'
 		});
 
-		return fetch(url, this.wikiDomain);
+		return this.fetch(url);
 	}
 }
 
@@ -163,12 +165,13 @@ export class ArticleRequest extends BaseRequest {
  * @param redirects the number of redirects to follow, default 1
  * @return {Promise<any>}
  */
-export function fetch (url: string, host: string = '', redirects: number = 1, headers = {}): Promise<any> {
-	var forwardedHeaders = require('deep-extend')(headers, {'Host': host});
+export function fetch (url: string, host: string = '', redirects: number = 1, headers: any = {}): Promise<any> {
+	headers.Host = host;
+
 	return new Promise((resolve: Function, reject: Function): void => {
 		Wreck.get(url, {
 			redirects: redirects,
-			headers: forwardedHeaders,
+			headers: headers,
 			timeout: localSettings.backendRequestTimeout,
 			json: true
 		}, (err: any, response: any, payload: any): void => {

--- a/server/lib/Utils.ts
+++ b/server/lib/Utils.ts
@@ -1,4 +1,5 @@
 /// <reference path="../../config/localSettings.d.ts" />
+/// <reference path="../../typings/hoek/hoek.d.ts" />
 
 import Hoek = require('hoek');
 

--- a/typings/mercury/mercury-server.d.ts
+++ b/typings/mercury/mercury-server.d.ts
@@ -1,10 +1,3 @@
-interface ArticleRequestParams {
-	wikiDomain: string;
-	title?: string;
-	redirect?: any;
-	headers?: any;
-}
-
 interface SearchRequestParams {
 	wikiDomain: string;
 	query: string;

--- a/typings/mercury/mercury-server.d.ts
+++ b/typings/mercury/mercury-server.d.ts
@@ -8,3 +8,10 @@ interface ArticleCommentsRequestParams {
 	articleId: number;
 	page: number;
 }
+
+interface ArticleRequestParams {
+	wikiDomain: string;
+	title?: string;
+	redirect?: any;
+	headers?: any;
+}

--- a/typings/mercury/mercury-server.d.ts
+++ b/typings/mercury/mercury-server.d.ts
@@ -1,7 +1,8 @@
 interface ArticleRequestParams {
 	wikiDomain: string;
-	title: string;
+	title?: string;
 	redirect?: any;
+	headers?: any;
 }
 
 interface SearchRequestParams {


### PR DESCRIPTION
This PR is part of a fix for HG-736. At a high level, there is a race between our purges in Celery, the MW edit API and refreshing/viewing an article in Mercury. In order to prevent a user who has just edited from getting stale content (and also for logged in users), we're going to use the same mechanism MW does and simply ignore cache for requests in which the `wikicities_session` cookie is present.

Previously, calls to the internal Varnish were not setting any cookies. This sets the user session cookie if it is available. 