### PR TITLE
ADEN-2406 Added detection script and event listeners to track blocking

### DIFF
--- a/front/scripts/mercury/modules/Ads.ts
+++ b/front/scripts/mercury/modules/Ads.ts
@@ -15,10 +15,14 @@ module Mercury.Modules {
 
 	export class Ads {
 		private static instance: Mercury.Modules.Ads = null;
+		private static blocking: boolean = null;
 		private adSlots: string[][] = [];
 		private adsContext: any = null;
 		private adEngineModule: any;
 		private adContextModule: any;
+		private sourcePointModule: {
+			initDetection (): void;
+		};
 		private adConfigMobile: any;
 		private adLogicPageViewCounterModule: {
 			get (): number;
@@ -55,20 +59,24 @@ module Mercury.Modules {
 						'ext.wikia.adEngine.adContext',
 						'ext.wikia.adEngine.config.mobile',
 						'ext.wikia.adEngine.adLogicPageViewCounter',
+						'ext.wikia.adEngine.sourcePoint',
 						'wikia.krux'
 					], (
 						adEngineModule: any,
 						adContextModule: any,
 						adConfigMobile: any,
 						adLogicPageViewCounterModule: any,
+						sourcePointModule: any,
 						krux: any
 					) => {
 						this.adEngineModule = adEngineModule;
 						this.adContextModule = adContextModule;
+						this.sourcePointModule = sourcePointModule;
 						this.adConfigMobile = adConfigMobile;
 						this.adLogicPageViewCounterModule = adLogicPageViewCounterModule;
 						window.Krux = krux || [];
 						this.isLoaded = true;
+						this.addDetectionListeners();
 						this.reloadWhenReady();
 						this.kruxTrackFirstPage();
 					});
@@ -105,6 +113,27 @@ module Mercury.Modules {
 			KruxTracker.trackPageView();
 		}
 
+		private trackBlocking (value: string): void {
+			var dimensions: string[] = [],
+				GATracker: Mercury.Modules.Trackers.UniversalAnalytics;
+			dimensions[6] = value;
+			Mercury.Modules.Trackers.UniversalAnalytics.setDimensions(dimensions);
+			GATracker = new Mercury.Modules.Trackers.UniversalAnalytics();
+			GATracker.track('ads-sourcepoint-detection', 'impression', value, 0, false);
+			this.gaTrackAdEvent('ad/sourcepoint/detection', value, '', 0, false);
+			Ads.blocking = value === 'Yes';
+		}
+
+		private addDetectionListeners (): void {
+			var trackBlocking: Function = this.trackBlocking;
+			window.addEventListener('sp.blocking', function (): void {
+				trackBlocking('Yes');
+			});
+			window.addEventListener('sp.not_blocking', function (): void {
+				trackBlocking('No');
+			});
+		}
+
 		private setContext (adsContext: any): void {
 			this.adsContext = adsContext ? adsContext : null;
 		}
@@ -117,12 +146,17 @@ module Mercury.Modules {
 			// Store the context for external reuse
 			this.setContext(adsContext);
 			this.currentAdsContext = adsContext;
+			// We need a copy of adSlots as adEngineModule.run destroys it
 			this.slotsQueue = this.getSlots();
 
 			if (this.isLoaded && adsContext) {
 				this.adContextModule.setContext(adsContext);
+				if (Ads.blocking !== null) {
+					this.trackBlocking(Ads.blocking ? 'Yes' : 'No');
+				} else {
+					this.sourcePointModule.initDetection();
+				}
 				this.adLogicPageViewCounterModule.increment();
-				// We need a copy of adSlots as .run destroys it
 				this.adEngineModule.run(this.adConfigMobile, this.slotsQueue, 'queue.mercury');
 			}
 		}

--- a/front/scripts/mercury/modules/Ads.ts
+++ b/front/scripts/mercury/modules/Ads.ts
@@ -120,7 +120,7 @@ module Mercury.Modules {
 			Mercury.Modules.Trackers.UniversalAnalytics.setDimensions(dimensions);
 			GATracker = new Mercury.Modules.Trackers.UniversalAnalytics();
 			GATracker.track('ads-sourcepoint-detection', 'impression', value, 0, false);
-			this.gaTrackAdEvent('ad/sourcepoint/detection', value, '', 0, false);
+			this.gaTrackAdEvent.call(this, 'ad/sourcepoint/detection', value, '', 0, false);
 			Ads.blocking = value === 'Yes';
 		}
 

--- a/front/scripts/mercury/modules/Ads.ts
+++ b/front/scripts/mercury/modules/Ads.ts
@@ -21,7 +21,7 @@ module Mercury.Modules {
 		private adEngineModule: any;
 		private adContextModule: any;
 		private sourcePointDetectionModule: {
-			initDetection (): void;
+			initDetection(): void;
 		};
 		private adConfigMobile: any;
 		private adLogicPageViewCounterModule: {

--- a/front/scripts/mercury/modules/Ads.ts
+++ b/front/scripts/mercury/modules/Ads.ts
@@ -20,7 +20,7 @@ module Mercury.Modules {
 		private adsContext: any = null;
 		private adEngineModule: any;
 		private adContextModule: any;
-		private sourcePointModule: {
+		private sourcePointDetectionModule: {
 			initDetection (): void;
 		};
 		private adConfigMobile: any;
@@ -59,19 +59,19 @@ module Mercury.Modules {
 						'ext.wikia.adEngine.adContext',
 						'ext.wikia.adEngine.config.mobile',
 						'ext.wikia.adEngine.adLogicPageViewCounter',
-						'ext.wikia.adEngine.sourcePoint',
+						'ext.wikia.adEngine.sourcePointDetection',
 						'wikia.krux'
 					], (
 						adEngineModule: any,
 						adContextModule: any,
 						adConfigMobile: any,
 						adLogicPageViewCounterModule: any,
-						sourcePointModule: any,
+						sourcePointDetectionModule: any,
 						krux: any
 					) => {
 						this.adEngineModule = adEngineModule;
 						this.adContextModule = adContextModule;
-						this.sourcePointModule = sourcePointModule;
+						this.sourcePointDetectionModule = sourcePointDetectionModule;
 						this.adConfigMobile = adConfigMobile;
 						this.adLogicPageViewCounterModule = adLogicPageViewCounterModule;
 						window.Krux = krux || [];
@@ -154,7 +154,7 @@ module Mercury.Modules {
 				if (Ads.blocking !== null) {
 					this.trackBlocking(Ads.blocking ? 'Yes' : 'No');
 				} else {
-					this.sourcePointModule.initDetection();
+					this.sourcePointDetectionModule.initDetection();
 				}
 				this.adLogicPageViewCounterModule.increment();
 				this.adEngineModule.run(this.adConfigMobile, this.slotsQueue, 'queue.mercury');

--- a/test/specs/front/scripts/mercury/modules/Ads.js
+++ b/test/specs/front/scripts/mercury/modules/Ads.js
@@ -45,7 +45,7 @@ QUnit.test('Reload ads works', function () {
 	instance.adEngineModule = {
 		run: runSpy
 	};
-	instance.sourcePointModule = {
+	instance.sourcePointDetectionModule = {
 		initDetection: initDetectionSpy
 	};
 	instance.adConfigMobile = {

--- a/test/specs/front/scripts/mercury/modules/Ads.js
+++ b/test/specs/front/scripts/mercury/modules/Ads.js
@@ -36,6 +36,7 @@ QUnit.test('Reload ads works', function () {
 		setContextSpy = this.spy(),
 		runSpy = this.spy(),
 		incrementSpy = this.spy(),
+		initDetectionSpy = this.spy(),
 		instance = Mercury.Modules.Ads.getInstance();
 
 	instance.adContextModule = {
@@ -43,6 +44,9 @@ QUnit.test('Reload ads works', function () {
 	};
 	instance.adEngineModule = {
 		run: runSpy
+	};
+	instance.sourcePointModule = {
+		initDetection: initDetectionSpy
 	};
 	instance.adConfigMobile = {
 		test: 2
@@ -57,6 +61,7 @@ QUnit.test('Reload ads works', function () {
 	instance.reload(testContext);
 	ok(setContextSpy.calledWith(testContext));
 	ok(incrementSpy.calledOnce);
+	ok(initDetectionSpy.calledOnce);
 	ok(runSpy.calledWith(instance.adConfigMobile, instance.adSlots, 'queue.mercury'));
 	instance.adContextModule = undefined;
 	instance.adEngineModule = undefined;


### PR DESCRIPTION
We want to track blocking page views on Mercury, so we add existing module to dependencies and track status with existing GA methods (both profiles: ads and regular).

**Please don't merge it before ADEN-2406 app part is released.**

App PR: https://github.com/Wikia/app/pull/8627