### PR TITLE
Hg 669 Fixing article comments query param regression

### DIFF
--- a/front/scripts/main/controllers/ApplicationController.ts
+++ b/front/scripts/main/controllers/ApplicationController.ts
@@ -9,6 +9,7 @@ App.ApplicationController = Em.Controller.extend(App.LoadingSpinnerMixin, App.Al
 	needs: ['article'],
 	queryParams: ['file', 'map',
 		{ noAds: 'noads' },
+		// TODO: should be on articles controller https://wikia-inc.atlassian.net/browse/HG-815
 		{ commentsPage: 'comments_page' }
 	],
 	file: null,

--- a/front/scripts/main/controllers/ApplicationController.ts
+++ b/front/scripts/main/controllers/ApplicationController.ts
@@ -7,12 +7,14 @@ App.ApplicationController = Em.Controller.extend(App.LoadingSpinnerMixin, App.Al
 	// This has to be here because we need to access media from ArticleController model to open lightbox
 	// TODO: Should be refactored when decoupling article from application
 	needs: ['article'],
-	queryParams: ['file', 'map', {
-		noAds: 'noads'
-	}],
+	queryParams: ['file', 'map',
+		{ noAds: 'noads' },
+		{ commentsPage: 'comments_page' }
+	],
 	file: null,
 	map: null,
 	noAds: '',
+	commentsPage: null,
 
 	smartBannerVisible: false,
 	sideNavCollapsed: true,

--- a/front/scripts/main/controllers/ArticleController.ts
+++ b/front/scripts/main/controllers/ArticleController.ts
@@ -5,11 +5,8 @@
 
 App.ArticleController = Em.Controller.extend({
 	needs: ['application'],
-	queryParams: [{
-		commentsPage: 'comments_page'
-	}],
-	commentsPage: null,
 	noAds: Em.computed.alias('controllers.application.noAds'),
+	commentsPage: Em.computed.alias('controllers.application.commentsPage'),
 
 	init: function (): void {
 		this.setProperties({

--- a/front/scripts/main/routes/ApplicationRoute.ts
+++ b/front/scripts/main/routes/ApplicationRoute.ts
@@ -6,6 +6,12 @@
 'use strict';
 
 App.ApplicationRoute = Em.Route.extend(Em.TargetActionSupport, App.TrackClickMixin, {
+	queryParams: {
+		comments_page: {
+			replace: true
+		}
+	},
+
 	model: function <T>(params: T): T {
 		return params;
 	},

--- a/front/scripts/main/routes/ArticleRoute.ts
+++ b/front/scripts/main/routes/ArticleRoute.ts
@@ -4,12 +4,6 @@
 'use strict';
 
 App.ArticleRoute = Em.Route.extend({
-	queryParams: {
-		comments_page: {
-			replace: true
-		}
-	},
-
 	beforeModel: function (transition: EmberStates.Transition):void {
 		var title = transition.params.article.title.replace('wiki/', '');
 

--- a/front/scripts/main/routes/ArticleRoute.ts
+++ b/front/scripts/main/routes/ArticleRoute.ts
@@ -78,6 +78,6 @@ App.ArticleRoute = Em.Route.extend({
 
 			// bubble up to ApplicationRoute#didTransition
 			return true;
-		},
+		}
 	}
 });

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -31,7 +31,7 @@ gulp.task('watch', ['build', 'build-views'], function () {
 	gulp.watch(path.join(
 		paths.scripts.front.src,
 		paths.scripts.front.files
-	), ['tslint', 'scripts-front', 'copy-ts-source']).on('change', function (event) {
+	), ['tslint', 'build-combined', 'copy-ts-source']).on('change', function (event) {
 		if (event.path.match('baseline')) {
 			gulp.start('build-views');
 		}


### PR DESCRIPTION
This is a bit of a hacky way to get the article comments query param working again. It really seems to belong on the article controller, not the application controller. 

I'm submitting this PR in the interest of time and getting it done within our sprint. I'll continue to look for a better solution though. 

@rogatty @kenkouot @katanka 