### PR TITLE
SOC-1552 | Can't upvote post that are lazy-loader

### DIFF
--- a/front/scripts/main/models/DiscussionForumModel.ts
+++ b/front/scripts/main/models/DiscussionForumModel.ts
@@ -23,6 +23,9 @@ App.DiscussionForumModel = Em.Object.extend(App.DiscussionErrorMixin, {
 				data: {
 					page: pageNum
 				},
+				xhrFields: {
+					withCredentials: true,
+				},
 				dataType: 'json',
 				success: (data: any) => {
 					var newPosts = data._embedded['doc:threads'],

--- a/front/scripts/main/models/DiscussionPostModel.ts
+++ b/front/scripts/main/models/DiscussionPostModel.ts
@@ -31,6 +31,9 @@ App.DiscussionPostModel = Em.Object.extend(App.DiscussionErrorMixin, {
 						'pivot': this.pivotId,
 						'page': this.page+1
 					}),
+				xhrFields: {
+					withCredentials: true,
+				},
 				dataType: 'json',
 				success: (data: any) => {
 					var newReplies = data._embedded['doc:posts'];


### PR DESCRIPTION
After scrolling down, older posts are loaded. When trying to upvote loaded posts, nothing happen.
https://wikia-inc.atlassian.net/browse/SOC-1552

Fix is simple: I've added credentials to the loadPage request - after that server sends us all needed data for the upvoting.