### PR TITLE
HG-727 adding loading graphic for A/B test

### DIFF
--- a/front/scripts/main/views/ApplicationView.ts
+++ b/front/scripts/main/views/ApplicationView.ts
@@ -39,6 +39,9 @@ App.ApplicationView = Em.View.extend({
 
 	willInsertElement: function (): void {
 		$('#article-preload').remove();
+
+		// A/B test spinner (HG-727)
+		$('.ab-test-loading-overlay').hide();
 	},
 
 	handleLink: function (target: HTMLAnchorElement): void {

--- a/front/scripts/main/views/ArticleView.ts
+++ b/front/scripts/main/views/ArticleView.ts
@@ -87,9 +87,6 @@ App.ArticleView = Em.View.extend(App.AdsMixin, App.ViewportMixin, App.LanguagesM
 			M.trackPageView(model.get('adsContext.targeting'));
 		}
 
-		// A/B test spinner (HG-727)
-		$('.ab-test-loading-overlay').hide();
-
 		return true;
 	},
 

--- a/front/scripts/main/views/ArticleView.ts
+++ b/front/scripts/main/views/ArticleView.ts
@@ -87,6 +87,9 @@ App.ArticleView = Em.View.extend(App.AdsMixin, App.ViewportMixin, App.LanguagesM
 			M.trackPageView(model.get('adsContext.targeting'));
 		}
 
+		// A/B test spinner (HG-727)
+		$('.ab-test-loading-overlay').hide();
+
 		return true;
 	},
 

--- a/front/styles/main/module/_loader.scss
+++ b/front/styles/main/module/_loader.scss
@@ -34,6 +34,11 @@ $duration: 1s;
 	z-index: $z-6;
 }
 
+// A/B test (HG-727)
+.ab-test-loading-overlay {
+	display: none;
+}
+
 .spinner {
 	animation: rotator $duration linear infinite;
 	left: 50%;

--- a/server/views/_layouts/ember-main.hbs
+++ b/server/views/_layouts/ember-main.hbs
@@ -63,6 +63,13 @@
 		{{> qualaroo}}
 		<!-- @include ../../../www/front/svg/main.svg -->
 
+		<!-- A/B test (HG-727) -->
+		<div class="loading-overlay ab-test-loading-overlay">
+			<svg class='spinner' width='65' height='65' viewBox='0 0 66 66' xmlns='http://www.w3.org/2000/svg'>
+				<circle class='path' fill='none' stroke-width='6' stroke-linecap='round' cx='33' cy='33' r='30'></circle>
+			</svg>
+		</div>
+
 		<div id="article-preload">
 			{{{content}}}
 		</div>


### PR DESCRIPTION
This is the basis for an A/B test to see if engagement increases when we provide visual feedback to users via a loading graphic, instead of showing a blank page, while ember is bootstrapping. 

The JS to include via optimizely for users in the test is: 
```javascript
// with jQuery
$('.ab-test-loading-overlay').show();

// without jQuery
document.querySelector('.ab-test-loading-overlay').style.display='block';
```

@kenkouot @katanka 