### PR TITLE
HG-892 fixing top-nav headroom interaction

### DIFF
--- a/front/scripts/main/components/DiscussionHeaderComponent.ts
+++ b/front/scripts/main/components/DiscussionHeaderComponent.ts
@@ -4,6 +4,8 @@
 
 App.DiscussionHeaderComponent = Em.Component.extend(App.HeadroomMixin, {
 	classNames: ['discussion-header'],
+	// TODO: not sure this is always accurate
+	smartBannerVisible: Em.computed.alias('controllers.application.smartBannerVisible'),
 
 	siteName: Em.computed(function (): string {
 		return Em.get(Mercury, 'wiki.siteName');

--- a/front/scripts/main/components/TopBarComponent.ts
+++ b/front/scripts/main/components/TopBarComponent.ts
@@ -5,5 +5,6 @@
 'use strict';
 
 App.TopBarComponent = Em.Component.extend(App.HeadroomMixin, {
+	classNames: ['top-bar-component'],
 	logoHref: Em.getWithDefault(Mercury, 'wiki.homepage', 'http://www.wikia.com')
 });

--- a/front/scripts/main/components/UserStatusComponent.ts
+++ b/front/scripts/main/components/UserStatusComponent.ts
@@ -5,10 +5,10 @@
 'use strict';
 
 
-App.UserStatusComponent = Em.Component.extend(App.HeadroomMixin, {
+App.UserStatusComponent = Em.Component.extend({
 	userLoggedIn: Em.computed('currentUser.isAuthenticated', function () {
 		if (this.get('currentUser.isAuthenticated') === true) {
-			return false;
+			return true;
 		}
 		// HTMLBars attribute binding only removes an attribute if it's value is set to null
 		return null;

--- a/front/scripts/main/controllers/DiscussionForumController.ts
+++ b/front/scripts/main/controllers/DiscussionForumController.ts
@@ -5,8 +5,6 @@ App.DiscussionForumController = Em.Controller.extend({
 	sortBy: null,
 	// Whether the sort component is currently visible
 	sortVisible: false,
-	// TODO: not sure this is always accurate
-	smartBannerVisible: Em.computed.alias('controllers.application.smartBannerVisible'),
 
 	sortTypes: [
 		{

--- a/front/scripts/main/controllers/DiscussionForumController.ts
+++ b/front/scripts/main/controllers/DiscussionForumController.ts
@@ -1,9 +1,12 @@
 /// <reference path="../app.ts" />
 
 App.DiscussionForumController = Em.Controller.extend({
+	needs: 'application',
 	sortBy: null,
 	// Whether the sort component is currently visible
 	sortVisible: false,
+	// TODO: not sure this is always accurate
+	smartBannerVisible: Em.computed.alias('controllers.application.smartBannerVisible'),
 
 	sortTypes: [
 		{

--- a/front/styles/main/component/_top-bar.scss
+++ b/front/styles/main/component/_top-bar.scss
@@ -1,3 +1,6 @@
+.top-bar-component {
+	width: 100%; // needed for headroom js when it sets position to absolute
+}
 top-bar {
 	border-bottom: 1px solid $color-blue-gray-light;
 	direction: ltr;

--- a/front/templates/main/application.hbs
+++ b/front/templates/main/application.hbs
@@ -13,7 +13,9 @@
 	}}
 
 	{{#if useNewNav}}
-		{{top-bar}}
+		{{top-bar
+			smartBannerVisible=smartBannerVisible
+		}}
 	{{else}}
 		{{site-head
 			smartBannerVisible=smartBannerVisible

--- a/front/templates/main/components/top-bar.hbs
+++ b/front/templates/main/components/top-bar.hbs
@@ -1,7 +1,5 @@
 <top-bar logo-href="{{logoHref}}">
 	{{svg 'wikia-logo' role='img' class='icon wikia-logo logo-image'}}
 
-	{{user-status
-		currentUser=currentUser
-	}}
+	{{user-status}}
 </top-bar>

--- a/front/templates/main/discussion/forum.hbs
+++ b/front/templates/main/discussion/forum.hbs
@@ -3,7 +3,6 @@
 	name=model.name
 }}
 {{discussion-header
-	smartBannerVisible=smartBannerVisible
 	showSortComponent='showSortComponent'
 	hideSortComponent='hideSortComponent'
 	sortBy=sortBy

--- a/front/templates/main/discussion/forum.hbs
+++ b/front/templates/main/discussion/forum.hbs
@@ -3,6 +3,7 @@
 	name=model.name
 }}
 {{discussion-header
+	smartBannerVisible=smartBannerVisible
 	showSortComponent='showSortComponent'
 	hideSortComponent='hideSortComponent'
 	sortBy=sortBy


### PR DESCRIPTION
There were a few styling issues outlined in this ticket https://wikia-inc.atlassian.net/browse/HG-892. Turns out there was weirdness the `userLoggedIn` logic as well as some issues with the headroom JS interaction. I've fixed the headroom JS interaction for the top-bar but the discussions header still needs a bit of work. We can handle that in a separate ticket. 