### PR TITLE
HG-734 Replace assets path for ember-main.hbs only

### DIFF
--- a/gulp/options/prod.js
+++ b/gulp/options/prod.js
@@ -50,7 +50,7 @@ module.exports = {
 		}
 	},
 	replace: {
-		selector: '**/*.hbs',
+		selector: '**/ember-main.hbs',
 		find: '/front/',
 		replace: '{{server.cdnBaseUrl}}/mercury-static/'
 	}


### PR DESCRIPTION
https://github.com/Wikia/mercury/pull/962 caused issue where auth pages didn't have assets loaded (tried to load from https://www.wikia.com/mercury-static/styles/auth/app-2bd62818.css). We had to rollback release-94 because of that.

This is a quick fix to unblock release, I've tested it on sandbox-qa04.

@kenkouot please take a look at the root of this issue, thanks.

/cc @kvas-damian @hakubo 