### PR TITLE
CONCF-669 Add temporary check to not break descriptions on production

### DIFF
--- a/front/scripts/main/models/ArticleModel.ts
+++ b/front/scripts/main/models/ArticleModel.ts
@@ -154,6 +154,9 @@ App.ArticleModel.reopenClass({
 				error: error
 			};
 		} else if (source) {
+			// TODO temporary, remove in CONCF-670
+			var descriptionCopied = false;
+
 			if (source.details) {
 				var details = source.details;
 
@@ -162,9 +165,14 @@ App.ArticleModel.reopenClass({
 					cleanTitle: details.title,
 					comments: details.comments,
 					id: details.id,
-					user: details.revision.user_id,
-					description: details.description
+					user: details.revision.user_id
 				});
+
+				// TODO temporary, extend with the rest above in CONCF-670
+				if (details.description) {
+					data.description = details.description;
+					descriptionCopied = true;
+				}
 			}
 
 			if (source.article) {
@@ -179,6 +187,11 @@ App.ArticleModel.reopenClass({
 					}),
 					categories: article.categories
 				});
+
+				// TODO temporary, remove in CONCF-670
+				if (!descriptionCopied && article.description) {
+					data.description = article.description;
+				}
 			}
 
 			if (source.relatedPages) {

--- a/front/scripts/main/routes/ArticleRoute.ts
+++ b/front/scripts/main/routes/ArticleRoute.ts
@@ -36,7 +36,6 @@ App.ArticleRoute = Em.Route.extend({
 	model: function (params: any) {
 		return App.ArticleModel.find({
 			basePath: Mercury.wiki.basePath,
-			description: params.description,
 			title: params.title,
 			wiki: this.controllerFor('application').get('domain')
 		});

--- a/server/views/_layouts/ember-main.hbs
+++ b/server/views/_layouts/ember-main.hbs
@@ -5,7 +5,7 @@
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<title>{{#if displayTitle}}{{displayTitle}} - {{/if}}{{wiki.siteName}}</title>
 		<meta name="keywords" content="{{#if wiki.siteMessage}}{{wiki.siteMessage}},{{/if}}{{wiki.siteName}},{{wiki.dbName}},{{displayTitle}}">
-		<!-- TODO: Use article.details.description after CONCF-509 is pushed to app@prod and caches are fresh -->
+		<!-- TODO: Use article.details.description after CONCF-509 is pushed to app@prod and caches are fresh, see CONCF-670 -->
 		<meta name="description" content="{{#if article.details.description}}{{article.details.description}}{{else}}{{article.article.description}}{{/if}}">
 		<meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1, minimal-ui">
 		{{#if themeColor}}

--- a/server/views/_layouts/ember-main.hbs
+++ b/server/views/_layouts/ember-main.hbs
@@ -5,7 +5,8 @@
 		<meta http-equiv="X-UA-Compatible" content="IE=edge">
 		<title>{{#if displayTitle}}{{displayTitle}} - {{/if}}{{wiki.siteName}}</title>
 		<meta name="keywords" content="{{#if wiki.siteMessage}}{{wiki.siteMessage}},{{/if}}{{wiki.siteName}},{{wiki.dbName}},{{displayTitle}}">
-		<meta name="description" content="{{article.details.description}}">
+		<!-- TODO: Use article.details.description after CONCF-509 is pushed to app@prod and caches are fresh -->
+		<meta name="description" content="{{#if article.details.description}}{{article.details.description}}{{else}}{{article.article.description}}{{/if}}">
 		<meta name="viewport" content="user-scalable=no, width=device-width, initial-scale=1, maximum-scale=1, minimal-ui">
 		{{#if themeColor}}
 		<meta name="theme-color" content="{{themeColor}}">


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/CONCF-669

https://github.com/Wikia/mercury/pull/916 would break page descriptions on Mercury until https://github.com/Wikia/app/pull/7512 is pushed to production. This is a temporary solution to avoid errors.

/cc @bognix @tomasznapieralski 