### PR TITLE
INT-117: Photo/Edit icons style change for Japanese Wikia

### DIFF
--- a/front/scripts/main/views/ArticleView.ts
+++ b/front/scripts/main/views/ArticleView.ts
@@ -212,9 +212,7 @@ App.ArticleView = Em.View.extend(App.AdsMixin, App.LanguagesMixin, App.ViewportM
 
 		this.$(':header[section]').each((i: Number, item: any): void => {
 			var $sectionHeader = this.$(item);
-
-			$sectionHeader.prepend(this.$(iconsWrapper));
-			$sectionHeader.addClass('short-header');
+			$sectionHeader.prepend(iconsWrapper).addClass('short-header');
 		});
 		this.setupButtonsListeners();
 	},
@@ -237,14 +235,14 @@ App.ArticleView = Em.View.extend(App.AdsMixin, App.LanguagesMixin, App.ViewportM
 				});
 			})
 			.on('change', '.upload-photo', (event: JQueryEventObject): void => {
-				var $photoUpload = $(event.target).parent(),
+				var $uploadPhotoContainer = $(event.target).parent(),
 				    sectionIndex: number = parseInt($(event.target).closest(':header[section]').attr('section'), 10);
-				this.onPhotoIconChange($photoUpload, sectionIndex);
+				this.onPhotoIconChange($uploadPhotoContainer, sectionIndex);
 			});
 	},
 
-	onPhotoIconChange: function(photoUpload: JQuery, sectionNumber: number): void {
-		var photoData = (<HTMLInputElement>photoUpload.find('.file-input')[0]).files[0];
+	onPhotoIconChange: function(uploadPhotoContainer: JQuery, sectionNumber: number): void {
+		var photoData = (<HTMLInputElement>uploadPhotoContainer.find('.file-input')[0]).files[0];
 		this.get('controller').send('addPhoto', this.get('controller.model.title'), sectionNumber, photoData);
 	},
 

--- a/front/scripts/main/views/ArticleView.ts
+++ b/front/scripts/main/views/ArticleView.ts
@@ -194,6 +194,7 @@ App.ArticleView = Em.View.extend(App.AdsMixin, App.LanguagesMixin, App.ViewportM
 		// TODO: There should be a helper for generating this HTML
 		var pencil = '<div class="edit-section"><svg class="icon pencil" role="img"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#pencil"></use></svg></div>',
 			photo = '<div class="upload-photo"><svg class="icon camera" role="img"><use xlink:href="#camera"></use></svg><input class="file-input" type="file" accept="image/*" capture="camera"/></div>',
+			iconsWrapper = '<div class="icon-wrapper">' + pencil + photo + '</div>',
 			$photoZero = this.$('.upload-photo');
 
 		$photoZero
@@ -210,12 +211,10 @@ App.ArticleView = Em.View.extend(App.AdsMixin, App.LanguagesMixin, App.ViewportM
 			});
 
 		this.$(':header[section]').each((i: Number, item: any): void => {
-			var $sectionHeader = this.$(item),
-				$pencil = this.$(pencil),
-				$photo = this.$(photo);
+			var $sectionHeader = this.$(item);
 
+			$sectionHeader.prepend(this.$(iconsWrapper));
 			$sectionHeader.addClass('short-header');
-			$sectionHeader.after($pencil, $photo);
 		});
 		this.setupButtonsListeners();
 	},
