### PR TITLE
HG-768 adding query string param for bucky sampling

### DIFF
--- a/server/facets/operations/prepareArticleData.ts
+++ b/server/facets/operations/prepareArticleData.ts
@@ -40,8 +40,13 @@ function prepareArticleData (request: Hapi.Request, result: any): void {
 	result.canonicalUrl = result.wiki.basePath + result.wiki.articlePath + title.replace(/ /g, '_');
 	result.themeColor = Utils.getVerticalColor(localSettings, result.wiki.vertical);
 	// the second argument is a whitelist of acceptable parameter names
-	result.queryParams = Utils.parseQueryParams(request.query, ['noexternals']);
+	result.queryParams = Utils.parseQueryParams(request.query, ['noexternals', 'buckysampling']);
+
 	result.weppyConfig = localSettings.weppy;
+	if (typeof result.queryParams.buckySampling === 'number') {
+		result.weppyConfig.samplingRate = result.queryParams.buckySampling / 100;
+	}
+
 	result.userId = request.state.wikicitiesUserID ? request.state.wikicitiesUserID : 0;
 }
 


### PR DESCRIPTION
This is a convenience for QA and troubleshooting. 

I'm not entirely sure it's in the right place though, b/c that function is called `prepareArticleData`. I'm open to suggestions on where to put it. 