### PR TITLE
ADEN-2569 Fix krux implementation

### DIFF
--- a/front/scripts/mercury/modules/Ads.ts
+++ b/front/scripts/mercury/modules/Ads.ts
@@ -31,6 +31,7 @@ module Mercury.Modules {
 		private adMercuryListenerModule: {
 			startOnLoadQueue(): void;
 		};
+		private kruxTracker: Mercury.Modules.Trackers.Krux = null;
 		private currentAdsContext: any = null;
 		private isLoaded = false;
 		private slotsQueue: string[][] = [];
@@ -80,7 +81,7 @@ module Mercury.Modules {
 						this.adConfigMobile = adConfigMobile;
 						this.adLogicPageViewCounterModule = adLogicPageViewCounterModule;
 						this.adMercuryListenerModule = adMercuryListener;
-						window.Krux = krux || [];
+						this.kruxTracker = new Mercury.Modules.Trackers.Krux(krux);
 						this.isLoaded = true;
 						this.addDetectionListeners();
 						this.reloadWhenReady();
@@ -109,14 +110,13 @@ module Mercury.Modules {
 		}
 
 		/**
-		 * Function fired when Krux is ready (see init()).
-		 * Calls the trackPageView() function on Krux instance.
+		 * Function fired when this.kruxTracker is ready (see init()).
+		 * Calls the trackPageView() function on krux tracker.
 		 * load() in krux.js (/app) automatically detect that
 		 * there is a first page load (needs to load Krux scripts).
 		 */
 		private kruxTrackFirstPage (): void {
-			var KruxTracker = new Mercury.Modules.Trackers.Krux();
-			KruxTracker.trackPageView();
+			this.kruxTracker.trackPageView();
 		}
 
 		private trackBlocking (value: string): void {

--- a/front/scripts/mercury/modules/Trackers/Krux.ts
+++ b/front/scripts/mercury/modules/Trackers/Krux.ts
@@ -1,16 +1,13 @@
 'use strict';
 
-interface Window {
-	Krux: {
-		load?: (skinSiteId: string) => void;
-	};
-}
-
 module Mercury.Modules.Trackers {
 	export class Krux {
+		private kruxModule: {
+			load?: (skinSiteId: string) => void;
+		};
 
-		constructor () {
-			window.Krux = window.Krux || [];
+		constructor (krux: any) {
+			this.kruxModule = krux || {};
 		}
 
 		/**
@@ -19,8 +16,8 @@ module Mercury.Modules.Trackers {
 		* (see ads_run.js and krux.js in app repository)
 		*/
 		trackPageView (): void {
-			if (typeof window.Krux.load === 'function') {
-				window.Krux.load(M.prop('tracking.krux.mobileId'));
+			if (typeof this.kruxModule.load === 'function') {
+				this.kruxModule.load(M.prop('tracking.krux.mobileId'));
 			}
 		}
 	}


### PR DESCRIPTION
Those changes should prevent occurring error in console `Krux is not a function` - issue connected with SP detection on mobile.

Details:
Previously `window.Krux` object was used only to load krux module from `Mercury.Modules.Trackers.Krux` (kind of temporary variable?). But `window.Kurx` is a queue-function ([in app code](https://github.com/Wikia/app/blob/dev/resources/wikia/modules/krux.js#L2)) and previous implementation causes an issue when response from krux is relatively slow. 