### PR TITLE
Make use of buildUrl when constructing API calls

### DIFF
--- a/front/scripts/main/models/EditModel.ts
+++ b/front/scripts/main/models/EditModel.ts
@@ -18,7 +18,7 @@ App.EditModel.reopenClass({
 	getEditToken: function(title: string): Em.RSVP.Promise {
 		return new Em.RSVP.Promise((resolve: Function, reject: Function): void => {
 			Em.$.ajax({
-				url: '/api.php',
+				url: M.buildUrl({path: '/api.php'}),
 				data: {
 					action: 'query',
 					prop: 'info',
@@ -50,7 +50,7 @@ App.EditModel.reopenClass({
 			this.getEditToken(model.title)
 				.then((token: any): void => {
 					Em.$.ajax({
-						url: '/api.php',
+						url: M.buildUrl({path: '/api.php'}),
 						data: {
 							action: 'edit',
 							title: model.title,
@@ -82,7 +82,7 @@ App.EditModel.reopenClass({
 
 	load: function(title: string, sectionIndex: number): Em.RSVP.Promise {
 		return new Em.RSVP.Promise((resolve: Function, reject: Function): void => {
-			Em.$.ajax('/api.php', {
+			Em.$.ajax(M.buildUrl({path: '/api.php'}), {
 				dataType: 'json',
 				cache: false,
 				data: {


### PR DESCRIPTION
Make use of buildUrl when constructing API calls now that it is available so we
support all environments including running it locally.

/cc @rogatty 