### PR TITLE
INT-130: Adding country parameter in context for performance data.

### DIFF
--- a/front/scripts/main/app.ts
+++ b/front/scripts/main/app.ts
@@ -175,6 +175,11 @@ App.initializer({
 		var geoCookie = $.cookie('Geo');
 		if (geoCookie) {
 			M.prop('geo', JSON.parse(geoCookie));
+		} else if (M.prop('environment') === 'dev') {
+			M.prop('geo', {
+					country: 'fake-country',
+					continent: 'fake-continent'
+			});
 		} else {
 			Ember.debug('Geo cookie is not set');
 		}

--- a/front/scripts/main/app.ts
+++ b/front/scripts/main/app.ts
@@ -166,7 +166,8 @@ App.initializer({
 
 /**
  * A "Geo" cookie is set by Fastly on every request.
- * If you run mercury app on your laptop, the cookie won't be automatically present.
+ * If you run mercury app on your laptop (e.g. development), the cookie won't be automatically present; hence,
+ * we set fake geo cookie values for 'dev'.
  */
 App.initializer({
 	name: 'geo',
@@ -177,8 +178,8 @@ App.initializer({
 			M.prop('geo', JSON.parse(geoCookie));
 		} else if (M.prop('environment') === 'dev') {
 			M.prop('geo', {
-				country: 'fake-country',
-				continent: 'fake-continent'
+				country: 'wikia-dev-country',
+				continent: 'wikia-dev-continent'
 			});
 		} else {
 			Ember.debug('Geo cookie is not set');

--- a/front/scripts/main/app.ts
+++ b/front/scripts/main/app.ts
@@ -177,8 +177,8 @@ App.initializer({
 			M.prop('geo', JSON.parse(geoCookie));
 		} else if (M.prop('environment') === 'dev') {
 			M.prop('geo', {
-					country: 'fake-country',
-					continent: 'fake-continent'
+				country: 'fake-country',
+				continent: 'fake-continent'
 			});
 		} else {
 			Ember.debug('Geo cookie is not set');

--- a/front/scripts/mercury/modules/Trackers/Perf.ts
+++ b/front/scripts/mercury/modules/Trackers/Perf.ts
@@ -25,6 +25,7 @@ module Mercury.Modules.Trackers {
 			url?: string;
 			'user-agent': string;
 			env: string;
+			country: string;
 		};
 
 		constructor () {
@@ -33,7 +34,8 @@ module Mercury.Modules.Trackers {
 				skin: 'mercury',
 				'user-agent': window.navigator.userAgent,
 				env: M.prop('environment'),
-				url: window.location.href.split('#')[0]
+				url: window.location.href.split('#')[0],
+				country: M.prop('geo.country')
 			};
 			this.tracker.setOptions({
 				host: M.prop('weppyConfig').host,


### PR DESCRIPTION
We want to measure performance of traffic from Japan. Adding country info read by users geo cookie enables filtering per geo for performance data in grafana.