### PR TITLE
ADEN-2393 adding robots metatag

### DIFF
--- a/server/views/_layouts/ember-main.hbs
+++ b/server/views/_layouts/ember-main.hbs
@@ -11,6 +11,9 @@
 		{{#if themeColor}}
 			<meta name="theme-color" content="{{themeColor}}">
 		{{/if}}
+		{{#if wiki.specialRobotPolicy}}
+			<meta name="robots" content="{{wiki.specialRobotPolicy}}">
+		{{/if}}
 		{{#if asyncArticle}}
 			<meta name="fragment" content="!">
 		{{/if}}


### PR DESCRIPTION
I've added robots meta-tag in order to be consistent with the desktop application and hide staging versions from search engines. The wiki `specialRobotPolicy` variable comes from mediawiki API (see: `MercuryApiController::getWikiVariables()`). 

https://github.com/Wikia/app/pull/8560