### PR TITLE
Fixed scoping for table:not for article rendering

### DIFF
--- a/front/styles/main/module/article/_table.scss
+++ b/front/styles/main/module/article/_table.scss
@@ -1,5 +1,7 @@
-table:not(.infobox, .dirbox) {
-	visibility: hidden;
+.article-content {
+	table:not(.infobox, .dirbox) {
+		visibility: hidden;
+	}
 }
 
 .article-table-wrapper {


### PR DESCRIPTION
The original css was causing problems for google custom search rendering. Added .article-content to scope as suggested by @rogatty 