### PR TITLE
fixing user name in top bar

### DIFF
--- a/front/scripts/main/components/UserStatusComponent.ts
+++ b/front/scripts/main/components/UserStatusComponent.ts
@@ -16,7 +16,7 @@ App.UserStatusComponent = Em.Component.extend({
 
 	userAvatarSrc: Em.computed.oneWay('currentUser.avatarPath'),
 
-	userName: Em.computed.oneWay('currentUser.avatarPath'),
+	userName: Em.computed.oneWay('currentUser.name'),
 
 	anonAvatarHref: Em.computed(function (): string {
 		if (Mercury.wiki.enableNewAuth) {


### PR DESCRIPTION
The alt attribute for the logged in user avatar will be the user's name now, rather than the avatar URL. 