### PR TITLE
Don't include domain name for google search tracking

### DIFF
--- a/front/scripts/main/routes/SearchResultsRoute.ts
+++ b/front/scripts/main/routes/SearchResultsRoute.ts
@@ -17,7 +17,7 @@ App.SearchResultsRoute = Em.Route.extend({
 		controller.set('site', window.location.hostname);
 
 		// Send extra tracking info to GA to track search usage
-		M.trackGoogleSearch(window.location.href + 'search?q=' + controller.q);
+		M.trackGoogleSearch(`${window.location.pathname}/search?q=${controller.q}`);
 	},
 
 	/**


### PR DESCRIPTION
The extra pageview impression when performing google custom search to track search should only include the path and not the domain.