### PR TITLE
INT-195: Add search action

### DIFF
--- a/front/scripts/main/controllers/ApplicationController.ts
+++ b/front/scripts/main/controllers/ApplicationController.ts
@@ -136,6 +136,15 @@ App.ApplicationController = Em.Controller.extend(App.LoadingSpinnerMixin, App.Al
 		},
 
 		/**
+		 * @desc Bubbles up to ApplicationRoute
+		 *
+		 * @param searchString
+		 */
+		search: function (searchString : string) {
+			this.get('target').send('search', searchString);
+		},
+
+		/**
 		 * @desc Sets query param with given name to given value. Uses whitelist.
 		 *
 		 * @param name

--- a/front/scripts/main/routes/ApplicationRoute.ts
+++ b/front/scripts/main/routes/ApplicationRoute.ts
@@ -148,6 +148,10 @@ App.ApplicationRoute = Em.Route.extend(Em.TargetActionSupport, App.TrackClickMix
 				});
 		},
 
+		search: function (searchString : string) {
+			this.transitionTo('searchResults', {queryParams: {q: searchString}});
+		},
+
 		// We need to proxy these actions because of the way Ember is bubbling them up through routes
 		// see http://emberjs.com/images/template-guide/action-bubbling.png
 		handleLightbox: function (): void {

--- a/front/templates/main/application.hbs
+++ b/front/templates/main/application.hbs
@@ -23,6 +23,7 @@
 	toggleSideNav=(action 'toggleSideNav')
 	toggleSmartBanner=(action 'toggleSmartBanner')
 	toggleUserMenu=(action 'toggleUserMenu')
+	search=(action 'search')
 }}
 	{{outlet}}
 {{/application-wrapper}}

--- a/front/templates/main/application.hbs
+++ b/front/templates/main/application.hbs
@@ -19,11 +19,11 @@
 	closeLightbox=(action 'closeLightbox')
 	handleLink=(action 'handleLink')
 	loadRandomArticle=(action 'loadRandomArticle')
+	search=(action 'search')
 	setQueryParam=(action 'setQueryParam')
 	toggleSideNav=(action 'toggleSideNav')
 	toggleSmartBanner=(action 'toggleSmartBanner')
 	toggleUserMenu=(action 'toggleUserMenu')
-	search=(action 'search')
 }}
 	{{outlet}}
 {{/application-wrapper}}

--- a/front/templates/main/components/application-wrapper.hbs
+++ b/front/templates/main/components/application-wrapper.hbs
@@ -36,6 +36,7 @@
 		shouldBeVisible=sideNavVisible
 		loadRandomArticle=attrs.loadRandomArticle
 		toggleVisibility=attrs.toggleSideNav
+		search=attrs.search
 	}}
 	{{user-menu
 		shouldBeVisible=userMenuVisible

--- a/front/templates/main/components/application-wrapper.hbs
+++ b/front/templates/main/components/application-wrapper.hbs
@@ -35,8 +35,8 @@
 	{{side-nav
 		shouldBeVisible=sideNavVisible
 		loadRandomArticle=attrs.loadRandomArticle
-		toggleVisibility=attrs.toggleSideNav
 		search=attrs.search
+		toggleVisibility=attrs.toggleSideNav
 	}}
 	{{user-menu
 		shouldBeVisible=userMenuVisible


### PR DESCRIPTION
Add new action "search" to enable transition into SearchResultsRoute.

This will be activated in a separate PR from enter() in SideNavComponent like so:

	if (<optimizely ab test for google search is set>) {
		this.sendAction('toggleVisibility', false);
		this.send('searchCancel');

		this.sendAction('search', value);
	} else {
	 window.location.assign('%@Special:Searchsearch=%@&fulltext=Search'.fmt(Mercury.wiki.articlePath, value));
	}
