### PR TITLE
HG-810 - only build old way in prod

### DIFF
--- a/gulp/tasks/build-views.js
+++ b/gulp/tasks/build-views.js
@@ -44,15 +44,17 @@ gulp.task('build-views', ['scripts-front', 'copy-ts-source', 'vendor', 'build-ve
 
 		// TODO: Leave this in for now to run the normal template based assets pipeline for the duration
 		// of the test
-		gulpif('**/_layouts/*.hbs', piper(
-			assets,
-			//before running build I can not know what files from vendor to minify
-			gulpif('**/*.js', uglify()),
-			rev(),
-			gulp.dest(paths.base),
-			assets.restore(),
-			useref(),
-			revReplace()
+		gulpif(environment.isProduction,
+			gulpif('**/_layouts/*.hbs', piper(
+				assets,
+				//before running build I can not know what files from vendor to minify
+				gulpif('**/*.js', uglify()),
+				rev(),
+				gulp.dest(paths.base),
+				assets.restore(),
+				useref(),
+				revReplace()
+			)
 		)),
 
 		gulpif('**/_layouts/*.hbs', gulp.dest('www/server/views/_layouts')),

--- a/gulp/tasks/watch.js
+++ b/gulp/tasks/watch.js
@@ -12,7 +12,7 @@ var gulp = require('gulp'),
 	browserSync = require('browser-sync'),
 	reload = browserSync.reload;
 
-gulp.task('watch', ['build', 'build-views'], function () {
+gulp.task('watch', ['build'], function () {
 	log('Watching files');
 
 	if (!gutil.env.nosync) {


### PR DESCRIPTION
This should fix the error in `build-views` when a server template is changed.