### PR TITLE
movnig polymer asset loading outside of main app for now

### DIFF
--- a/front/templates/main/discussion/index.hbs
+++ b/front/templates/main/discussion/index.hbs
@@ -1,3 +1,5 @@
+<link rel="import" href="/front/vendor/polymer/polymer.html">
+<link rel="import" href="/front/vendor/wikia-style-guide/dist/components/top-bar/top-bar.html">
 <top-bar
 	logo-src="/front/vendor/wikia-style-guide/dist/svg/wikia_logo.svg"
 	user-logged-in="false"

--- a/server/views/_layouts/ember-main.hbs
+++ b/server/views/_layouts/ember-main.hbs
@@ -123,8 +123,6 @@
 				});
 			}());
 		</script>
-		<link rel="import" href="/front/vendor/polymer/polymer.html">
-		<link rel="import" href="/front/vendor/wikia-style-guide/dist/components/top-bar/top-bar.html">
 		<script src="//{{server.mediawikiDomain}}/__load/-/only=scripts/wikia.ext.instantGlobals,instantGlobalsOverride,abtesting" async></script>
 		{{> tracking-pixels}}
 	</body>


### PR DESCRIPTION
I noticed that polymer is loading a few different scripts, causing multiple requests. Since we're not going to release the top-bar component just yet, I moved asset loading to within the discussions pages to we don't pollute production. 

@kenkouot 
