### PR TITLE
Discussions | Enable discussions by default on dev env

### DIFF
--- a/config/localSettings.dev.ts
+++ b/config/localSettings.dev.ts
@@ -20,7 +20,8 @@ var localSettings = baseLocalSettings.extendSettings({
 	qualaroo: {
 		scriptUrl: '//s3.amazonaws.com/ki.js/52510/dlS.js'
 	},
-	port: 7000
+	port: 7000,
+	enableDiscussions: true
 });
 
 export function extendSettings(customLocalSet: any): LocalSettings {


### PR DESCRIPTION
For now we show the splash page when discussion link is accessed on production, but we don't need to manually switch the flag enabling discussions on our localSettings since we can use localSettings.dev once to do that.

@kvas-damian 