### PR TITLE
Small change to use --nosync in dev environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,9 @@
 
     export = localSettings;
 ```
-* `npm run dev` to start server and watch files
+* Start the server and watch files:
+** `npm run local` If running everything locally (e.g. your laptop)
+** `npm run dev` For hosted environments.  Same as 'local' but includes the --nosync paramter to disable live reload
 
 ## Access Mercury
 Open http://muppet.127.0.0.1.xip.io:8000/wiki/Gonzo in your browser

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 ```
 * Start the server and watch files:
   * `npm run local` If running everything locally (e.g. your laptop)
-  * `npm run dev` For hosted environments.  Same as 'local' but includes the --nosync paramter to disable [Live Reload](#Live reload)
+  * `npm run dev` For hosted environments.  Same as 'local' but includes the --nosync paramter to disable [Live Reload](#live-reload)
 
 ## Access Mercury
 Open http://muppet.127.0.0.1.xip.io:8000/wiki/Gonzo in your browser

--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Open http://muppet.127.0.0.1.xip.io:8000/wiki/Gonzo in your browser
 $ curl -H "Host:muppet.wikia-dev.com" "http://dev-joe:8000/wiki/Gonzo"
 
 ##Live reload
-on dev environments livereload server runs that reload your web browser on any change in front folder
-you can disable that by running gulp with --nosync parameter
+In dev environments the livereload plugin is available when the server is started with `npm run local`.  This will reload your web browser on any change to the `front` folder.  
+You can disable this behavior by running gulp with --nosync parameter, or as noted previously, by starting the server with `npm run dev`.
 
 ##[Release procedure](https://one.wikia-inc.com/wiki/Mercury/Release)
 

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@
     export = localSettings;
 ```
 * Start the server and watch files:
-** `npm run local` If running everything locally (e.g. your laptop)
-** `npm run dev` For hosted environments.  Same as 'local' but includes the --nosync paramter to disable live reload
+  * `npm run local` If running everything locally (e.g. your laptop)
+  * `npm run dev` For hosted environments.  Same as 'local' but includes the --nosync paramter to disable live reload
 
 ## Access Mercury
 Open http://muppet.127.0.0.1.xip.io:8000/wiki/Gonzo in your browser

--- a/README.md
+++ b/README.md
@@ -30,14 +30,15 @@
 ```
 * Start the server and watch files:
   * `npm run local` If running everything locally (e.g. your laptop)
-  * `npm run dev` For hosted environments.  Same as 'local' but includes the --nosync paramter to disable live reload
+  * `npm run dev` For hosted environments.  Same as 'local' but includes the --nosync paramter to disable [Live Reload](#Live reload)
 
 ## Access Mercury
 Open http://muppet.127.0.0.1.xip.io:8000/wiki/Gonzo in your browser
 $ curl -H "Host:muppet.wikia-dev.com" "http://dev-joe:8000/wiki/Gonzo"
 
 ##Live reload
-In dev environments the livereload plugin is available when the server is started with `npm run local`.  This will reload your web browser on any change to the `front` folder.  
+In dev environments the livereload plugin is available when the server is started with `npm run local`.  This will reload your web browser on any change to the `front` folder.
+
 You can disable this behavior by running gulp with --nosync parameter, or as noted previously, by starting the server with `npm run dev`.
 
 ##[Release procedure](https://one.wikia-inc.com/wiki/Mercury/Release)

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Wikia Web Application",
   "main": "server.js",
   "scripts": {
-    "dev": "rm -rf www && gulp",
+    "dev": "rm -rf www && gulp --nosync",
+    "local": "rm -rf www && gulp",
     "start": "rm -rf www && npm run build && node www/server/server.js",
     "test": "rm -rf www && gulp build --type prod --nosync --testing && gulp karma && gulp node-test",
     "coverage": "rm -rf www && gulp build --nosync --testing && gulp karma && gulp node-test",


### PR DESCRIPTION
This change allows dev box users to remove the sync script.  When working on a devbox it can take over 20s for the call requesting the nonexistent (on the devbox) sync JS resource to timeout, blocking all other JS.

Tagging those active in the ```discuss``` branch pull request, plus the Hg team:

@rogatty, @kenkouot, @nandy-andy, @mklucsarits, @lizlux 