### PR TITLE
INT-195: Fix for incorrect variation number for Google Custom Search …

### DIFF
--- a/front/scripts/main/components/SideNavComponent.ts
+++ b/front/scripts/main/components/SideNavComponent.ts
@@ -59,7 +59,7 @@ App.SideNavComponent = Em.Component.extend({
 				},
 				variationNumber = Mercury.Utils.VariantTesting.getExperimentVariationNumber(experimentIds);
 
-			if (variationNumber === 2) {
+			if (variationNumber === 1) {
 				// Use Google Search
 				// Hide SideNav
 				this.sendAction('toggleVisibility', false);


### PR DESCRIPTION
…A/B test

Using variant numbers 0 and 1 rather than 1 and 2.
