### PR TITLE
XW-461 add mw-content class to all modules on main page

### DIFF
--- a/front/scripts/main/components/CuratedContentComponent.ts
+++ b/front/scripts/main/components/CuratedContentComponent.ts
@@ -5,7 +5,7 @@
 'use strict';
 
 App.CuratedContentComponent = Em.Component.extend(App.LoadingSpinnerMixin, App.TrackClickMixin, {
-	classNames: ['curated-content'],
+	classNames: ['curated-content', 'mw-content'],
 
 	actions: {
 		clickItem(item: CuratedContentItem): void {

--- a/front/scripts/main/components/MainPageComponent.ts
+++ b/front/scripts/main/components/MainPageComponent.ts
@@ -4,7 +4,7 @@
 'use strict';
 
 App.MainPageComponent = Em.Component.extend(App.AdsMixin, App.TrackClickMixin, {
-	classNames: ['main-page-modules', 'main-page-body', 'mw-content'],
+	classNames: ['main-page-modules', 'main-page-body'],
 	tagName: 'section',
 
 	featuredContentComponentVariation: Em.computed(function (): string {

--- a/front/scripts/main/components/TrendingArticlesComponent.ts
+++ b/front/scripts/main/components/TrendingArticlesComponent.ts
@@ -2,5 +2,5 @@
 'use strict';
 
 App.TrendingArticlesComponent = Em.Component.extend({
-	classNames: ['trending', 'trending-articles']
+	classNames: ['trending', 'trending-articles', 'mw-content']
 });

--- a/front/scripts/main/components/TrendingVideosComponent.ts
+++ b/front/scripts/main/components/TrendingVideosComponent.ts
@@ -2,7 +2,7 @@
 'use strict';
 
 App.TrendingVideosComponent = Em.Component.extend({
-	classNames: ['trending', 'trending-videos'],
+	classNames: ['trending', 'trending-videos', 'mw-content'],
 
 	actions: {
 		openLightbox(video: any): void {

--- a/front/scripts/main/components/WikiaStatsComponent.ts
+++ b/front/scripts/main/components/WikiaStatsComponent.ts
@@ -2,7 +2,7 @@
 'use strict';
 
 App.WikiaStatsComponent = Em.Component.extend({
-	classNames: ['wikia-stats'],
+	classNames: ['wikia-stats', ],
 	items: Em.computed('model', function (): any {
 		return [
 			{'label': 'app.pages-label', 'value': this.get('model.articles')},

--- a/front/scripts/main/components/WikiaStatsComponent.ts
+++ b/front/scripts/main/components/WikiaStatsComponent.ts
@@ -2,7 +2,7 @@
 'use strict';
 
 App.WikiaStatsComponent = Em.Component.extend({
-	classNames: ['wikia-stats', ],
+	classNames: ['wikia-stats'],
 	items: Em.computed('model', function (): any {
 		return [
 			{'label': 'app.pages-label', 'value': this.get('model.articles')},

--- a/front/scripts/main/mixins/FeaturedContentMixin.ts
+++ b/front/scripts/main/mixins/FeaturedContentMixin.ts
@@ -27,7 +27,7 @@ interface FeaturedContentItem {
 
 App.FeaturedContentMixin = Em.Mixin.create({
 	layoutName: 'components/featured-content',
-	classNames: ['featured-content'],
+	classNames: ['featured-content', 'mw-content'],
 	currentItemIndex: 0,
 
 	hasMultipleItems: Em.computed('model', function (): boolean {


### PR DESCRIPTION
add mw-content class to all modules on main page not main page itself so handleLink function won't handle link to main page on section and category view

JIRA ticket: https://wikia-inc.atlassian.net/browse/XW-461