### PR TITLE
INT-200: Fix for text getting cut off in featured communities on Japa…

### DIFF
--- a/homepage/bower.json
+++ b/homepage/bower.json
@@ -10,6 +10,7 @@
     "bourbon": "4.2.3",
     "neat": "1.7.2",
     "bitters": "1.0.0",
-    "slick.js": "1.5.6"
+    "slick.js": "1.5.6",
+    "jquery-bigtext": "~1.3.0"
   }
 }

--- a/homepage/front/scripts/main/main.ts
+++ b/homepage/front/scripts/main/main.ts
@@ -29,7 +29,9 @@ $(function() : void {
 		variableWidth: true
 	});
 
-	// Dynamically adjust text size to show community title without text break
+	// Dynamically adjust text size to show community title without text break.
+	// bigText adjusts the size programatically and strips off css padding, so it is
+	// necessary to add it in explicitly afterwards
 	var headings = $('.grid-heading');
 	headings.bigText({maximumFontSize: 20, verticalAlign: 'top'});
 	headings.css({padding: '.1rem'});

--- a/homepage/front/scripts/main/main.ts
+++ b/homepage/front/scripts/main/main.ts
@@ -5,7 +5,7 @@
 
 // bigText JQuery plugin
 interface JQuery {
-	bigText(options : any) : any;
+	bigText(options: any): any;
 }
 
 var parallaxWindow : JQuery = $('#js-parallax-window');
@@ -30,8 +30,9 @@ $(function() : void {
 	});
 
 	// Dynamically adjust text size to show community title without text break
-	$('.grid-heading').bigText({maximumFontSize: 20, verticalAlign: 'top'});
-	$('.grid-heading').css({padding: '.1rem'});
+	var headings = $('.grid-heading');
+	headings.bigText({maximumFontSize: 20, verticalAlign: 'top'});
+	headings.css({padding: '.1rem'});
 });
 
 function parallax() : void {

--- a/homepage/front/scripts/main/main.ts
+++ b/homepage/front/scripts/main/main.ts
@@ -3,6 +3,11 @@
 
 'use strict';
 
+// bigText JQuery plugin
+interface JQuery {
+	bigText(options : any) : any;
+}
+
 var parallaxWindow : JQuery = $('#js-parallax-window');
 
 $(function() : void {
@@ -23,6 +28,10 @@ $(function() : void {
 		centerMode: false,
 		variableWidth: true
 	});
+
+	// Dynamically adjust text size to show community title without text break
+	$('.grid-heading').bigText({maximumFontSize: 20, verticalAlign: 'top'});
+	$('.grid-heading').css({padding: '.1rem'});
 });
 
 function parallax() : void {

--- a/homepage/gulp/tasks/build-combined.js
+++ b/homepage/gulp/tasks/build-combined.js
@@ -10,7 +10,11 @@ var gulp = require('gulp'),
 	piper = require('../utils/piper');
 
 gulp.task('build-combined', ['scripts'], function () {
-	var src = ['front/js/main.js'];
+	var src = [
+		'vendor/jquery/dist/jquery.min.js',
+		'vendor/jquery-bigtext/jquery-bigtext.js',
+		'vendor/slick.js/slick/slick.min.js',
+		'front/js/main.js'];
 
 	if (!environment.isProduction) {
 		src.push('front/js/dev.js');

--- a/homepage/server/views/_layouts/default.hbs
+++ b/homepage/server/views/_layouts/default.hbs
@@ -12,8 +12,6 @@
 <body>
 {{{content}}}
 
-<script src="/vendor/jquery/dist/jquery.min.js"></script>
-<script src="/vendor/slick.js/slick/slick.min.js"></script>
 <script src="/globals.js"></script>
 <script src="/js/combined.js"></script>
 </body>

--- a/homepage/server/views/_partials/popular.hbs
+++ b/homepage/server/views/_partials/popular.hbs
@@ -4,7 +4,7 @@
       <a href="{{url}}" class="grid-item {{layout}} grid-item-image">
         <img src="{{imageLarge}}" alt="" class="grid-image-large">
         <img src="{{imageSmall}}" alt="" class="grid-image-small">
-        <h1>{{name}}</h1>
+        <h1 class="grid-heading">{{name}}</h1>
       </a>
     {{/each}}
   </div>


### PR DESCRIPTION
…n HP

Use bigText jquery plugin to dynamically adjust text size to make sure it is never cut off for featured communities.

Also refactored gulp build-combined task to include jquery, slick and bigText plugins in combined.js