### PR TITLE
INT-215: Revert Reuse tracking template from Mercury as shared templa…

### DIFF
--- a/homepage/server/index.js
+++ b/homepage/server/index.js
@@ -45,7 +45,7 @@ server.views({
 	},
 	path: path.resolve(__dirname, 'views'),
 	layoutPath: path.resolve(__dirname, 'views/_layouts'),
-	partialsPath: [path.join(__dirname, 'views/_partials'), path.join(__dirname, '../../server/views/_partials')],
+	partialsPath: path.join(__dirname, 'views/_partials'),
 	layout: 'default'
 });
 

--- a/homepage/server/views/_partials/tracking.hbs
+++ b/homepage/server/views/_partials/tracking.hbs
@@ -1,0 +1,20 @@
+<!-- Universal Analytics -->
+<script>
+	(function (i, s, o, g, r, a, m) {
+		i['GoogleAnalyticsObject'] = r; // Acts as a pointer to support renaming.
+		// Creates an initial ga() function.  The queued commands will be executed once analytics.js loads.
+		i[r] = i[r] || function () {
+			(i[r].q = i[r].q || []).push(arguments);
+		},
+		// Sets the time (as an integer) this tag was executed.  Used for timing hits.
+		i[r].l = 1 * new Date ();
+		// Insert the script tag asynchronously.  Inserts above current tag to prevent blocking in
+		// addition to using the async attribute.
+		a = s.createElement(o),
+		m = s.getElementsByTagName(o)[0];
+		a.async = 1;
+		a.src = g;
+		m.parentNode.insertBefore(a, m);
+	})(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga');
+</script>
+<!-- End Universal Analyitcs -->


### PR DESCRIPTION
…tes are not available after deployment.

Follow-up to https://github.com/Wikia/mercury/pull/1472.

It is not possible to re-use the templates because the homepage is run as a separate app and copied to its own location, which does not include the mercury templates.