### PR TITLE
SOC-904 Do not show header on Auth Pages in modal

### DIFF
--- a/server/facets/auth/authView.ts
+++ b/server/facets/auth/authView.ts
@@ -30,6 +30,7 @@ module authView {
 		headerText?: string;
 		bodyClasses?: string;
 		trackingConfig?: any;
+		isModal?: boolean;
 	}
 
 	export function view (template: string, context: AuthViewContext, request: Hapi.Request, reply: any): Hapi.Response {
@@ -82,18 +83,20 @@ module authView {
 	}
 
 	export function getDefaultContext (request: Hapi.Request): AuthViewContext {
-		var viewType: string = this.getViewType(request);
+		var viewType: string = this.getViewType(request),
+			isModal: boolean = request.query.modal === '1';
 		return {
 			title: null,
 			canonicalUrl: this.getCanonicalUrl(request),
 			exitTo: this.getRedirectUrl(request),
 			mainPage: "http://www.wikia.com",
+			isModal: isModal,
 			language: request.server.methods.i18n.getInstance().lng(),
 			trackingConfig: localSettings.tracking,
 			optimizelyScript: localSettings.optimizely.scriptPath +
 				(localSettings.environment === Utils.Environment.Prod ?
 					localSettings.optimizely.account : localSettings.optimizely.devAccount) + '.js',
-			standalonePage: (viewType === authView.VIEW_TYPE_DESKTOP),
+			standalonePage: (viewType === authView.VIEW_TYPE_DESKTOP && !isModal),
 			pageParams: {
 				viewType: viewType
 			}

--- a/server/views/_layouts/auth.hbs
+++ b/server/views/_layouts/auth.hbs
@@ -21,13 +21,15 @@
 				<a class="main-page" href="{{mainPage}}"><span>Wikia</span></a>
 			</nav>
 		{{else}}
-			{{#if exitTo }}
+			{{#unless isModal}}
+			{{#if exitTo}}
 			<a class="close" href="{{exitTo}}">
 				<svg role="img">
 					<use xlink:href="#close"></use>
 				</svg>
 			</a>
 			{{/if}}
+			{{/unless}}
 		{{/if}}
 
 		{{#unless hideHeader}}

--- a/server/views/_layouts/auth.hbs
+++ b/server/views/_layouts/auth.hbs
@@ -22,13 +22,11 @@
 			</nav>
 		{{else}}
 			{{#unless isModal}}
-			{{#if exitTo}}
 			<a class="close" href="{{exitTo}}">
 				<svg role="img">
 					<use xlink:href="#close"></use>
 				</svg>
 			</a>
-			{{/if}}
 			{{/unless}}
 		{{/if}}
 


### PR DESCRIPTION
@rafalkalinski @garthwebb 
https://wikia-inc.atlassian.net/browse/SOC-904
If a URL contains "modal=1" let's get rid of a corporate header and gray background and siplay the raw auth view.