### PR TITLE
HG-769 - sending logged_in flag to weppy

### DIFF
--- a/front/scripts/mercury/modules/Trackers/Perf.ts
+++ b/front/scripts/mercury/modules/Trackers/Perf.ts
@@ -42,7 +42,8 @@ module Mercury.Modules.Trackers {
 				transport: 'url',
 				context: this.defaultContext,
 				sample: M.prop('weppyConfig').samplingRate,
-				aggregationInterval: M.prop('weppyConfig').aggregationInterval
+				aggregationInterval: M.prop('weppyConfig').aggregationInterval,
+				logged_in: !!M.prop('userId')
 			});
 			super();
 		}


### PR DESCRIPTION
This sends the `logged_in` flag to weppy.
Related: https://github.com/Wikia/cheetah/pull/156