### PR TITLE
HG-816 upping sampling rate

### DIFF
--- a/config/localSettings.base.ts
+++ b/config/localSettings.base.ts
@@ -95,7 +95,7 @@ var localSettings: LocalSettings = {
 	weppy: {
 		enabled: process.env.WIKIA_ENVIRONMENT === 'prod',
 		host: 'http://speed.wikia.net/__rum',
-		samplingRate: 0.01,
+		samplingRate: 0.1,
 		aggregationInterval: 1000
 	},
 	wikiFallback: 'community',


### PR DESCRIPTION
Sample rate for Weppy used to be 1%, now it's 10%. 

https://github.com/Wikia/weppy#sample