### PR TITLE
HG-825 Fix itemController deprecation

### DIFF
--- a/front/scripts/main/controllers/CategoryListItemController.ts
+++ b/front/scripts/main/controllers/CategoryListItemController.ts
@@ -1,9 +1,0 @@
-/// <reference path="../app.ts" />
-/// <reference path="../../mercury/utils/string.ts" />
-
-'use strict';
-App.CategoryListItemController = Em.Controller.extend({
-	cleanTitle: Em.computed('model.title', function () {
-		return M.String.normalizeToWhitespace(this.get('model.title').toString());
-	})
-});

--- a/front/templates/main/components/article-wrapper.hbs
+++ b/front/templates/main/components/article-wrapper.hbs
@@ -68,9 +68,9 @@
 					observe=model.cleanTitle
 					trackingEvent='category'
 				}}
-					{{#each model.categories itemController='categoryListItem' as |category|}}
-						<li class="mw-content" {{action 'trackClick' 'category' 'link'}}><a href="{{unbound category.model.url}}" title="{{unbound category.model.title}}">
-							{{category.cleanTitle}}
+					{{#each model.categories as |category|}}
+						<li class="mw-content" {{action 'trackClick' 'category' 'link'}}><a href="{{unbound category.url}}" title="{{unbound category.title}}">
+							{{unbound category.title}}
 							{{svg 'chevron' viewBox='0 0 12 7' class='icon chevron'}}
 						</a></li>
 					{{/each}}


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/HG-825

It's a simple fix. There is no need to normalize category title as it's coming from the API without underscores already.

/cc @lizlux @hakubo 