### PR TITLE
Hg 843

### DIFF
--- a/front/scripts/main/routes/ArticleRoute.ts
+++ b/front/scripts/main/routes/ArticleRoute.ts
@@ -8,7 +8,7 @@ App.ArticleRoute = Em.Route.extend({
 		var title = transition.params.article.title.replace('wiki/', '');
 
 		if (Mercury.error) {
-			transition.abort();
+			this.transitionTo('notFound');
 		}
 
 		this.controllerFor('application').send('closeLightbox');

--- a/front/scripts/main/routes/ArticleRoute.ts
+++ b/front/scripts/main/routes/ArticleRoute.ts
@@ -8,7 +8,12 @@ App.ArticleRoute = Em.Route.extend({
 		var title = transition.params.article.title.replace('wiki/', '');
 
 		if (Mercury.error) {
-			this.transitionTo('notFound');
+			if (Mercury.error.code === 404) {
+				this.transitionTo('notFound');
+			} else {
+				Em.Logger.debug('App error: ', Mercury.error);
+				transition.abort();
+			}
 		}
 
 		this.controllerFor('application').send('closeLightbox');


### PR DESCRIPTION
I'll admit I'm not 100% sure why this broke, but now instead of aborting the transition when there's a 404 we're transitioning to the `notFound` route instead. 