### PR TITLE
Disable source maps

### DIFF
--- a/gulp/tasks/scripts-front.js
+++ b/gulp/tasks/scripts-front.js
@@ -8,7 +8,6 @@ var gulp = require('gulp'),
 	gulpif = require('gulp-if'),
 	folders = require('gulp-folders'),
 	ts = require('gulp-typescript'),
-	sourcemaps = require('gulp-sourcemaps'),
 	concat = require('gulp-concat'),
 	gutil = require('gulp-util'),
 	newer = require('gulp-newer'),
@@ -28,7 +27,6 @@ gulp.task('scripts-front', folders(paths.src, function (folder) {
 			'!' + path.join(paths.src, folder, paths.dFiles),
 			path.join(paths.src, folder, paths.files)
 		])
-		//.pipe(gulpif(!environment.isProduction, sourcemaps.init()))
 		.pipe(newer(path.join(paths.dest, folder + '.js')))
 		.pipe(ts(tsProjects[folder])).js
 		.on('error', function () {
@@ -39,10 +37,5 @@ gulp.task('scripts-front', folders(paths.src, function (folder) {
 		})
 		.pipe(concat(folder + '.js'))
 		.pipe(gulpif(environment.isProduction, uglify()))
-		//.pipe(gulpif(!environment.isProduction, sourcemaps.write('.' , {
-		//	includeContent: true,
-		//	sourceRoot: '/front/scripts/',
-		//	sourceMappingURLPrefix: '/front/scripts/'
-		//})))
 		.pipe(gulp.dest(paths.dest));
 }));

--- a/gulp/tasks/scripts-front.js
+++ b/gulp/tasks/scripts-front.js
@@ -28,7 +28,7 @@ gulp.task('scripts-front', folders(paths.src, function (folder) {
 			'!' + path.join(paths.src, folder, paths.dFiles),
 			path.join(paths.src, folder, paths.files)
 		])
-		.pipe(gulpif(!environment.isProduction, sourcemaps.init()))
+		//.pipe(gulpif(!environment.isProduction, sourcemaps.init()))
 		.pipe(newer(path.join(paths.dest, folder + '.js')))
 		.pipe(ts(tsProjects[folder])).js
 		.on('error', function () {
@@ -39,10 +39,10 @@ gulp.task('scripts-front', folders(paths.src, function (folder) {
 		})
 		.pipe(concat(folder + '.js'))
 		.pipe(gulpif(environment.isProduction, uglify()))
-		.pipe(gulpif(!environment.isProduction, sourcemaps.write('.' , {
-			includeContent: true,
-			sourceRoot: '/front/scripts/',
-			sourceMappingURLPrefix: '/front/scripts/'
-		})))
+		//.pipe(gulpif(!environment.isProduction, sourcemaps.write('.' , {
+		//	includeContent: true,
+		//	sourceRoot: '/front/scripts/',
+		//	sourceMappingURLPrefix: '/front/scripts/'
+		//})))
 		.pipe(gulp.dest(paths.dest));
 }));

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "gulp-tslint": "1.x.x",
     "gulp-typedoc": "^1.1.0",
     "gulp-typescript": "~2.6.0",
-    "gulp-sourcemaps": "~1.5.2",
     "gulp-uglify": "1.x.x",
     "gulp-useref": "1.x.x",
     "gulp-util": "3.x.x",


### PR DESCRIPTION
This implementation is buggy and tends to break the `debugger` statement functionality. My hope is that we're moving to ES6 so we'll no longer need TS source maps. (We may want ES6 source maps but we can handle that later.) 