### PR TITLE
INT-231: Remove some links from Japan HP footer in mobile view

### DIFF
--- a/homepage/front/styles/component/_footer.scss
+++ b/homepage/front/styles/component/_footer.scss
@@ -30,6 +30,12 @@
 		}
 	}
 
+	.footer-link-desktop {
+		@include media($mobile) {
+			display: none;
+		}
+	}
+
 	ul {
 		margin-bottom: $base-spacing * 2;
 		padding: 0;

--- a/homepage/server/views/_partials/footer.hbs
+++ b/homepage/server/views/_partials/footer.hbs
@@ -11,11 +11,11 @@
     <ul>
       <li><h3>Community</h3></li>
       <li><a href="http://ja.community.wikia.com/wiki/%E3%83%A1%E3%82%A4%E3%83%B3%E3%83%9A%E3%83%BC%E3%82%B8">コミュニティセントラル</a></li>
-      <li><a href="http://ja.wikia.com/WAM">WAM スコア</a></li>
-      <li><a href="http://ja.community.wikia.com/wiki/%E3%83%96%E3%83%AD%E3%82%B0%3A%E3%82%A6%E3%82%A3%E3%82%AD%E3%82%A2%E3%82%B9%E3%82%BF%E3%83%83%E3%83%95%E3%83%96%E3%83%AD%E3%82%B0
+      <li class="footer-link-desktop"><a href="http://ja.wikia.com/WAM">WAM スコア</a></li>
+      <li class="footer-link-desktop"><a href="http://ja.community.wikia.com/wiki/%E3%83%96%E3%83%AD%E3%82%B0%3A%E3%82%A6%E3%82%A3%E3%82%AD%E3%82%A2%E3%82%B9%E3%82%BF%E3%83%83%E3%83%95%E3%83%96%E3%83%AD%E3%82%B0
 ">スタッフブログ</a></li>
-      <li><a href="http://ja.community.wikia.com/wiki/%E3%83%98%E3%83%AB%E3%83%97%3A%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E3%82%A2%E3%82%AF%E3%82%BB%E3%82%B9%E3%83%AC%E3%83%99%E3%83%AB">設立者＆管理者</a></li>
-      <li><a href="http://ja.community.wikia.com/wiki/%E3%83%98%E3%83%AB%E3%83%97%3A%E3%82%B3%E3%83%B3%E3%83%86%E3%83%B3%E3%83%84">ヘルプ</a></li>
+      <li class="footer-link-desktop"><a href="http://ja.community.wikia.com/wiki/%E3%83%98%E3%83%AB%E3%83%97%3A%E3%83%A6%E3%83%BC%E3%82%B6%E3%83%BC%E3%82%A2%E3%82%AF%E3%82%BB%E3%82%B9%E3%83%AC%E3%83%99%E3%83%AB">設立者＆管理者</a></li>
+      <li class="footer-link-desktop"><a href="http://ja.community.wikia.com/wiki/%E3%83%98%E3%83%AB%E3%83%97%3A%E3%82%B3%E3%83%B3%E3%83%86%E3%83%B3%E3%83%84">ヘルプ</a></li>
       <li><a href="http://ja.live.wikia.com/wiki/Wikia_Live">ウィキア Live</a></li>
       <li><a href="https://twitter.com/wikiaJapan">Twitter</a></li>
     </ul>


### PR DESCRIPTION
Some of the links in Japan HP footer do not work on mobile, and should only show in desktop mode.