### PR TITLE
GA tracking for google custom search

### DIFF
--- a/front/scripts/main/routes/SearchResultsRoute.ts
+++ b/front/scripts/main/routes/SearchResultsRoute.ts
@@ -9,6 +9,9 @@ App.SearchResultsRoute = Em.Route.extend({
 		this._super(controller, model, transition);
 		// Only search in current community
 		controller.set('site', window.location.hostname);
+
+		// Send extra tracking info to GA to track search usage
+		M.trackGoogleSearch(window.location.href + 'search?q=' + controller.q);
 	},
 
 	/*

--- a/front/scripts/mercury/modules/Trackers/UniversalAnalytics.ts
+++ b/front/scripts/mercury/modules/Trackers/UniversalAnalytics.ts
@@ -212,7 +212,9 @@ module Mercury.Modules.Trackers {
 
 		/**
 		 * Tracks usage of Google Custom Search
-		 * @param queryParam
+		 * 
+		 * @param {string} queryParam
+		 * @returns {undefined}
 		 */
 		trackGoogleSearch (queryParam: string): void {
 			this.tracked.forEach((account:GAAccount) => {

--- a/front/scripts/mercury/modules/Trackers/UniversalAnalytics.ts
+++ b/front/scripts/mercury/modules/Trackers/UniversalAnalytics.ts
@@ -209,5 +209,16 @@ module Mercury.Modules.Trackers {
 				ga(`${prefix}send`, 'pageview');
 			});
 		}
+
+		/**
+		 * Tracks usage of Google Custom Search
+		 * @param queryParam
+		 */
+		trackGoogleSearch (queryParam: string): void {
+			this.tracked.forEach((account:GAAccount) => {
+				var prefix = this.getPrefix(account);
+				ga(`${prefix}send`, 'pageview', queryParam);
+			});
+		}
 	}
 }

--- a/front/scripts/mercury/utils/track.ts
+++ b/front/scripts/mercury/utils/track.ts
@@ -34,6 +34,7 @@ interface TrackerInstance {
 	new(): TrackerInstance;
 	track: TrackFunction;
 	trackPageView: (context?: TrackContext) => void;
+	trackGoogleSearch: (queryParam: string) => void;
 	updateTrackedUrl: (url: string) => void;
 	usesAdsContext: boolean;
 }
@@ -180,6 +181,29 @@ module Mercury.Utils {
 				instance = new Tracker(isSpecialWiki());
 				console.info('Track pageView:', tracker);
 				instance.trackPageView(instance.usesAdsContext ? adsContext : context);
+			}
+		});
+	}
+
+	/**
+	 * Track usage of Google Custom Search
+	 * @param queryParam
+	 */
+	export function trackGoogleSearch (queryParam: string) {
+		var trackers: any = Mercury.Modules.Trackers;
+
+		if (M.prop('queryParams.noexternals')) {
+			return;
+		}
+
+		Object.keys(trackers).forEach((tracker: string): void => {
+			var Tracker = trackers[tracker],
+				instance: TrackerInstance;
+
+			if (typeof Tracker.prototype.trackGoogleSearch === 'function') {
+				instance = new Tracker(isSpecialWiki());
+				console.info('Track Google Search:', tracker);
+				instance.trackGoogleSearch(queryParam);
 			}
 		});
 	}

--- a/front/scripts/mercury/utils/track.ts
+++ b/front/scripts/mercury/utils/track.ts
@@ -187,7 +187,9 @@ module Mercury.Utils {
 
 	/**
 	 * Track usage of Google Custom Search
-	 * @param queryParam
+	 *
+	 * @param {string} queryParam
+	 * @returns {undefined}
 	 */
 	export function trackGoogleSearch (queryParam: string) {
 		var trackers: any = Mercury.Modules.Trackers;


### PR DESCRIPTION
We are doing an A/B test for Google Custom Search on Japanese wikias.

We want to track this using the Site Search panel in GA, and this requires that we send an extra pageview impression to GA, which I add in the PR.

Documentation here: 
https://support.google.com/analytics/answer/1012264?hl=en
