### PR TITLE
Share Feature | Trigger this.attrs handlers only if they exist

### DIFF
--- a/front/scripts/main/components/ShareFeatureComponent.ts
+++ b/front/scripts/main/components/ShareFeatureComponent.ts
@@ -42,14 +42,18 @@ App.ShareFeatureComponent = Em.Component.extend(
 		 * @returns {undefined}
 		 */
 		mouseEnter(): void {
-			this.attrs.onMouseEnter();
+			if (this.attrs && typeof this.attrs.onMouseEnter === 'function') {
+				this.attrs.onMouseEnter();
+			}
 		},
 
 		/**
 		 * @returns {undefined}
 		 */
 		mouseLeave(): void {
-			this.attrs.onMouseLeave();
+			if (this.attrs && typeof this.attrs.onMouseLeave === 'function') {
+				this.attrs.onMouseLeave();
+			}
 		},
 	}
 );


### PR DESCRIPTION
Since the functionality was not broken, it was just throwing after opening a social network share url, this should be enough to prevent it.

@hakubo @rogatty @Warkot 