### PR TITLE
Infoboxes- don't handle infobox collapsing when clicked on button

### DIFF
--- a/front/scripts/main/components/PortableInfoboxComponent.ts
+++ b/front/scripts/main/components/PortableInfoboxComponent.ts
@@ -63,7 +63,7 @@ App.PortableInfoboxComponent = Em.Component.extend(App.ArticleContentMixin, App.
 			collapsed = this.get('collapsed'),
 			$target = $(event.target);
 
-		if ($target.is('a')) {
+		if ($target.is('a') || $target.is('button')) {
 			return;
 		}
 


### PR DESCRIPTION
Fix portable infobox logic to be prepared to handle the 'view more' button for linked gallery images. The goal is not to collapse/uncollapse the infobox when user clicked on link or on button (eg. view more button).

@RafLeszczynski