### PR TITLE
Use wild card path for article route

### DIFF
--- a/front/scripts/main/router.ts
+++ b/front/scripts/main/router.ts
@@ -24,7 +24,7 @@ App.Router.map(function () {
 	});
 
 	this.route('article', {
-		path: articlePath + ':title'
+		path: articlePath + '*title'
 	});
 
 	this.route('edit', { // Symbolic link to EditController


### PR DESCRIPTION
This adds support for subpages and fixes a bug where redirects from 404 subpages were created malformed redirects.