### PR TITLE
XW-230 Update Host header when there is a redirect

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "hoek": "2.12.0",
     "i18next": "1.7.10",
     "newrelic": "1.18.1",
-    "wreck": "6.1.0"
+    "wreck": "rogatty/wreck#before-redirect"
   },
   "devDependencies": {
     "browser-sync": "^2.5.3",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "hoek": "2.12.0",
     "i18next": "1.7.10",
     "newrelic": "1.18.1",
-    "wreck": "rogatty/wreck#before-redirect"
+    "wreck": "rogatty/wreck"
   },
   "devDependencies": {
     "browser-sync": "^2.5.3",

--- a/server/lib/MediaWiki.ts
+++ b/server/lib/MediaWiki.ts
@@ -177,6 +177,7 @@ export class ArticleRequest extends BaseRequest {
  */
 export function fetch (url: string, host: string = '', redirects: number = 1, headers: any = {}): Promise<any> {
 	// Host might get changed when redirected so headers should be updated
+	// TODO: this is a temporary solution to fix additional domains, will be fixed properly in XW-236
 	var beforeRedirect = (redirectMethod: string, statusCode: number, location: string, redirectOptions: any): void => {
 		var redirectHost: string = Url.parse(location).hostname;
 

--- a/server/lib/MediaWiki.ts
+++ b/server/lib/MediaWiki.ts
@@ -10,6 +10,7 @@ import localSettings = require('../../config/localSettings');
 import Logger = require('./Logger');
 import Wreck = require('wreck');
 import Promise = require('bluebird');
+import Url = require('url');
 
 interface MWRequestParams {
 	wikiDomain: string;
@@ -169,10 +170,21 @@ export class ArticleRequest extends BaseRequest {
  * Fetch http resource
  *
  * @param url the url to fetch
+ * @param host
  * @param redirects the number of redirects to follow, default 1
+ * @param headers
  * @return {Promise<any>}
  */
 export function fetch (url: string, host: string = '', redirects: number = 1, headers: any = {}): Promise<any> {
+	// Host might get changed when redirected so headers should be updated
+	var beforeRedirect = (redirectMethod: string, statusCode: number, location: string, redirectOptions: any): void => {
+		var redirectHost: string = Url.parse(location).hostname;
+
+		if (redirectHost) {
+			redirectOptions.headers.Host = redirectHost;
+		}
+	};
+
 	headers.Host = host;
 
 	return new Promise((resolve: Function, reject: Function): void => {
@@ -180,7 +192,8 @@ export function fetch (url: string, host: string = '', redirects: number = 1, he
 			redirects: redirects,
 			headers: headers,
 			timeout: localSettings.backendRequestTimeout,
-			json: true
+			json: true,
+			beforeRedirect: beforeRedirect
 		}, (err: any, response: any, payload: any): void => {
 			if (err) {
 				Logger.error({


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-230

Trying to access www.starwars.wikia.com with Mercury was failing because Wreck was sending all requests with the original host, even when redirect location had a different one.

I'll update `package.json` when https://github.com/hapijs/wreck/compare/master...rogatty:before-redirect is merged. I still need to write tests and docs, no need to block P2 fix by that.

/cc @hakubo @Warkot @bognix 