### PR TITLE
HG-879 - add theme bar for discussion post pages - WIP

### DIFF
--- a/front/locales/en/main.json
+++ b/front/locales/en/main.json
@@ -150,6 +150,6 @@
   "userStatus": {
     "anon-cta": "__registerLink__ or __loginLink__",
     "register-text": "Register",
-    "login-text": "Login"
+    "login-text": "Sign In"
   }
 }

--- a/front/scripts/main/components/TopBarComponent.ts
+++ b/front/scripts/main/components/TopBarComponent.ts
@@ -4,7 +4,7 @@
 /// <reference path="../../../../typings/i18next/i18next.d.ts" />
 'use strict';
 
-App.TopBarComponent = Em.Component.extend(App.HeadroomMixin, {
+App.TopBarComponent = Em.Component.extend({
 	classNames: ['top-bar-component'],
 	logoHref: Em.getWithDefault(Mercury, 'wiki.homepage', 'http://www.wikia.com')
 });

--- a/front/styles/main/_settings.scss
+++ b/front/styles/main/_settings.scss
@@ -13,3 +13,4 @@ $label-color-active: $color-blue-gray-dark;
 $label-color-inactive: $color-blue-gray;
 $label-color-valid: $color-blue-gray-dark;
 $link-color: $color-blue-light;
+$top-bar-height: 46px;

--- a/front/styles/main/component/_discussion-header.scss
+++ b/front/styles/main/component/_discussion-header.scss
@@ -3,7 +3,7 @@ $discussion-header-color-text: #fff;
 
 .discussion-header {
 	color: $discussion-header-color-text;
-	margin-top: $global-nav-height;
+	margin-top: $top-bar-height;
 	max-width: inherit;
 	position: fixed;
 	top: 0;

--- a/front/styles/main/component/_discussion-header.scss
+++ b/front/styles/main/component/_discussion-header.scss
@@ -11,7 +11,7 @@ $discussion-header-color-text: #fff;
 	z-index: $z-6; // drop-downs from top-bar component (which is $z-7) display over the discussion header
 
 	&.un-pinned {
-		margin-top: $theme-bar-height;
+		margin-top: $theme-bar-height+$top-bar-height;
 	}
 
 	.header {

--- a/front/styles/main/component/_top-bar.scss
+++ b/front/styles/main/component/_top-bar.scss
@@ -5,14 +5,20 @@
 	z-index: $z-site-head;
 }
 top-bar {
-	background: $color-white;
 	border-bottom: 1px solid $color-blue-gray-light;
 	direction: ltr;
+	height: $top-bar-height;
 	max-width: inherit;
 	position: static;
 
-	&::shadow .inner {
-		padding-left: 15px;
-		padding-right: 15px;
+	&::shadow {
+		.inner {
+			padding-left: 15px;
+			padding-right: 15px;
+		}
+
+		.logo-wrapper {
+			line-height: 100%;
+		}
 	}
 }

--- a/front/styles/main/component/_top-bar.scss
+++ b/front/styles/main/component/_top-bar.scss
@@ -1,12 +1,15 @@
 .top-bar-component {
+	position: fixed;
+	top: 0;
 	width: 100%; // needed for headroom js when it sets position to absolute
+	z-index: $z-site-head;
 }
 top-bar {
+	background: $color-white;
 	border-bottom: 1px solid $color-blue-gray-light;
 	direction: ltr;
 	max-width: inherit;
 	position: static;
-	z-index: $z-site-head;
 
 	&::shadow .inner {
 		padding-left: 15px;

--- a/front/styles/main/component/_user-status.scss
+++ b/front/styles/main/component/_user-status.scss
@@ -1,9 +1,17 @@
 user-status {
-	::shadow .drawer ::content li {
-		border-color: $color-blue-gray-light;
+	padding-right: 15px;
+	margin-right: -15px;
+	font-size: 14px;
+
+	&::shadow .drawer {
+		top: 36px;
+
+		::content li {
+			border-color: $color-blue-gray-light;
+		}
 	}
 
-	// extra specificity of .login.icon as well as position:static can be removed once new nav is rolled out site wide.
+	// extra specificity of .login.icon and `position: static` can be removed once new nav is rolled out site wide.
 	figure svg, .login.icon {
 		width: 25px;
 		height: 25px;

--- a/front/templates/main/components/discussion-header.hbs
+++ b/front/templates/main/components/discussion-header.hbs
@@ -1,9 +1,11 @@
-<div class="header clearfix">
-	<h1>{{siteName}}</h1>
-	<div {{action 'showSortComponent'}} class="sort">
-		<span>{{i18n sortMessageKey}}</span>
-		{{svg 'filter-dropdown-white' viewBox='0 0 7 4' class='icon dropdown'}}
+{{#if showContent}}
+	<div class="header clearfix">
+		<h1>{{siteName}}</h1>
+		<div {{action 'showSortComponent'}} class="sort">
+			<span>{{i18n sortMessageKey}}</span>
+			{{svg 'filter-dropdown-white' viewBox='0 0 7 4' class='icon dropdown'}}
+		</div>
+		<div {{action 'hideSortComponent'}} class="overlay"></div>
 	</div>
-	<div {{action 'hideSortComponent'}} class="overlay"></div>
-</div>
+{{/if}}
 <hr class="theme">

--- a/front/templates/main/discussion/forum.hbs
+++ b/front/templates/main/discussion/forum.hbs
@@ -3,6 +3,7 @@
 	name=model.name
 }}
 {{discussion-header
+	showContent=true
 	showSortComponent='showSortComponent'
 	hideSortComponent='hideSortComponent'
 	sortBy=sortBy

--- a/front/templates/main/discussion/post.hbs
+++ b/front/templates/main/discussion/post.hbs
@@ -1,3 +1,10 @@
+{{discussion-header
+	showContent=false
+	showSortComponent='showSortComponent'
+	hideSortComponent='hideSortComponent'
+	sortBy=sortBy
+	sortMessageKey=sortMessageKey
+}}
 <div class="discussion post">
 	{{post-detail
 		author=model.firstPost.createdBy


### PR DESCRIPTION
On the post details page there was a theme-bar below the site-nav component. Now that we're using the top-bar component instead, the theme-bar will have to be re-inserted and styles fixed.