### PR TITLE
Add assert with type to all jQuery AJAX calls

### DIFF
--- a/front/scripts/main/mixins/EditMixin.ts
+++ b/front/scripts/main/mixins/EditMixin.ts
@@ -6,7 +6,7 @@ App.EditMixin = Em.Mixin.create({
 
 	getEditToken: function(title: string): Em.RSVP.Promise {
 		return new Em.RSVP.Promise((resolve: Function, reject: Function): void => {
-			Em.$.ajax({
+			Em.$.ajax(<JQueryAjaxSettings>{
 				url: M.buildUrl({path: '/api.php'}),
 				data: {
 					action: 'query',

--- a/front/scripts/main/models/AddPhotoModel.ts
+++ b/front/scripts/main/models/AddPhotoModel.ts
@@ -74,7 +74,7 @@ App.AddPhotoModel.reopenClass(App.EditMixin, {
 
 	editContent(editData: any): Em.RSVP.Promise {
 		return new Em.RSVP.Promise((resolve: Function, reject: Function): void => {
-			Em.$.ajax({
+			Em.$.ajax(<JQueryAjaxSettings>{
 				url: M.buildUrl({ path: '/api.php' }),
 				dataType: 'json',
 				method: 'POST',
@@ -130,7 +130,7 @@ App.AddPhotoModel.reopenClass(App.EditMixin, {
 				title: photoTitle,
 				tempName: tempName
 			};
-			Em.$.ajax({
+			Em.$.ajax(<JQueryAjaxSettings>{
 				url: M.buildUrl({ path: '/api.php' }),
 				method: 'POST',
 				data: params,
@@ -155,7 +155,7 @@ App.AddPhotoModel.reopenClass(App.EditMixin, {
 		formData.append('file', photoData);
 
 		return new Em.RSVP.Promise((resolve: Function, reject: Function): void => {
-			Em.$.ajax({
+			Em.$.ajax(<JQueryAjaxSettings>{
 				url: M.buildUrl({
 					path: '/api.php',
 					query: {

--- a/front/scripts/main/models/ArticleCommentsModel.ts
+++ b/front/scripts/main/models/ArticleCommentsModel.ts
@@ -15,7 +15,7 @@ App.ArticleCommentsModel = Em.Object.extend({
 
 		if (page && page >= 0 && articleId) {
 			return new Em.RSVP.Promise((resolve: Function, reject: Function) => {
-				Em.$.ajax({
+				Em.$.ajax(<JQueryAjaxSettings>{
 					url: this.url(articleId, page),
 					success: (data) => {
 						this.setProperties(data.payload);

--- a/front/scripts/main/models/ArticleModel.ts
+++ b/front/scripts/main/models/ArticleModel.ts
@@ -75,7 +75,7 @@ App.ArticleModel.reopenClass({
 				return;
 			}
 
-			Em.$.ajax({
+			Em.$.ajax(<JQueryAjaxSettings>{
 				url: this.url(params),
 				dataType: 'json',
 				success: (data): void => {
@@ -99,7 +99,7 @@ App.ArticleModel.reopenClass({
 
 	getArticleRandomTitle: function (): Em.RSVP.Promise {
 		return new Em.RSVP.Promise((resolve: Function, reject: Function): void => {
-			Em.$.ajax({
+			Em.$.ajax(<JQueryAjaxSettings>{
 				url: App.get('apiBase') + '/article?random&titleOnly',
 				cache: false,
 				dataType: 'json',

--- a/front/scripts/main/models/CuratedContentEditorItemModel.ts
+++ b/front/scripts/main/models/CuratedContentEditorItemModel.ts
@@ -40,7 +40,7 @@ App.CuratedContentEditorItemModel.reopenClass({
 
 	getImage(title: string, size: number): Em.RSVP.Promise {
 		return new Em.RSVP.Promise((resolve: Function, reject: Function): void => {
-			Em.$.ajax({
+			Em.$.ajax(<JQueryAjaxSettings>{
 				url: M.buildUrl({
 					path: '/wikia.php',
 				}),
@@ -69,7 +69,7 @@ App.CuratedContentEditorItemModel.reopenClass({
 		});
 
 		return new Em.RSVP.Promise((resolve: Function, reject: Function): void => {
-			Em.$.ajax({
+			Em.$.ajax(<JQueryAjaxSettings>{
 				url: M.buildUrl({
 					path: '/wikia.php'
 				}),

--- a/front/scripts/main/models/CuratedContentEditorModel.ts
+++ b/front/scripts/main/models/CuratedContentEditorModel.ts
@@ -27,7 +27,7 @@ App.CuratedContentEditorModel = Em.Object.extend({
 App.CuratedContentEditorModel.reopenClass({
 	save(model: CuratedContentEditorModel): Em.RSVP.Promise {
 		return new Em.RSVP.Promise((resolve: Function, reject: Function): void => {
-			Em.$.ajax({
+			Em.$.ajax(<JQueryAjaxSettings>{
 				url: M.buildUrl({
 					path: '/wikia.php',
 					query: {
@@ -50,7 +50,7 @@ App.CuratedContentEditorModel.reopenClass({
 
 	load(): Em.RSVP.Promise {
 		return new Em.RSVP.Promise((resolve: Function, reject: Function): void => {
-			Em.$.ajax({
+			Em.$.ajax(<JQueryAjaxSettings>{
 				url: M.buildUrl({
 					path: '/wikia.php'
 				}),

--- a/front/scripts/main/models/CuratedContentModel.ts
+++ b/front/scripts/main/models/CuratedContentModel.ts
@@ -45,7 +45,7 @@ App.CuratedContentModel.reopenClass({
 					params.offset = offset;
 				}
 
-				Em.$.ajax({
+				Em.$.ajax(<JQueryAjaxSettings>{
 					url,
 					data: params,
 					success: (data: any): void => {

--- a/front/scripts/main/models/EditModel.ts
+++ b/front/scripts/main/models/EditModel.ts
@@ -19,7 +19,7 @@ App.EditModel.reopenClass(App.EditMixin, {
 		return new Em.RSVP.Promise((resolve: Function, reject: Function): void => {
 			this.getEditToken(model.title)
 				.then((token: any): void => {
-					Em.$.ajax({
+					Em.$.ajax(<JQueryAjaxSettings>{
 						url: M.buildUrl({path: '/api.php'}),
 						data: {
 							action: 'edit',

--- a/front/scripts/main/models/UserModel.ts
+++ b/front/scripts/main/models/UserModel.ts
@@ -26,7 +26,7 @@ App.UserModel.reopenClass({
 			model = App.UserModel.create();
 
 		return new Em.RSVP.Promise((resolve: Function, reject: Function): void => {
-			Em.$.ajax({
+			Em.$.ajax(<JQueryAjaxSettings>{
 				url: App.get('apiBase') + '/userDetails',
 				dataType: 'json',
 				data: {


### PR DESCRIPTION
Add assert for all jQuery AJAX call (as described in `jquery.d.ts`) do webStorm's TSLINT is not showing errors.

/cc @rogatty @kenkouot @hakubo 