### PR TITLE
ADEN-2466 Fix close button in mobile lightbox

### DIFF
--- a/front/templates/main/components/lightbox-wrapper.hbs
+++ b/front/templates/main/components/lightbox-wrapper.hbs
@@ -1,9 +1,7 @@
 {{#if type}}
 	<div class="lightbox-header {{if headerHidden 'hidden'}}">
 		<div class="lightbox-close-wrapper">
-			<svg role="img" class="lightbox-close-button">
-				<use xlink:href="#close"></use>
-			</svg>
+			{{svg 'close' role='img' class='lightbox-close-button pointer-events-none'}}
 		</div>
 		<div class="lightbox-header-title">{{header}}</div>
 	</div>


### PR DESCRIPTION
The mobile lightbox (Mercury lightbox) is hard to be closed since taping on "X" icon doesn't make it disappear. The fix below was cherry-picked from existing pull request https://github.com/Wikia/mercury/pull/1402 as a fix for P3.