### PR TITLE
Fixing unit tests

### DIFF
--- a/test/specs/front/scripts/auth/common/Cookie.js
+++ b/test/specs/front/scripts/auth/common/Cookie.js
@@ -1,12 +1,24 @@
-QUnit.module('auth/common/Cookie)');
+// TODO: replace this with a class method to delete a cookie
+function delete_cookie( name ) {
+	document.cookie = name + '=; expires=Thu, 01 Jan 1970 00:00:01 GMT;';
+}
+
+QUnit.module('auth/common/Cookie', {
+	beforeEach: function () {
+		document.cookie = 'wikia_beacon_id=FM6JQNhtx5';
+		document.cookie = 'Geo={%22city%22:%22FIXME%22%2C%22country%22:%22PL%22%2C%22continent%22:%22EU%22}';
+		document.cookie = 'i18next=en';
+	},
+	afterEach: function () {
+		delete_cookie('wikia_beacon_id');
+		delete_cookie('Geo');
+		delete_cookie('i18next');
+	}
+});
 
 QUnit.test('Cookie class is loaded', function () {
 	ok(typeof window.Cookie === 'function');
 });
-
-document.cookie = 'wikia_beacon_id=FM6JQNhtx5';
-document.cookie = 'Geo={%22city%22:%22FIXME%22%2C%22country%22:%22PL%22%2C%22continent%22:%22EU%22}';
-document.cookie = 'i18next=en';
 
 QUnit.test('Cookie getter is extracting right value from a cookie', function () {
 	equal(window.Cookie.get('Geo'), '{"city":"FIXME","country":"PL","continent":"EU"}');
@@ -21,4 +33,3 @@ QUnit.test('Cookie getter is returning null if cookie value not found', function
 QUnit.test('Cookie getter is extracting right value from the end of cookie string', function () {
 	equal(window.Cookie.get('i18next'), 'en');
 });
-


### PR DESCRIPTION
For some reason, setting cookies in the global test scope caused seemingly unrelated tests to fail. There were 9 failures, each along the lines of: 
```
PhantomJS 1.9.8 (Mac OS X 0.0.0) Article Comments Model reset, resets model properties FAILED
	afterEach failed on reset, resets model properties: Attempting to change value of a readonly property.
	TypeError: Attempting to change value of a readonly property.

	Expected 2 assertions, but 3 were run
	    at /Users/liz_lux/WebstormProjects/mercury/node_modules/qunitjs/qunit/qunit.js:263
	    at /Users/liz_lux/WebstormProjects/mercury/www/front/vendor/sinon-qunit/lib/sinon-qunit.js:27
	    at test (/Users/liz_lux/WebstormProjects/mercury/front/vendor/ember-qunit/ember-qunit.js:252)
	    at /Users/liz_lux/WebstormProjects/mercury/test/specs/front/scripts/main/models/ArticleCommentsModel.js:39
```
Moving cookie addition and deletion to the `beforeEach` and `afterEach` hooks fixed the issue.  
@bkoval 