### PR TITLE
Changing default port to work better on devboxes

### DIFF
--- a/config/localSettings.base.ts
+++ b/config/localSettings.base.ts
@@ -49,7 +49,7 @@ var localSettings: LocalSettings = {
 		scriptUrlDev:  '//s3.amazonaws.com/ki.js/52510/dlS.js',
 		scriptUrlProd: '//s3.amazonaws.com/ki.js/52510/bgJ.js'
 	},
-	port: process.env.PORT || 8000,
+	port: process.env.PORT || 7000,
 	proxyMaxRedirects: 3,
 	redirectUrlOnNoData: 'http://community.wikia.com/wiki/Community_Central:Not_a_valid_Wikia',
 	tracking: {


### PR DESCRIPTION
Devboxes are looking for mercury on port 7000. Let's add it as a default so when we start mercury on devbox it doesn't need any additional localSettings to be able to work out of the box.

@rogatty @bognix @rafalkalinski 