### PR TITLE
Maintenance | Removing console warnings trigger from discussion code

### DIFF
--- a/server/facets/showApplication.ts
+++ b/server/facets/showApplication.ts
@@ -3,6 +3,13 @@
 /// <reference path='../lib/OpenGraph.ts' />
 /// <reference path="../../typings/hapi/hapi.d.ts" />
 
+/**
+ * CommunityAppConfig
+ * @typedef {Object} CommunityAppConfig
+ * @property {string} androidAppLink
+ * @property {string} iosAppLink
+ */
+
 import MW = require('../lib/MediaWiki');
 import Utils = require('../lib/Utils');
 import Tracking = require('../lib/Tracking');
@@ -58,7 +65,7 @@ function outputResponse (request: Hapi.Request, reply: Hapi.Response, context: a
 
 /**
  * @param {string} hostName
- * @returns {*}
+ * @returns {CommunityAppConfig}
  */
 function getDistilledDiscussionsSplashPageConfig(hostName: string): Object {
 	var mainConfig = discussionsSplashPageConfig[hostName];

--- a/server/facets/showApplication.ts
+++ b/server/facets/showApplication.ts
@@ -56,13 +56,19 @@ function outputResponse (request: Hapi.Request, reply: Hapi.Response, context: a
 	reply.view('application', context);
 }
 
+/**
+ * @param {string} hostName
+ * @returns {*}
+ */
 function getDistilledDiscussionsSplashPageConfig(hostName: string): Object {
-	var distilledConfig = {};
-	if (discussionsSplashPageConfig[hostName]) {
-		distilledConfig['androidAppLink'] = discussionsSplashPageConfig[hostName].androidAppLink;
-		distilledConfig['iosAppLink'] = discussionsSplashPageConfig[hostName].iosAppLink;
+	var mainConfig = discussionsSplashPageConfig[hostName];
+	if (mainConfig) {
+		return {
+			androidAppLink: mainConfig.androidAppLink,
+			iosAppLink: mainConfig.iosAppLink,
+		};
 	}
-	return distilledConfig;
+	return {};
 }
 
 export = showApplication;


### PR DESCRIPTION
Seems like this code was triggering tslint's "no-object-literal" rule to be broken.