### PR TITLE
ADEN-2464 Fix externaltest on mobile

### DIFF
--- a/server/lib/Utils.ts
+++ b/server/lib/Utils.ts
@@ -126,7 +126,7 @@ export function clearHost (host: string): string {
 	// We use two special domain prefixes for Ad Operation and Sales reasons
 	// They behave similar to our staging prefixes but are not staging machines
 	// Talk to Ad Engineering Team if you want to learn more
-	var adDomainAliases: Array<string> = [ 'externaltest', 'showcase' ];
+	var adDomainAliases: Array<string> = ['externaltest', 'showcase'];
 
 	host = host.split(':')[0]; // get rid of port
 	Object.keys(adDomainAliases).forEach(function (key){

--- a/server/lib/Utils.ts
+++ b/server/lib/Utils.ts
@@ -117,13 +117,22 @@ export function getWikiDomainName (localSettings: LocalSettings, hostName: strin
 }
 
 /**
- * @desc Removes the port from hostname
+ * @desc Removes the port from hostname as well as ad domain aliases
  *
  * @param {string} host
  * @returns {string}
  */
 export function clearHost (host: string): string {
-	return host.split(':')[0]; //get rid of port
+	var adDomainAliases: Array<string> = [ 'externaltest', 'showcase' ];
+
+	host = host.split(':')[0]; // get rid of port
+	Object.keys(adDomainAliases).forEach(function (key){
+		if (host.indexOf(adDomainAliases[key]) === 0) {
+			host = host.replace(adDomainAliases[key] + '.', ''); // get rid of domain aliases
+		}
+	});
+
+	return host;
 }
 
 /**

--- a/server/lib/Utils.ts
+++ b/server/lib/Utils.ts
@@ -123,6 +123,9 @@ export function getWikiDomainName (localSettings: LocalSettings, hostName: strin
  * @returns {string}
  */
 export function clearHost (host: string): string {
+	// We use two special domain prefixes for Ad Operation and Sales reasons
+	// They behave similar to our staging prefixes but are not staging machines
+	// Talk to Ad Engineering Team if you want to learn more
 	var adDomainAliases: Array<string> = [ 'externaltest', 'showcase' ];
 
 	host = host.split(':')[0]; // get rid of port

--- a/test/specs/server/lib/Utils.js
+++ b/test/specs/server/lib/Utils.js
@@ -101,6 +101,18 @@ test('clearHost', function () {
 			host: 'example.com:8080',
 			expected: 'example.com',
 			description: 'clears the port from the host'
+		} , {
+			host: 'externaltest.muppet.wikia.com',
+			expected: 'muppet.wikia.com',
+			description: 'clears the externaltest ad domain alias'
+		} , {
+			host: 'showcase.muppet.wikia.com',
+			expected: 'muppet.wikia.com',
+			description: 'clears the showcase ad domain alias'
+		} , {
+			host: 'externaltest.muppet.wikia.com:8000',
+			expected: 'muppet.wikia.com',
+			description: 'clears the showcase ad domain alias and port'
 		}
 	];
 	testCases.forEach(function (testCase) {


### PR DESCRIPTION
Recently changes with using `x-original-host` probably broke `externaltest.*` and `showcase.*` domain aliases. Since those are quite edge cases and aren't separated machines we decided to treat it as edge case in Mercury server code.

This is the only idea we came up with as a quick fix. We can try it out tomorrow.

// cc @bognix @vforge @rogatty @hakubo 