### PR TITLE
INT-245: Workaround for broken z-index in Safari

### DIFF
--- a/homepage/front/styles/app.scss
+++ b/homepage/front/styles/app.scss
@@ -43,6 +43,7 @@ section {
 	margin-bottom: 3em;
 	padding-left: 3em;
 	padding-right: 3em;
+	-webkit-transform: translate3d(0,0,0); // workaround for broken z-index in safari
 
 	@include media($mobile) {
 		padding-left: .1em;

--- a/homepage/front/styles/app.scss
+++ b/homepage/front/styles/app.scss
@@ -43,7 +43,8 @@ section {
 	margin-bottom: 3em;
 	padding-left: 3em;
 	padding-right: 3em;
-	-webkit-transform: translate3d(0,0,0); // workaround for broken z-index in safari
+	// workaround for broken z-index in safari
+	transform: translate3d(0, 0, 0);
 
 	@include media($mobile) {
 		padding-left: .1em;


### PR DESCRIPTION
This is a workaround for what appears to be a bug in Safari related to z-order.

See screenshot here:
https://wikia-inc.atlassian.net/browse/INT-245
