### PR TITLE
INT-195: Styling for google custom search

### DIFF
--- a/front/styles/main/component/_search.scss
+++ b/front/styles/main/component/_search.scss
@@ -1,0 +1,9 @@
+
+// Hide top result options area for Google Custom Search
+.gsc-above-wrapper-area-container {
+	display: none;
+}
+
+.gsc-above-wrapper-area {
+	display: none;
+}

--- a/front/styles/main/component/_search.scss
+++ b/front/styles/main/component/_search.scss
@@ -1,9 +1,6 @@
 
 // Hide top result options area for Google Custom Search
-.gsc-above-wrapper-area-container {
-	display: none;
-}
-
+.gsc-above-wrapper-area-container
 .gsc-above-wrapper-area {
 	display: none;
 }

--- a/front/styles/main/component/index.scss
+++ b/front/styles/main/component/index.scss
@@ -20,6 +20,7 @@
 @import 'wikia-stats';
 @import 'user-menu';
 @import 'modal-dialog';
+@import 'search';
 @import 'sub-head';
 @import 'top-bar';
 @import 'user-status';


### PR DESCRIPTION
Google Custom Search renders google search results directly into the DOM.
This is just a simple style override to hide one of the elements on the results page.