@@ -223,12 +222,13 @@ App.ArticleView = Em.View.extend(App.AdsMixin, App.LanguagesMixin, App.ViewportM
 	setupButtonsListeners: function () : void {
 		this.$('.article-content')
 			.on('click', '.pencil', (event: JQueryEventObject): void => {
-				var $sectionHeader = $(event.target).parent().prevAll(':header[section]:first');
+				var $sectionHeader = $(event.target).closest(':header[section]');
 				this.get('controller').send('edit', this.get('controller.model.cleanTitle'), $sectionHeader.attr('section'));
 			})
 			.on('click', '.upload-photo', (event: JQueryEventObject): void => {
-				var $sectionHeader = $(event.target).parent().prevAll(':header[section]:first'),
+				var $sectionHeader = $(event.target).closest(':header[section]'),
 				    sectionIndex: number = parseInt($sectionHeader.attr('section'), 10);
+
 				M.track({
 					action: M.trackActions.click,
 					category: 'sectioneditor',
@@ -238,7 +238,7 @@ App.ArticleView = Em.View.extend(App.AdsMixin, App.LanguagesMixin, App.ViewportM
 			})
 			.on('change', '.upload-photo', (event: JQueryEventObject): void => {
 				var $photoUpload = $(event.target).parent(),
-				    sectionIndex: number = parseInt($photoUpload.prevAll(':header[section]:first').attr('section'), 10);
+				    sectionIndex: number = parseInt($(event.target).closest(':header[section]').attr('section'), 10);
 				this.onPhotoIconChange($photoUpload, sectionIndex);
 			});
 	},

--- a/front/scripts/main/views/ArticleView.ts
+++ b/front/scripts/main/views/ArticleView.ts
@@ -192,7 +192,7 @@ App.ArticleView = Em.View.extend(App.AdsMixin, App.LanguagesMixin, App.ViewportM
 
 	setupContributionButtons: function (): void {
 		// TODO: There should be a helper for generating this HTML
-		var pencil = '<svg class="icon pencil" role="img"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#pencil"></use></svg>',
+		var pencil = '<div class="edit-section"><svg class="icon pencil" role="img"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#pencil"></use></svg></div>',
 			photo = '<div class="upload-photo"><svg class="icon camera" role="img"><use xlink:href="#camera"></use></svg><input class="file-input" type="file" accept="image/*" capture="camera"/></div>',
 			$photoZero = this.$('.upload-photo');
 
@@ -212,9 +212,11 @@ App.ArticleView = Em.View.extend(App.AdsMixin, App.LanguagesMixin, App.ViewportM
 		this.$(':header[section]').each((i: Number, item: any): void => {
 			var $sectionHeader = this.$(item),
 				$pencil = this.$(pencil),
-				$photo = this.$(photo);
+				$photo = this.$(photo),
+				sectionHeaderNewWidth = $sectionHeader.width() - 85;
 
-			$sectionHeader.append($photo, $pencil);
+			$sectionHeader.css({ display: 'inline-block', width: sectionHeaderNewWidth });
+			$sectionHeader.after($pencil, $photo);
 		});
 		this.setupButtonsListeners();
 	},
@@ -222,12 +224,12 @@ App.ArticleView = Em.View.extend(App.AdsMixin, App.LanguagesMixin, App.ViewportM
 	setupButtonsListeners: function () : void {
 		this.$('.article-content')
 			.on('click', '.pencil', (event: JQueryEventObject): void => {
-				var $sectionHeader = $(event.target).parent();
+				var $sectionHeader = $(event.target).parent().prev('h2');
 				this.get('controller').send('edit', this.get('controller.model.cleanTitle'), $sectionHeader.attr('section'));
 
 			})
 			.on('click', '.upload-photo', (event: JQueryEventObject): void => {
-				var $sectionHeader = $(event.target).parent().parent(),
+				var $sectionHeader = $(event.target).parent().prev().prev('h2'),
 				    sectionIndex: number = parseInt($sectionHeader.attr('section'), 10);
 				M.track({
 					action: M.trackActions.click,
@@ -237,13 +239,14 @@ App.ArticleView = Em.View.extend(App.AdsMixin, App.LanguagesMixin, App.ViewportM
 				});
 			})
 			.on('change', '.upload-photo', (event: JQueryEventObject): void => {
-			var $sectionHeader = $(event.target).parent().parent();
-				this.onPhotoIconChange($sectionHeader, $sectionHeader.attr('section'));
+				var $photoUpload = $(event.target).parent(),
+					sectionIndex: number = parseInt($(event.target).parent().prev().prev('h2').attr('section'), 10);
+				this.onPhotoIconChange($photoUpload, sectionIndex);
 			});
 	},
 
-	onPhotoIconChange: function(sectionHeader: JQuery, sectionNumber: number): void {
-		var photoData = (<HTMLInputElement>sectionHeader.find('.file-input')[0]).files[0];
+	onPhotoIconChange: function(photoUpload: JQuery, sectionNumber: number): void {
+		var photoData = (<HTMLInputElement>photoUpload.find('.file-input')[0]).files[0];
 		this.get('controller').send('addPhoto', this.get('controller.model.title'), sectionNumber, photoData);
 	},
 

--- a/front/scripts/main/views/ArticleView.ts
+++ b/front/scripts/main/views/ArticleView.ts
@@ -240,7 +240,7 @@ App.ArticleView = Em.View.extend(App.AdsMixin, App.LanguagesMixin, App.ViewportM
 			})
 			.on('change', '.upload-photo', (event: JQueryEventObject): void => {
 				var $photoUpload = $(event.target).parent(),
-					sectionIndex: number = parseInt($(event.target).parent().prev().prev('h2').attr('section'), 10);
+				    sectionIndex: number = parseInt($(event.target).parent().prev().prev('h2').attr('section'), 10);
 				this.onPhotoIconChange($photoUpload, sectionIndex);
 			});
 	},

--- a/front/scripts/main/views/ArticleView.ts
+++ b/front/scripts/main/views/ArticleView.ts
@@ -193,9 +193,9 @@ App.ArticleView = Em.View.extend(App.AdsMixin, App.LanguagesMixin, App.ViewportM
 	setupContributionButtons: function (): void {
 		// TODO: There should be a helper for generating this HTML
 		var pencil = '<div class="edit-section"><svg class="icon pencil" role="img"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#pencil"></use></svg></div>',
-			photo = '<div class="upload-photo"><svg class="icon camera" role="img"><use xlink:href="#camera"></use></svg><input class="file-input" type="file" accept="image/*" capture="camera"/></div>',
-			iconsWrapper = '<div class="icon-wrapper">' + pencil + photo + '</div>',
-			$photoZero = this.$('.upload-photo');
+		    photo = '<div class="upload-photo"><svg class="icon camera" role="img"><use xlink:href="#camera"></use></svg><input class="file-input" type="file" accept="image/*" capture="camera"/></div>',
+		    iconsWrapper = '<div class="icon-wrapper">' + pencil + photo + '</div>',
+		    $photoZero = this.$('.upload-photo');
 
 		$photoZero
 			.on('change', () => {

--- a/front/scripts/main/views/ArticleView.ts
+++ b/front/scripts/main/views/ArticleView.ts
@@ -212,10 +212,9 @@ App.ArticleView = Em.View.extend(App.AdsMixin, App.LanguagesMixin, App.ViewportM
 		this.$(':header[section]').each((i: Number, item: any): void => {
 			var $sectionHeader = this.$(item),
 				$pencil = this.$(pencil),
-				$photo = this.$(photo),
-				sectionHeaderNewWidth = $sectionHeader.width() - 85;
+				$photo = this.$(photo);
 
-			$sectionHeader.css({ display: 'inline-block', width: sectionHeaderNewWidth });
+			$sectionHeader.addClass('short-header');
 			$sectionHeader.after($pencil, $photo);
 		});
 		this.setupButtonsListeners();
@@ -224,12 +223,11 @@ App.ArticleView = Em.View.extend(App.AdsMixin, App.LanguagesMixin, App.ViewportM
 	setupButtonsListeners: function () : void {
 		this.$('.article-content')
 			.on('click', '.pencil', (event: JQueryEventObject): void => {
-				var $sectionHeader = $(event.target).parent().prev('h2');
+				var $sectionHeader = $(event.target).parent().prevAll(':header[section]:first');
 				this.get('controller').send('edit', this.get('controller.model.cleanTitle'), $sectionHeader.attr('section'));
-
 			})
 			.on('click', '.upload-photo', (event: JQueryEventObject): void => {
-				var $sectionHeader = $(event.target).parent().prev().prev('h2'),
+				var $sectionHeader = $(event.target).parent().prevAll(':header[section]:first'),
 				    sectionIndex: number = parseInt($sectionHeader.attr('section'), 10);
 				M.track({
 					action: M.trackActions.click,
@@ -240,7 +238,7 @@ App.ArticleView = Em.View.extend(App.AdsMixin, App.LanguagesMixin, App.ViewportM
 			})
 			.on('change', '.upload-photo', (event: JQueryEventObject): void => {
 				var $photoUpload = $(event.target).parent(),
-				    sectionIndex: number = parseInt($(event.target).parent().prev().prev('h2').attr('section'), 10);
+				    sectionIndex: number = parseInt($photoUpload.prevAll(':header[section]:first').attr('section'), 10);
 				this.onPhotoIconChange($photoUpload, sectionIndex);
 			});
 	},

--- a/front/styles/main/module/edit/_addphoto.scss
+++ b/front/styles/main/module/edit/_addphoto.scss
@@ -47,6 +47,7 @@ $upload-icon-size: 2.2rem;
 	margin-left: 0.8rem;
 	overflow:hidden;
 	position: relative;
+	vertical-align: top;
 	width: $upload-icon-size;
 
 	&.zero {

--- a/front/styles/main/module/edit/_addphoto.scss
+++ b/front/styles/main/module/edit/_addphoto.scss
@@ -51,7 +51,7 @@ $upload-icon-size: 2.2rem;
 	width: $upload-icon-size;
 
 	&.zero {
-		height: 2.2rem;
+		height: $upload-icon-size;
 		margin-left: 0.55rem;
 	}
 

--- a/front/styles/main/module/edit/_addphoto.scss
+++ b/front/styles/main/module/edit/_addphoto.scss
@@ -42,18 +42,23 @@ $upload-icon-size: 2.2rem;
 }
 
 .upload-photo {
-	float: right;
-	height: $upload-icon-size;
+	display: inline-block;
+	height: 4.7rem;
 	margin-left: 0.8rem;
 	overflow:hidden;
 	position: relative;
 	width: $upload-icon-size;
 
+	&.zero {
+		height: 2.2rem;
+		margin-left: 0.55rem;
+	}
+
 	.icon {
+		bottom: 0;
 		height: $upload-icon-size;
 		position:absolute;
 		right: 0;
-		top: 0;
 		width: $upload-icon-size;
 	}
 

--- a/front/styles/main/module/edit/_edit-common.scss
+++ b/front/styles/main/module/edit/_edit-common.scss
@@ -1,5 +1,3 @@
-$contribution-icons-space : 5.2rem;
-
 .contribution-container {
 	text-align: right;
 	width: 100%;
@@ -44,6 +42,6 @@ $contribution-icons-space : 5.2rem;
 }
 
 .short-header {
-	padding-right: $contribution-icons-space;
+	padding-right: 5.2rem; /* edit/photo icons width (2.2 * 2) + margin (0.8) in between */
 	position: relative;
 }

--- a/front/styles/main/module/edit/_edit-common.scss
+++ b/front/styles/main/module/edit/_edit-common.scss
@@ -1,3 +1,5 @@
+$contribution-icons-space : 5.2rem;
+
 .contribution-container {
 	text-align: right;
 	width: 100%;
@@ -33,4 +35,9 @@
 			font-weight: normal;
 		}
 	}
+}
+
+.short-header {
+	display: inline-block;
+	width: calc(100% - #{$contribution-icons-space});
 }

--- a/front/styles/main/module/edit/_edit-common.scss
+++ b/front/styles/main/module/edit/_edit-common.scss
@@ -1,3 +1,8 @@
+.contribution-container {
+	text-align: right;
+	width: 100%;
+}
+
 .edit-head {
 	@extend .site-head;
 	text-align: inherit;

--- a/front/styles/main/module/edit/_edit-common.scss
+++ b/front/styles/main/module/edit/_edit-common.scss
@@ -37,7 +37,13 @@ $contribution-icons-space : 5.2rem;
 	}
 }
 
+.icon-wrapper {
+	position: absolute;
+	right: 0;
+	top: 0;
+}
+
 .short-header {
-	display: inline-block;
-	width: calc(100% - #{$contribution-icons-space});
+	padding-right: $contribution-icons-space;
+	position: relative;
 }

--- a/front/styles/main/module/edit/_edit.scss
+++ b/front/styles/main/module/edit/_edit.scss
@@ -14,6 +14,7 @@ textarea {
 	height: 4.7rem;
 	overflow: hidden;
 	position: relative;
+	vertical-align: top;
 	width: 2.2rem;
 
 	&.zero {

--- a/front/styles/main/module/edit/_edit.scss
+++ b/front/styles/main/module/edit/_edit.scss
@@ -1,3 +1,5 @@
+$upload-icon-size: 2.2rem;
+
 textarea {
 	border: none;
 	height: 50%;
@@ -15,17 +17,17 @@ textarea {
 	overflow: hidden;
 	position: relative;
 	vertical-align: top;
-	width: 2.2rem;
+	width: $upload-icon-size;
 
 	&.zero {
-		height: 2.2rem;
+		height: $upload-icon-size;
 	}
 
 	.pencil {
 		bottom: 0;
-		height: 2.2rem;
+		height: $upload-icon-size;
 		position:absolute;
 		right: 0;
-		width: 2.2rem;
+		width: $upload-icon-size;
 	}
 }

--- a/front/styles/main/module/edit/_edit.scss
+++ b/front/styles/main/module/edit/_edit.scss
@@ -9,22 +9,22 @@ textarea {
 	top: 3.125rem;
 }
 
-.pencil {
-	float: right;
-	height: 2.2rem;
+.edit-section {
+	display: inline-block;
+	height: 4.7rem;
+	overflow: hidden;
+	position: relative;
 	width: 2.2rem;
+
 	&.zero {
-		position: relative;
-		right: 0;
+		height: 2.2rem;
 	}
-}
 
-.zero-button-wrapper {
-	padding: 0.1rem;
-}
-
-.zero-button-wrapper::after {
-	clear: both;
-	content: '';
-	display: block;
+	.pencil {
+		bottom: 0;
+		height: 2.2rem;
+		position:absolute;
+		right: 0;
+		width: 2.2rem;
+	}
 }

--- a/front/templates/main/article.hbs
+++ b/front/templates/main/article.hbs
@@ -25,13 +25,17 @@
 			{{/collapsible-menu}}
 		{{/if}}
 		{{#if view.contributionFeatureEnabled}}
-			<div class="upload-photo zero">
-				{{svg 'camera' role='img' class='icon camera'}}
-				<input class="file-input" type="file" accept="image/*" capture="camera"/>
+			<div class="contribution-container">
+				<div class="edit-section zero">
+					<span {{action 'edit' model.title '0'}} class='zero-button-wrapper'>
+						{{svg 'pencil' role='img' class='icon pencil'}}
+					</span>
+				</div>
+				<div class="upload-photo zero">
+					{{svg 'camera' role='img' class='icon camera'}}
+					<input class="file-input" type="file" accept="image/*" capture="camera"/>
+				</div>
 			</div>
-			<span {{action 'edit' model.title '0'}} class='zero-button-wrapper'>
-				{{svg 'pencil' role='img' class='icon pencil zero'}}
-			</span>
 		{{/if}}
 		<article class="article-content mw-content">
 			{{#if model.article}}


### PR DESCRIPTION
When the section title takes up the whole width of the screen on a mobile device, the edit and photo icons are displaced and moved to a second line. We want these icons aligned in 1 line with section header to avoid displacement. When we show the icons, we shorten section header to make room for icons and display them vertical-top alignment.