### PR TITLE
rebuild templates on watch task

### DIFF
--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -47,7 +47,7 @@ gulp.task('watch', ['build', 'build-views'], function () {
 	gulp.watch(path.join(
 		paths.templates.src,
 		paths.templates.files
-	), ['templates']).on('change', function (event) {
+	), ['build-combined']).on('change', function (event) {
 		log('Template changed:', gutil.colors.green(event.path));
 	});
 


### PR DESCRIPTION
This rebuilds templates properly. The browser sync task still fires too early sometime. Any ideas on that? @rogatty @hakubo