### PR TITLE
Update Wreck from 5.4.0 to 6.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "hoek": "2.12.0",
     "i18next": "1.7.10",
     "newrelic": "1.18.1",
-    "wreck": "5.4.0"
+    "wreck": "6.1.0"
   },
   "devDependencies": {
     "browser-sync": "^2.5.3",


### PR DESCRIPTION
This update provides support for parsing JSON from application/hal+json response types, which is needed for requests to new Wikia services API.

/cc @tomasznapieralski @rogatty 