### PR TITLE
HG-764: Add "cookie" to "vary" header

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -199,6 +199,7 @@ function getOnPreResponseHandler (isDevbox: boolean): any {
 		if (response && response.header) {
 			response.header('x-backend-response-time', responseTimeSec);
 			response.header('x-served-by', servedBy);
+			response.vary('cookie');
 		} else if (response.isBoom) {
 			// see https://github.com/hapijs/boom
 			response.output.headers['x-backend-response-time'] = responseTimeSec;


### PR DESCRIPTION
This is required by Fastly's varnishes, specifically it tells them that particular object should be cached separately (varied) based on cookie presence - however fastly has additonal logic to whitelist which cookies matter (for instance wikicities_session does matter, but some ad related cookie does not).

More info:
https://wikia-inc.atlassian.net/browse/HG-764
https://wikia-inc.atlassian.net/browse/OPS-6571
https://wikia-inc.atlassian.net/browse/HG-736