### PR TITLE
HG-761 adding first content perf tracking and sending weppy in dev env

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -14,7 +14,7 @@
     "headroom.js": "0.7.0",
     "fastclick": "1.0.6",
     "jquery.cookie": "1.4.1",
-    "weppy": "Wikia/weppy",
+    "weppy": "Wikia/weppy#0.9.1",
     "ember-performance-sender": "1.1.0",
     "vignette": "wikia/vignette-js#2.1.1",
     "wikia-style-guide": "Wikia/style-guide#1.0.1",

--- a/front/scripts/main/views/ApplicationView.ts
+++ b/front/scripts/main/views/ApplicationView.ts
@@ -44,6 +44,20 @@ App.ApplicationView = Em.View.extend({
 		$('.ab-test-loading-overlay').remove();
 	},
 
+	didInsertElement: function (): void {
+		this.trackFirstContent();
+	},
+
+	trackFirstContent: function () {
+		var timing = Date.now() - performance.timing.fetchStart;
+
+		M.trackPerf({
+			name: 'firstContent',
+			type: 'timer',
+			value: timing
+		});
+	},
+
 	/**
 	 * Necessary because presently, we open external links in new pages, so if we didn't
 	 * cancel the click event on the current page, then the mouseUp handler would open

--- a/front/scripts/main/views/ApplicationView.ts
+++ b/front/scripts/main/views/ApplicationView.ts
@@ -49,12 +49,9 @@ App.ApplicationView = Em.View.extend({
 	},
 
 	trackFirstContent: function () {
-		var timing = Date.now() - performance.timing.fetchStart;
-
 		M.trackPerf({
 			name: 'firstContent',
-			type: 'timer',
-			value: timing
+			type: 'mark'
 		});
 	},
 

--- a/front/scripts/mercury/modules/Trackers/Perf.ts
+++ b/front/scripts/mercury/modules/Trackers/Perf.ts
@@ -25,7 +25,7 @@ module Mercury.Modules.Trackers {
 			url?: string;
 			'user-agent': string;
 			env: string;
-		}
+		};
 
 		constructor () {
 			this.tracker = Weppy.namespace('mercury');

--- a/front/scripts/mercury/modules/Trackers/Perf.ts
+++ b/front/scripts/mercury/modules/Trackers/Perf.ts
@@ -8,7 +8,7 @@ interface PerfTrackerParams {
 	context?: any;
 	module?: string;
 	name: string;
-	value: number;
+	value?: number;
 	annotations?: any;
 }
 
@@ -70,8 +70,11 @@ module Mercury.Modules.Trackers {
 				case 'timer':
 					trackFn.timer.send(params.name, params.value, params.annotations);
 					break;
+				case 'mark':
+					trackFn.timer.mark(params.name, params.annotations);
+					break;
 				case undefined:
-					throw 'You failed to specify a tracker type.'
+					throw 'You failed to specify a tracker type.';
 					break;
 				default:
 					throw 'This action not supported in Weppy tracker';

--- a/server/views/_layouts/ember-main.hbs
+++ b/server/views/_layouts/ember-main.hbs
@@ -49,6 +49,7 @@
 			{{#if error}}
 			M.provide('article.error', {{{error}}});
 			{{/if}}
+			
 		</script>
 
 		<!-- @ifdef browserSync -->

--- a/server/views/_layouts/ember-main.hbs
+++ b/server/views/_layouts/ember-main.hbs
@@ -49,7 +49,6 @@
 			{{#if error}}
 			M.provide('article.error', {{{error}}});
 			{{/if}}
-			
 		</script>
 
 		<!-- @ifdef browserSync -->

--- a/server/views/_layouts/ember-main.hbs
+++ b/server/views/_layouts/ember-main.hbs
@@ -97,10 +97,8 @@
 			<script src="/front/vendor/i18next/i18next.js"></script>
 			<script src="/front/vendor/vignette/dist/vignette.js"></script>
 			<script src="/front/vendor/numeral/numeral.js"></script>
-			<!-- @if WIKIA_ENVIRONMENT='prod' -->
-				<script src="/front/vendor/weppy/dist/weppy.js"></script>
-				<script src="/front/vendor/ember-performance-sender/dist/ember-performance-sender.js"></script>
-			<!-- @endif -->
+			<script src="/front/vendor/weppy/dist/weppy.js"></script>
+			<script src="/front/vendor/ember-performance-sender/dist/ember-performance-sender.js"></script>
 		<!-- endbuild -->
 
 		<script src="//{{server.mediawikiDomain}}/__load/-/only=scripts/wikia.ext.instantGlobals,instantGlobalsOverride,abtesting" defer></script>


### PR DESCRIPTION
One of the HG team performance goals is to decrease the time it takes to show the user content. In order to measure this, I set up this performance tracking call. 

The data sent with the request will look like `"data":{"mercury::firstContent":[[10193]]}`

I also removed the conditional to only load weppy code in a production environment. The tracking calls include `env: "dev"`, which is consistent with how MW sends dev calls, so I'm assuming it will be fine to send calls from dev environment to ease development. @wladekb can you confirm?