### PR TITLE
Change mainPage route to the MW main page article route

### DIFF
--- a/front/scripts/main/router.ts
+++ b/front/scripts/main/router.ts
@@ -12,7 +12,7 @@ App.Router.map(function () {
 	var articlePath = Em.getWithDefault(Mercury, 'wiki.articlePath', '/wiki/').replace(/\/?$/, '/');
 
 	this.route('mainPage', {
-		path: '/'
+		path: '/wiki/' + Mercury.wiki.mainPageTitle
 	}, function () {
 		this.route('section', {
 			path: '/main/section/:sectionName'


### PR DESCRIPTION
This PR changes the curated mobile main pages static route from `/` to the legacy MW style route `/wiki/{articleName}`. This is a temporary change intended to fix a P2 (MAIN-5225) until a longer term solution is available.