### PR TITLE
Abstract out Open Graph attributes

### DIFF
--- a/server/facets/operations/prepareArticleData.ts
+++ b/server/facets/operations/prepareArticleData.ts
@@ -44,6 +44,18 @@ function prepareArticleData (request: Hapi.Request, result: any): void {
 	result.themeColor = Utils.getVerticalColor(localSettings, result.wiki.vertical);
 	// the second argument is a whitelist of acceptable parameter names
 	result.queryParams = Utils.parseQueryParams(request.query, allowedQueryParams);
+	result.openGraph = {
+		type: 'article',
+		title: title
+	};
+	if (result.article.details) {
+		if (result.article.details.abstract) {
+			result.openGraph.description = result.article.details.abstract;
+		}
+		if (result.article.details.thumbnail) {
+			result.openGraph.image = result.article.details.thumbnail;
+		}
+	}
 
 	result.weppyConfig = localSettings.weppy;
 	if (typeof result.queryParams.buckysampling === 'number') {

--- a/server/facets/operations/prepareMainPageData.ts
+++ b/server/facets/operations/prepareMainPageData.ts
@@ -47,6 +47,18 @@ function prepareMainPageData (request: Hapi.Request, result: any): void {
 	result.themeColor = Utils.getVerticalColor(localSettings, result.wiki.vertical);
 	// the second argument is a whitelist of acceptable parameter names
 	result.queryParams = Utils.parseQueryParams(request.query, ['noexternals', 'buckysampling']);
+	result.openGraph = {
+		type: result.isMainPage ? 'website' : 'article',
+		title: result.isMainPage ? result.wiki.siteName : title
+	};
+	if (result.article.details) {
+		if (result.article.details.abstract) {
+			result.openGraph.description = result.article.details.abstract;
+		}
+		if (result.article.details.thumbnail) {
+			result.openGraph.image = result.article.details.thumbnail;
+		}
+	}
 
 	result.weppyConfig = localSettings.weppy;
 	if (typeof result.queryParams.buckySampling === 'number') {

--- a/server/facets/operations/processCuratedContentData.ts
+++ b/server/facets/operations/processCuratedContentData.ts
@@ -51,6 +51,18 @@ function prepareData (request: Hapi.Request, result: any): void {
 	result.canonicalUrl = result.wiki.basePath + '/';
 	// the second argument is a whitelist of acceptable parameter names
 	result.queryParams = Utils.parseQueryParams(request.query, ['noexternals', 'buckysampling']);
+	result.openGraph = {
+		type: 'website',
+		title: result.wiki.siteName
+	};
+	if (result.article.details) {
+		if (result.article.details.abstract) {
+			result.openGraph.description = result.article.details.abstract;
+		}
+		if (result.article.details.thumbnail) {
+			result.openGraph.image = result.article.details.thumbnail;
+		}
+	}
 
 	result.weppyConfig = localSettings.weppy;
 	if (typeof result.queryParams.buckySampling === 'number') {

--- a/server/views/_partials/open-graph-tags.hbs
+++ b/server/views/_partials/open-graph-tags.hbs
@@ -1,15 +1,15 @@
-<meta property='og:type' content='{{#if isMainPage}}website{{else}}article{{/if}}' />
+<meta property="og:type" content="{{openGraph.type}}" />
 {{#unless isMainPage}}
-<meta property='og:site_name' content='{{wiki.siteName}}' />
+<meta property="og:site_name" content="{{wiki.siteName}}" />
 {{/unless}}
-<meta property='og:title' content='{{#if isMainPage}}{{wiki.siteName}}{{else}}{{displayTitle}}{{/if}}' />
-{{#if article.details.abstract}}
-<meta property='og:description' content='{{article.details.abstract}}' />
+<meta property="og:title" content="{{openGraph.title}}" />
+{{#if openGraph.description}}
+<meta property="og:description" content="{{openGraph.description}}" />
 {{/if}}
-<meta property='og:url' content='{{canonicalUrl}}' />
-{{#if article.details.thumbnail}}
-<meta property='og:image' content='{{article.details.thumbnail}}' />
+<meta property="og:url" content="{{canonicalUrl}}" />
+{{#if openGraph.image}}
+<meta property="og:image" content="{{openGraph.image}}" />
 {{/if}}
 {{#if wiki.facebookAppId}}
-<meta property='fb:app_id' content='{{wiki.facebookAppId}}' prefix='fb: http://www.facebook.com/2008/fbml' />
+<meta property="fb:app_id" content="{{wiki.facebookAppId}}" prefix="fb: http://www.facebook.com/2008/fbml" />
 {{/if}}

--- a/server/views/_partials/open-graph-tags.hbs
+++ b/server/views/_partials/open-graph-tags.hbs
@@ -1,15 +1,15 @@
 <meta property="og:type" content="{{openGraph.type}}" />
 {{#unless isMainPage}}
-<meta property="og:site_name" content="{{wiki.siteName}}" />
+	<meta property="og:site_name" content="{{wiki.siteName}}" />
 {{/unless}}
 <meta property="og:title" content="{{openGraph.title}}" />
 {{#if openGraph.description}}
-<meta property="og:description" content="{{openGraph.description}}" />
+	<meta property="og:description" content="{{openGraph.description}}" />
 {{/if}}
 <meta property="og:url" content="{{canonicalUrl}}" />
 {{#if openGraph.image}}
-<meta property="og:image" content="{{openGraph.image}}" />
+	<meta property="og:image" content="{{openGraph.image}}" />
 {{/if}}
 {{#if wiki.facebookAppId}}
-<meta property="fb:app_id" content="{{wiki.facebookAppId}}" prefix="fb: http://www.facebook.com/2008/fbml" />
+	<meta property="fb:app_id" content="{{wiki.facebookAppId}}" prefix="fb: http://www.facebook.com/2008/fbml" />
 {{/if}}


### PR DESCRIPTION
These changes were originally included as part of the Discussions code (https://github.com/Wikia/mercury/pull/1066), so that non-article pages could assign Open Graph tag attributes.

@rogatty @lizlux 