### PR TITLE
Move ads out of application template

### DIFF
--- a/front/styles/main/module/_ads.scss
+++ b/front/styles/main/module/_ads.scss
@@ -14,7 +14,7 @@
 
 .mobile-top-leaderboard {
 	min-height: 50px;
-	margin-top: 60px;
+	margin-top: 10px;
 	position: relative;
 	z-index: $z-ads-top-leaderboard;
 }

--- a/front/templates/main/application.hbs
+++ b/front/templates/main/application.hbs
@@ -31,8 +31,6 @@
 		shouldBeVisible=userMenuVisible
 		toggleVisibility='toggleUserMenu'
 	}}
-	{{ad-slot name='INVISIBLE_HIGH_IMPACT' noAds=noAds}}
-	{{ad-slot name='MOBILE_TOP_LEADERBOARD' noAds=noAds}}
 	<div class='page-wrapper' lang={{language.content}} dir={{language.contentDir}}>
 		{{outlet}}
 	</div>

--- a/front/templates/main/article.hbs
+++ b/front/templates/main/article.hbs
@@ -1,3 +1,5 @@
+{{ad-slot name='INVISIBLE_HIGH_IMPACT' noAds=noAds}}
+{{ad-slot name='MOBILE_TOP_LEADERBOARD' noAds=noAds}}
 {{article-wrapper
 	commentsPage=commentsPage
 	mainPageTitle=mainPageTitle


### PR DESCRIPTION
This change moves ad slots out of the main application template. The purpose of this change is to allow content on pages using ```application.hbs``` to easily present content that is flush at the top of the page with the site header, allowing them to instead place ads underneath or wherever they need to go, depending on each page. This was primarily motivated by development of Discussions, which has its own forum header that goes directly underneath the site header. A positive side effect of this change is that the margin above the ad slots no longer depends on the height of site header.

I've added the ad slots for articles into ```article.hbs```. I wasn't sure if ad slots are needed in any of the other main templates. If they are, please say so.

@nandy-andy @hakubo You'll both want to look at this one.