### PR TITLE
HG-686 disabled caching for random page querys

### DIFF
--- a/server/facets/api/article.ts
+++ b/server/facets/api/article.ts
@@ -35,7 +35,7 @@ export function get (request: Hapi.Request,  reply: any): void {
 	if (isRequestForRandomTitle(request.query)) {
 		Article.getArticleRandomTitle(wikiDomain, (error: any, result: any): void => {
 			var wrappedResult = wrapResult(error, result);
-			Caching.setResponseCaching(reply(wrappedResult), randomTitleCachingTimes);
+			Caching.disableCache(reply(wrappedResult));
 		});
 		return;
 	}

--- a/server/lib/Caching.ts
+++ b/server/lib/Caching.ts
@@ -79,6 +79,10 @@ module Caching {
 		return Policy[policy].toLowerCase();
 	}
 
+	/**
+	 * Disables use of cache in the response
+	 * @param response
+	 */
 	export function disableCache (response: Hapi.Response): void {
 		response.header('Cache-Control', 'private, s-maxage=0, max-age=0, must-revalidate');
 	}


### PR DESCRIPTION
This fixes this issue where the random page request returned the same page repeatedly. Varnish caches by URL, and the random page request url is the same for every call, so it was just returning one response for all requests. By disabling caching for random page responses, it now returns random pages.