### PR TITLE
INT-217: Return front end globals for Japan HP via json file

### DIFF
--- a/homepage/bower.json
+++ b/homepage/bower.json
@@ -5,12 +5,13 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "wikia-style-guide": "Wikia/style-guide#1.0.1",
-    "jquery": "2.1.4",
-    "bourbon": "4.2.3",
-    "neat": "1.7.2",
     "bitters": "1.0.0",
+    "bourbon": "4.2.3",
+    "jquery": "2.1.4",
+    "jquery-bigtext": "~1.3.0",
+    "neat": "1.7.2",
+    "rsvp.js": "rsvp#~3.1.0",
     "slick.js": "1.5.6",
-    "jquery-bigtext": "~1.3.0"
+    "wikia-style-guide": "Wikia/style-guide#1.0.1"
   }
 }

--- a/homepage/front/scripts/main/globals.ts
+++ b/homepage/front/scripts/main/globals.ts
@@ -1,0 +1,29 @@
+/// <reference path="../../../../typings/jquery/jquery.d.ts" />
+/// <reference path="../../../../typings/rsvp/rsvp.d.ts" />
+
+'use strict';
+
+class Globals {
+	cachedData: any;
+	promise: RSVP.Promise;
+
+	constructor() {
+		this.cachedData = null;
+
+		this.promise = new RSVP.Promise((resolve, reject) : void => {
+			$.get( '/globals', (data) : void => {
+				this.cachedData = data;
+			});
+
+			resolve();
+		});
+	}
+
+	getLoginUrl() : string {
+		return this.cachedData ? this.cachedData.loginUrl : null;
+	}
+
+	getSignupUrl() : string {
+		return this.cachedData ? this.cachedData.signupUrl : null;
+	}
+}

--- a/homepage/front/scripts/main/main.ts
+++ b/homepage/front/scripts/main/main.ts
@@ -1,5 +1,6 @@
 /// <reference path="../../../../typings/jquery/jquery.d.ts" />
 /// <reference path="../../../../typings/slick/slick.d.ts" />
+/// <reference path="./globals.ts" />
 
 'use strict';
 
@@ -9,6 +10,8 @@ interface JQuery {
 }
 
 var parallaxWindow : JQuery = $('#js-parallax-window');
+
+var globals : Globals;
 
 $(function() : void {
 	if (parallaxWindow.length) {
@@ -35,6 +38,8 @@ $(function() : void {
 	var headings = $('.grid-heading');
 	headings.bigText({maximumFontSize: 20, verticalAlign: 'top'});
 	headings.css({padding: '.1rem'});
+
+	globals = new Globals();
 });
 
 function parallax() : void {
@@ -73,7 +78,7 @@ $('#loginIcon').click(function(event) : void {
 	if ($(document).width() < 710) {
 		$('#userInfoToggle').toggle();
 	} else {
-		window.location.href = getGlobals().loginUrl;
+		window.location.href = globals.getLoginUrl();
 	}
 
 	event.preventDefault();

--- a/homepage/gulp/tasks/build-combined.js
+++ b/homepage/gulp/tasks/build-combined.js
@@ -13,6 +13,7 @@ gulp.task('build-combined', ['scripts'], function () {
 	var src = [
 		'vendor/jquery/dist/jquery.min.js',
 		'vendor/jquery-bigtext/jquery-bigtext.js',
+		'vendor/rsvp.js/rsvp.min.js',
 		'vendor/slick.js/slick/slick.min.js',
 		'front/js/main.js'];
 

--- a/homepage/server/facets/globals.js
+++ b/homepage/server/facets/globals.js
@@ -7,15 +7,10 @@
 var util = require('../util');
 
 function globals(request, reply) {
-	var loginUrl = util.getLoginUrl(),
-		signupUrl = util.getSignupUrl(),
-		script = 'function getGlobals () {' +
-			'	return { ' +
-			'		loginUrl: \''  + loginUrl + '\', ' +
-			'		signupUrl: \'' + signupUrl + '\' ' +
-			'}}\n';
-
-	return reply(script);
+	return reply({
+		loginUrl: util.getLoginUrl(),
+		signupUrl: util.getSignupUrl()
+	});
 }
 
 module.exports = globals;

--- a/homepage/server/routes.js
+++ b/homepage/server/routes.js
@@ -44,7 +44,7 @@ exports.routes = [
 	},
 	{
 		method: 'GET',
-		path: '/globals.js',
+		path: '/globals',
 		handler: require('./facets/globals')
 	},
 	{

--- a/homepage/server/views/_layouts/default.hbs
+++ b/homepage/server/views/_layouts/default.hbs
@@ -12,6 +12,5 @@
 <body>
 {{{content}}}
 
-<script src="/globals.js"></script>
 <script src="/js/combined.js"></script>
 </body>

--- a/typings/rsvp/rsvp.d.ts
+++ b/typings/rsvp/rsvp.d.ts
@@ -1,0 +1,65 @@
+
+declare module RSVP {
+	interface PromiseResolve {
+		(value?: any): void;
+	}
+	interface PromiseReject {
+		(reason?: any): void;
+	}
+	interface PromiseResolverFunction {
+		(resolve: PromiseResolve, reject: PromiseReject): void;
+	}
+
+	class Promise {
+
+		/**
+		 Promise objects represent the eventual result of an asynchronous operation. The
+		 primary way of interacting with a promise is through its `then` method, which
+		 registers callbacks to receive either a promise's eventual value or the reason
+		 why the promise cannot be fulfilled.
+		 @class RSVP.Promise
+		 @param {function} resolver
+		 @param {String} label optional string for labeling the promise.
+		 Useful for tooling.
+		 @constructor
+		 */
+		constructor(resolver: PromiseResolverFunction, label?: string);
+
+		/**
+		 The primary way of interacting with a promise is through its `then` method,
+		 which registers callbacks to receive either a promise's eventual value or the
+		 reason why the promise cannot be fulfilled.
+		 @method then
+		 @param {Function} onFulfilled
+		 @param {Function} onRejected
+		 @param {String} label optional string for labeling the promise.
+		 Useful for tooling.
+		 @return {Promise}
+		 */
+		then(onFulfilled?: Function, onRejected?: Function): Promise;
+
+		/**
+		 `catch` is simply sugar for `then(undefined, onRejection)` which makes it the same
+		 as the catch block of a try/catch statement.
+
+		 @method catch
+		 @param {Function} onRejection
+		 @param {String} label optional string for labeling the promise.
+		 Useful for tooling.
+		 @return {Promise}
+		 */
+		catch(onRejection: Function, label?: string): Promise;
+
+		/**
+		 `finally` will be invoked regardless of the promise's fate just as native
+		 try/catch/finally behaves
+
+		 @method finally
+		 @param {Function} callback
+		 @param {String} label optional string for labeling the promise.
+		 Useful for tooling.
+		 @return {Promise}
+		 */
+		finally(callback: Function, label?: string): Promise;
+	}
+}


### PR DESCRIPTION
Refactoring of how globals are sent from backend to frontend.

Previously, this was done by generating a .js file with the globals embedded as variables.

With this change, the globals are returned as json retrieved via a promise and wrapped in a front end class.