### PR TITLE
SOC-896 | Auth pages - Don't allow redirects to external domains

### DIFF
--- a/server/facets/auth/authView.ts
+++ b/server/facets/auth/authView.ts
@@ -1,6 +1,7 @@
 /// <reference path='../../../typings/hapi/hapi.d.ts' />
 
 import caching = require('../../lib/Caching');
+import url = require('url');
 
 module authView {
 	export interface AuthViewContext {
@@ -34,7 +35,29 @@ module authView {
 	}
 
 	export function getRedirectUrl (request: Hapi.Request): string {
-		return request.query.redirect || '/';
+		var redirectUrl: string = request.query.redirect || '/',
+			redirectUrlHost: string = url.parse(redirectUrl).host,
+			whiteListedDomains: Array<string> = ['wikia.com'],
+			isWhiteListedDomain: boolean;
+
+		if (!redirectUrlHost) {
+			return redirectUrl;
+		}
+
+		if (redirectUrlHost.indexOf(request.headers.host) !== -1) {
+			return redirectUrl;
+		}
+
+		isWhiteListedDomain = whiteListedDomains.some((whiteListedDomain: string): boolean => {
+			return redirectUrlHost.indexOf(whiteListedDomain) !== -1;
+		});
+
+		if (isWhiteListedDomain) {
+			return redirectUrl;
+		}
+
+		// Not valid domain
+		return '/';
 	}
 
 	export function getCanonicalUrl (request: Hapi.Request): string {

--- a/server/facets/auth/authView.ts
+++ b/server/facets/auth/authView.ts
@@ -35,7 +35,8 @@ module authView {
 	}
 
 	export function getRedirectUrl (request: Hapi.Request): string {
-		var redirectUrl: string = request.query.redirect || '/',
+		var currentHost: string = request.headers.host,
+			redirectUrl: string = request.query.redirect || '/',
 			redirectUrlHost: string = url.parse(redirectUrl).host,
 			whiteListedDomains: Array<string> = ['wikia.com'],
 			isWhiteListedDomain: boolean;
@@ -44,12 +45,12 @@ module authView {
 			return redirectUrl;
 		}
 
-		if (redirectUrlHost.indexOf(request.headers.host) !== -1) {
+		if (redirectUrlHost.indexOf(currentHost, redirectUrlHost.length - currentHost.length) !== -1) {
 			return redirectUrl;
 		}
 
 		isWhiteListedDomain = whiteListedDomains.some((whiteListedDomain: string): boolean => {
-			return redirectUrlHost.indexOf(whiteListedDomain) !== -1;
+			return redirectUrlHost.indexOf(whiteListedDomain, redirectUrlHost.length - whiteListedDomain.length) !== -1;
 		});
 
 		if (isWhiteListedDomain) {

--- a/server/facets/auth/authView.ts
+++ b/server/facets/auth/authView.ts
@@ -38,14 +38,17 @@ module authView {
 		var currentHost: string = request.headers.host,
 			redirectUrl: string = request.query.redirect || '/',
 			redirectUrlHost: string = url.parse(redirectUrl).host,
-			whiteListedDomains: Array<string> = ['wikia.com'],
+			whiteListedDomains: Array<string> = ['.wikia.com'],
 			isWhiteListedDomain: boolean;
 
 		if (!redirectUrlHost) {
 			return redirectUrl;
 		}
 
-		if (redirectUrlHost.indexOf(currentHost, redirectUrlHost.length - currentHost.length) !== -1) {
+		if (
+			currentHost === redirectUrlHost ||
+			redirectUrlHost.indexOf('.' + currentHost, redirectUrlHost.length - currentHost.length - 1) !== -1
+		) {
 			return redirectUrl;
 		}
 

--- a/server/facets/auth/login.ts
+++ b/server/facets/auth/login.ts
@@ -104,7 +104,7 @@ export function post (request: Hapi.Request, reply: any): void {
 	var credentials: any = request.payload,
 		requestedWithHeader: string = request.headers['x-requested-with'],
 		isAJAX: boolean = requestedWithHeader && !!requestedWithHeader.match('XMLHttpRequest'),
-		redirect: string = request.query.redirect || '/',
+		redirect: string = authView.getRedirectUrl(request),
 		successRedirect: string,
 		context: LoginViewContext,
 		ttl = 1.57785e10; // 6 months

--- a/test/specs/server/facets/auth/authView.js
+++ b/test/specs/server/facets/auth/authView.js
@@ -45,10 +45,22 @@ test('getRedirectUrl', function () {
 			description: 'Don\'t allow external domain when current domain is in URL'
 		},
 		{
-			redirect: 'http://wikia.com.google.com/',
+			redirect: 'http://www.wikia.com.google.com/',
 			host: 'wikia.com',
 			expected: '/',
 			description: 'Don\'t allow external domain when current wikia.com is put as subdomain'
+		},
+		{
+			redirect: 'http://otherdomainwikia.com',
+			host: 'glee.devbox.wikia-dev.com',
+			expected: '/',
+			description: 'Don\'t allow external domain when wikia.com is the last part of an external domain'
+		},
+		{
+			redirect: 'http://otherdomainwikia.com',
+			host: 'wikia.com',
+			expected: '/',
+			description: 'Don\'t allow external domain when wikia.com is the last part of an external domain'
 		}
 	];
 

--- a/test/specs/server/facets/auth/authView.js
+++ b/test/specs/server/facets/auth/authView.js
@@ -1,0 +1,60 @@
+QUnit.module('facets/auth/authView');
+
+test('getRedirectUrl', function () {
+	var testCases = [
+		{
+			redirect: 'http://muppet.wikia.com/wiki/Kermit?action=edit',
+			host: 'localhost:8000',
+			expected: 'http://muppet.wikia.com/wiki/Kermit?action=edit',
+			description: 'Whitelists wikia.com domain'
+		},
+		{
+			redirect: 'http://glee.devbox.wikia-dev.com/wiki/Rachel_Berry',
+			host: 'glee.devbox.wikia-dev.com',
+			expected: 'http://glee.devbox.wikia-dev.com/wiki/Rachel_Berry',
+			description: 'Allow current domain'
+		},
+		{
+			redirect: '/wiki/Kermit',
+			host: 'muppet.wikia.com',
+			expected: '/wiki/Kermit',
+			description: 'Allow local URLs'
+		},
+		{
+			redirect: undefined,
+			host: 'glee.devbox.wikia-dev.com',
+			expected: '/',
+			description: 'Fallback to / when empty redirect'
+		},
+		{
+			redirect: 'http://www.google.com',
+			host: 'glee.wikia.com',
+			expected: '/',
+			description: 'Fallback to / when domain is not permitted'
+		},
+		{
+			redirect: 'http://www.google.com/?domain=wikia.com',
+			host: 'glee.wikia.com',
+			expected: '/',
+			description: 'Don\'t allow external domain when whitelisted domain is in URL'
+		},
+		{
+			redirect: 'http://www.google.com/?domain=glee.devbox.wikia-dev.com',
+			host: 'glee.devbox.wikia-dev.com',
+			expected: '/',
+			description: 'Don\'t allow external domain when current domain is in URL'
+		},
+	];
+
+	testCases.forEach(function (testCase) {
+		var request = {
+			query: {
+				redirect: testCase.redirect
+			},
+			headers: {
+				host: testCase.host
+			}
+		};
+		equal(global.getRedirectUrl(request), testCase.expected, testCase.description);
+	});
+});

--- a/test/specs/server/facets/auth/authView.js
+++ b/test/specs/server/facets/auth/authView.js
@@ -44,6 +44,12 @@ test('getRedirectUrl', function () {
 			expected: '/',
 			description: 'Don\'t allow external domain when current domain is in URL'
 		},
+		{
+			redirect: 'http://wikia.com.google.com/',
+			host: 'wikia.com',
+			expected: '/',
+			description: 'Don\'t allow external domain when current wikia.com is put as subdomain'
+		}
 	];
 
 	testCases.forEach(function (testCase) {


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/SOC-896

* allow localUrls
* allow subdomains of ```wikia.com```
* allow subdomains of current domain