### PR TITLE
Registering discussion i18n namespace to make it visible to the app

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -60,7 +60,7 @@ plugins = [
 			i18nextOptions: {
 				resGetPath: path.join(__dirname, '..', 'front/locales/__lng__/__ns__.json'),
 				ns: {
-					namespaces: ['main', 'auth'],
+					namespaces: ['main', 'auth', 'discussion'],
 					defaultNs: 'main'
 				},
 				fallbackLng: 'en',


### PR DESCRIPTION
@kvas-damian @garthwebb @mklucsarits @rafalkalinski It seems like the discussion namespace is not reachable by the app and we should fix it ASAP since it seems like open-graph needs a label form the translation file.