### PR TITLE
HG-753 Add asyncArticle to the main page response

### DIFF
--- a/server/facets/operations/prepareMainPageData.ts
+++ b/server/facets/operations/prepareMainPageData.ts
@@ -52,8 +52,21 @@ function prepareMainPageData (request: Hapi.Request, result: any): void {
 	}
 
 	result.userId = request.auth.isAuthenticated ? request.auth.credentials.userId : 0;
+	result.asyncArticle = shouldAsyncArticle(result);
 
 	delete result.adsContext;
+}
+
+/**
+ * (HG-753) This allows for loading article content asynchronously while providing a version of the page with
+ * article content that search engines can still crawl.
+ * @see https://developers.google.com/webmasters/ajax-crawling/docs/specification
+ */
+function shouldAsyncArticle(result: any): boolean {
+	var asyncEnabled = localSettings.asyncArticle.indexOf(result.wiki.dbName) > -1,
+		noEscapedFragment = result.queryParams._escaped_fragment_ !== 0;
+
+	return asyncEnabled && noEscapedFragment;
 }
 
 export = prepareMainPageData;


### PR DESCRIPTION
https://github.com/Wikia/mercury/pull/999 broke main pages because it didn't add `asyncArticle` property to them. This is a quick, copy paste fix. We're going to refactor this in CONCF-761.

/cc @bognix @lizlux 