### PR TITLE
INT-147 Add photo bug on Android/Chrome

### DIFF
--- a/front/scripts/main/views/ArticleView.ts
+++ b/front/scripts/main/views/ArticleView.ts
@@ -193,7 +193,7 @@ App.ArticleView = Em.View.extend(App.AdsMixin, App.LanguagesMixin, App.ViewportM
 	setupContributionButtons: function (): void {
 		// TODO: There should be a helper for generating this HTML
 		var pencil = '<div class="edit-section"><svg class="icon pencil" role="img"><use xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#pencil"></use></svg></div>',
-		    photo = '<div class="upload-photo"><svg class="icon camera" role="img"><use xlink:href="#camera"></use></svg><input class="file-input" type="file" accept="image/*" capture="camera"/></div>',
+		    photo = '<div class="upload-photo"><svg class="icon camera" role="img"><use xlink:href="#camera"></use></svg><input class="file-input" type="file" accept="image/*"/></div>',
 		    iconsWrapper = '<div class="icon-wrapper">' + pencil + photo + '</div>',
 		    $photoZero = this.$('.upload-photo');
 

--- a/front/templates/main/article.hbs
+++ b/front/templates/main/article.hbs
@@ -33,7 +33,7 @@
 				</div>
 				<div class="upload-photo zero">
 					{{svg 'camera' role='img' class='icon camera'}}
-					<input class="file-input" type="file" accept="image/*" capture="camera"/>
+					<input class="file-input" type="file" accept="image/*"/>
 				</div>
 			</div>
 		{{/if}}


### PR DESCRIPTION
George in Tokyo office reported on Android app (device and browser info is unknown).
When a user uses native browser for his/her Android phone and tap "add photo" icon, it takes a user straight to capture photo (camera) instead of presenting showing choices of actions (gallery, camera, etc).