### PR TITLE
ADEN-2486 | Add Flite tag support for mercury

### DIFF
--- a/front/scripts/main/components/ArticleContentComponent.ts
+++ b/front/scripts/main/components/ArticleContentComponent.ts
@@ -239,6 +239,7 @@ App.ArticleContentComponent = Em.Component.extend(App.AdsMixin, App.PollDaddyMix
 				twitter: 'WidgetTwitterComponent',
 				vk: 'WidgetVKComponent',
 				polldaddy: 'WidgetPolldaddyComponent',
+				flite: 'WidgetFliteComponent',
 			};
 
 		if (componentNames.hasOwnProperty(widgetType) && Em.typeOf(App[componentNames[widgetType]]) === 'class') {

--- a/front/scripts/main/components/WidgetFliteComponent.ts
+++ b/front/scripts/main/components/WidgetFliteComponent.ts
@@ -1,0 +1,8 @@
+/// <reference path="../mixins/WidgetScriptStateMixin.ts" />
+'use strict';
+
+App.WidgetFliteComponent = Em.Component.extend(App.WidgetScriptStateMixin, {
+	classNames: ['widget-flite'],
+	layoutName: 'components/widget-flite',
+	data: null
+});

--- a/front/templates/main/components/widget-flite.hbs
+++ b/front/templates/main/components/widget-flite.hbs
@@ -1,0 +1,13 @@
+ <script>
+	(function() {
+		var o = window;
+		var guid="{{data.guid}}";
+
+		o.FLITE=o.FLITE || {};
+		o.FLITE.config = o.FLITE.config || {};
+		o.FLITE.config[guid] = o.FLITE.config[guid] || {};
+		o.FLITE.config[guid].ts = (+ new Date());
+	})();
+</script>
+<script src="//s.flite.com/syndication/combo.js" async="async" data-instance="{{data.guid}}" data-width="{{data.width}}" data-height="{{data.height}}"></script>
+<noscript><a style="text-decoration:none;display:block;border:0;" href="//r.flite.com/syndication/backuplink/i/{{data.guid}}?ct=" target="_blank"><img border="0" src="//r.flite.com/syndication/backupimage/i/{{data.guid}}?at=" /></a></noscript>


### PR DESCRIPTION
Make it possible to use `<flite>` tag in articles' content on mercury.

Related PR: https://github.com/Wikia/app/pull/8806