### PR TITLE
Maintenance | Fixing tslint warnings

### DIFF
--- a/server/lib/MainPage.ts
+++ b/server/lib/MainPage.ts
@@ -174,7 +174,7 @@ export class MainPageRequestHelper {
 			mediawikiDomain: Utils.getWikiDomainName(localSettings, wikiDomain),
 			apiBase: localSettings.apiBase,
 			environment: Utils.getEnvironmentString(env),
-			cdnBaseUrl: Utils.getCDNBaseUrl(localSettings),
+			cdnBaseUrl: Utils.getCDNBaseUrl(localSettings)
 		};
 	}
 

--- a/server/lib/Utils.ts
+++ b/server/lib/Utils.ts
@@ -211,9 +211,7 @@ export function getCDNBaseUrl(localSettings: LocalSettings): String {
  * @returns {string}
  */
 export function getHostFromRequest(request: Hapi.Request): string {
-	/* tslint:disable:no-string-literal */
-	return request.headers['x-original-host'] || request.headers['host'];
-	/* tslint:enable:no-string-literal */
+	return request.headers['x-original-host'] || request.headers.host;
 }
 
 export function isXipHost(localSettings: LocalSettings, hostName: string): boolean {

--- a/server/lib/Utils.ts
+++ b/server/lib/Utils.ts
@@ -196,7 +196,7 @@ export function createServerData(localSettings: LocalSettings, wikiDomain: strin
 }
 
 export function getCDNBaseUrl(localSettings: LocalSettings): String {
-	return localSettings.environment !== Environment.Dev ? localSettings.cdnBaseUrl : ''
+	return localSettings.environment !== Environment.Dev ? localSettings.cdnBaseUrl : '';
 }
 
 /**
@@ -211,12 +211,14 @@ export function getCDNBaseUrl(localSettings: LocalSettings): String {
  * @returns {string}
  */
 export function getHostFromRequest(request: Hapi.Request): string {
+	/* tslint:disable:no-string-literal */
 	return request.headers['x-original-host'] || request.headers['host'];
+	/* tslint:enable:no-string-literal */
 }
 
 export function isXipHost(localSettings: LocalSettings, hostName: string): boolean {
 	return localSettings.environment === Environment.Dev &&
-		hostName.search(/(?:[\d]{1,3}\.){4}xip\.io$/) !== -1
+		hostName.search(/(?:[\d]{1,3}\.){4}xip\.io$/) !== -1;
 }
 
 /**


### PR DESCRIPTION
All these things were causing tslint to show:

(no-trailing-comma) lib/MainPage.ts[176, 49]: trailing comma
(no-string-literal) lib/Utils.ts[213, 62]: object access via string literals is disallowed
(semicolon) lib/Utils.ts[198, 85]: missing semicolon
(semicolon) lib/Utils.ts[218, 54]: missing semicolon

on dev branch.