### PR TITLE
HG-691 setting option to get locale folders names as all lower case

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -68,7 +68,8 @@ plugins = [
 				useCookie: false,
 				detectLngFromHeaders: false,
 				detectLngFromQueryString: true,
-				detectLngQS: 'uselang'
+				detectLngQS: 'uselang',
+				lowerCaseLng: true
 			}
 		}
 	}


### PR DESCRIPTION
Fixing issue with country codes that have dashes in them not working well in the auth pages server-side translation code. Setting the `lowerCaseLng` option. 

Here's where that option is referenced: https://github.com/i18next/i18next/blob/master/i18next.js#L1851-L1853