### PR TITLE
Generate TS sourcemaps to allow direct TS debugging in Chrome devtools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@ test/fixtures
 .idea
 /docs
 *.sublime-*
+
+front/scripts/**/*.js
+front/scripts/**/*.js.map

--- a/gulp/tasks/build-views.js
+++ b/gulp/tasks/build-views.js
@@ -24,7 +24,7 @@ if (sync) {
 	preprocessContext.browserSync = true;
 }
 
-gulp.task('build-views', ['scripts-front', 'vendor'], function () {
+gulp.task('build-views', ['scripts-front', 'copy-ts-source', 'vendor'], function () {
 	return piper(
 		gulp.src(paths.views.src, {
 			base: paths.baseFullServer

--- a/gulp/tasks/copy-ts-source.js
+++ b/gulp/tasks/copy-ts-source.js
@@ -1,0 +1,14 @@
+var gulp = require('gulp'),
+	environment = require('../utils/environment'),
+	paths = require('../paths').scripts.front,
+	path = require('path');
+
+gulp.task('copy-ts-source', [ 'scripts-front' ], function() {
+	var src  = path.join(paths.src, '/**/*');
+	var dest = path.join(paths.dest, process.cwd());
+
+	if (!environment.isProduction) {
+		gulp.src([src])
+			.pipe(gulp.dest(dest));
+	}
+});

--- a/gulp/tasks/scripts-front.js
+++ b/gulp/tasks/scripts-front.js
@@ -3,6 +3,7 @@ var gulp = require('gulp'),
 	gulpif = require('gulp-if'),
 	folders = require('gulp-folders'),
 	ts = require('gulp-typescript'),
+	sourcemaps = require('gulp-sourcemaps'),
 	concat = require('gulp-concat'),
 	gutil = require('gulp-util'),
 	newer = require('gulp-newer'),
@@ -22,6 +23,7 @@ gulp.task('scripts-front', folders(paths.src, function (folder) {
 			'!' + path.join(paths.src, folder, paths.dFiles),
 			path.join(paths.src, folder, paths.files)
 		])
+		.pipe(gulpif(!environment.isProduction, sourcemaps.init()))
 		.pipe(newer(path.join(paths.dest, folder + '.js')))
 		.pipe(ts(tsProjects[folder])).js
 		.on('error', function () {
@@ -32,5 +34,10 @@ gulp.task('scripts-front', folders(paths.src, function (folder) {
 		})
 		.pipe(concat(folder + '.js'))
 		.pipe(gulpif(environment.isProduction, uglify()))
+		.pipe(gulpif(!environment.isProduction, sourcemaps.write('.' , {
+			includeContent: true,
+			sourceRoot: '/front/scripts/',
+			sourceMappingURLPrefix: '/front/scripts/'
+		})))
 		.pipe(gulp.dest(paths.dest));
 }));

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -31,7 +31,7 @@ gulp.task('watch', ['build', 'build-views'], function () {
 	gulp.watch(path.join(
 		paths.scripts.front.src,
 		paths.scripts.front.files
-	), ['tslint', 'scripts-front']).on('change', function (event) {
+	), ['tslint', 'scripts-front', 'copy-ts-source']).on('change', function (event) {
 		if (event.path.match('baseline')) {
 			gulp.start('build-views');
 		}

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "gulp-tslint": "1.x.x",
     "gulp-typedoc": "^1.1.0",
     "gulp-typescript": "~2.6.0",
+    "gulp-sourcemaps": "~1.5.2",
     "gulp-uglify": "1.x.x",
     "gulp-useref": "1.x.x",
     "gulp-util": "3.x.x",


### PR DESCRIPTION
These changes add generation of TypeScript sourcemaps and copying of neccesary support files to allow direct debugging of TypeScript from inside Chrome devtools. Generated for dev config only.