### PR TITLE
Coding standard fixes for TS sourcemaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ front/vendor/
 # Static Assets
 .tmp/
 www/
-/* Should only commit json files, not compiled js fixtures */
+# Should only commit json files, not compiled js fixtures
 test/fixtures/**/*.js
 
 # Config

--- a/.gitignore
+++ b/.gitignore
@@ -37,5 +37,6 @@ test/fixtures
 /docs
 *.sublime-*
 
+/* Intermediate files from TypeScript compiler */
 front/scripts/**/*.js
 front/scripts/**/*.js.map

--- a/.gitignore
+++ b/.gitignore
@@ -1,42 +1,42 @@
-/* Misc Files */
+# Misc Files
 .DS_Store
 .sass-cache
 
-/* Editor Files */
+# Editor Files
 *.sw[a-z]
 *.orig
 
-/* Packages */
+# Packages
 node_modules/
 front/vendor/
 
-/* Node/NPM */
+# Node/NPM
 *.log
 
-/* Static Assets */
+# Static Assets
 .tmp/
 www/
 /* Should only commit json files, not compiled js fixtures */
 test/fixtures/**/*.js
 
-/* Config */
+# Config
 config/localSettings.ts
 config/localSettings.js
 config/localSettings.example.js
 
-/* coverage */
+# coverage
 test/coverage
 
-/* fixtures */
+# fixtures
 test/fixtures
 
-/* Jenkins Cache */
+# Jenkins Cache
 .*.md5
 
 .idea
 /docs
 *.sublime-*
 
-/* Intermediate files from TypeScript compiler */
+# Intermediate files from TypeScript compiler
 front/scripts/**/*.js
 front/scripts/**/*.js.map

--- a/gulp/tasks/copy-ts-source.js
+++ b/gulp/tasks/copy-ts-source.js
@@ -4,8 +4,8 @@ var gulp = require('gulp'),
 	path = require('path');
 
 gulp.task('copy-ts-source', [ 'scripts-front' ], function() {
-	var src  = path.join(paths.src, '/**/*');
-	var dest = path.join(paths.dest, process.cwd());
+	var src  = path.join(paths.src, '/**/*'),
+	    dest = path.join(paths.dest, process.cwd());
 
 	if (!environment.isProduction) {
 		gulp.src([src])

--- a/gulp/tasks/copy-ts-source.js
+++ b/gulp/tasks/copy-ts-source.js
@@ -5,7 +5,7 @@ var gulp = require('gulp'),
 
 gulp.task('copy-ts-source', [ 'scripts-front' ], function() {
 	var src  = path.join(paths.src, '/**/*'),
-	    dest = path.join(paths.dest, process.cwd());
+		dest = path.join(paths.dest, process.cwd());
 
 	if (!environment.isProduction) {
 		gulp.src([src])


### PR DESCRIPTION
Added comment in .gitignore.
Fixed coding standard issue in copy-ts-source.js
