### PR TITLE
HG-816 checking if window is loaded before binding event

### DIFF
--- a/front/scripts/main/app.ts
+++ b/front/scripts/main/app.ts
@@ -91,7 +91,12 @@ App.initializer({
 			return;
 		}
 
-		$(window).load(() => M.sendPagePerformance());
+		// Send page performance stats after window is loaded
+		if (document.readyState === 'complete') {
+			M.sendPagePerformance()
+		} else {
+			$(window).load(() => M.sendPagePerformance());
+		}
 
 		EmPerfSender.initialize({
 			// Specify a specific function for EmPerfSender to use when it has captured metrics

--- a/front/scripts/main/app.ts
+++ b/front/scripts/main/app.ts
@@ -92,6 +92,7 @@ App.initializer({
 		}
 
 		// Send page performance stats after window is loaded
+		// Since we load our JS async this code may execute post load event
 		if (document.readyState === 'complete') {
 			M.sendPagePerformance()
 		} else {

--- a/front/scripts/mercury/utils/trackPerf.ts
+++ b/front/scripts/mercury/utils/trackPerf.ts
@@ -23,5 +23,6 @@ module Mercury.Utils {
 		// Initializes Weppy context
 		getInstance();
 		Weppy.sendPagePerformance();
+		M.prop('pagePerformanceSent', true);
 	}
 }

--- a/front/scripts/mercury/utils/trackPerf.ts
+++ b/front/scripts/mercury/utils/trackPerf.ts
@@ -23,6 +23,7 @@ module Mercury.Utils {
 		// Initializes Weppy context
 		getInstance();
 		Weppy.sendPagePerformance();
+		// used for automation test
 		M.prop('pagePerformanceSent', true);
 	}
 }


### PR DESCRIPTION
See https://github.com/Wikia/mercury/pull/1137 for a description of the problem. 

This will fix the spikiness of the graphs as well as the apparent decrease in performance. After loading scripts asynchronously, it became possible for the code that binds the onload event to run after the event already fired. This will check if onload has fired before binding the event, and will send page performance stats if it has. 