### PR TITLE
SOC-1043 Use https url for tracking events internally

### DIFF
--- a/front/scripts/mercury/modules/Trackers/Internal.ts
+++ b/front/scripts/mercury/modules/Trackers/Internal.ts
@@ -31,7 +31,7 @@ interface InternalTrackingParams extends TrackingParams {
 
 module Mercury.Modules.Trackers {
 	export class Internal {
-		baseUrl: string = 'http://a.wikia-beacon.com/__track/';
+		baseUrl: string = 'https://beacon.wikia-services.com/__track/';
 		callbackTimeout: number = 200;
 		success: Function;
 		error: Function;

--- a/front/scripts/mercury/modules/Trackers/Internal.ts
+++ b/front/scripts/mercury/modules/Trackers/Internal.ts
@@ -31,7 +31,7 @@ interface InternalTrackingParams extends TrackingParams {
 
 module Mercury.Modules.Trackers {
 	export class Internal {
-		baseUrl: string = 'https://beacon.wikia-services.com/__track/';
+		baseUrl: string = '//beacon.wikia-services.com/__track/';
 		callbackTimeout: number = 200;
 		success: Function;
 		error: Function;

--- a/front/scripts/mercury/modules/Trackers/Internal.ts
+++ b/front/scripts/mercury/modules/Trackers/Internal.ts
@@ -31,7 +31,7 @@ interface InternalTrackingParams extends TrackingParams {
 
 module Mercury.Modules.Trackers {
 	export class Internal {
-		baseUrl: string = '//beacon.wikia-services.com/__track/';
+		baseUrl: string = 'https://beacon.wikia-services.com/__track/';
 		callbackTimeout: number = 200;
 		success: Function;
 		error: Function;


### PR DESCRIPTION
@lizlux @rogatty @mklucsarits @garthwebb @rafalkalinski 
https://wikia-inc.atlassian.net/browse/SOC-1043
We're changing tracker URL as we discovered http:// call is getting blocked on https pages.

It follows https://github.com/Wikia/wikia-vcl/pull/526