### PR TITLE
mediawikiDomain change

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 * `tsd update` will update typings folder with ambient files
 * Copy `config/localSettings.example.ts` to your own copy of `localSettings.ts` and set the `port` and `devboxDomain`.
   * The devboxDomain must have your devbox name (without the dev- prefix) in it.
-  * If you want to test with consul, add `mediawikiDomain: 'mediawiki.service.consul'` to your localSettings
+  * If you want to test with consul, add `mediawikiDomain: 'icache.service.sjc.consul'` to your localSettings
   * If you want to see debug output add `loggers: { console: 'debug' }` to your localSettings
 
     File should look something like this:


### PR DESCRIPTION
mediawikiDomain was outdated, changed to icache.service.sjc.consul