### PR TITLE
XW-716 | Setup UA account only once

### DIFF
--- a/front/scripts/mercury/modules/Trackers/UniversalAnalytics.js
+++ b/front/scripts/mercury/modules/Trackers/UniversalAnalytics.js
@@ -135,9 +135,10 @@ class UniversalAnalytics {
 	 * We create new tracker instance every time mercury/utils/track #track or #trackPageView is called
 	 * Google wants us to call methods below just once per account
 	 *
-	 * @param id
-	 * @param prefix
-	 * @param options
+	 * @param {string} id
+	 * @param {string} prefix
+	 * @param {Object} options
+	 * @returns {void}
 	 */
 	static setupAccountOnce(id, prefix, options) {
 		if (!UniversalAnalytics.createdAccounts.contains(id)) {

--- a/front/scripts/mercury/modules/Trackers/UniversalAnalytics.js
+++ b/front/scripts/mercury/modules/Trackers/UniversalAnalytics.js
@@ -1,4 +1,3 @@
-
 /**
  * @typedef {Object} TrackerOptions
  * @property {string} name
@@ -56,7 +55,6 @@ class UniversalAnalytics {
 		this.accounts = M.prop('tracking.ua');
 
 		this.initAccount(this.accountPrimary, domain);
-
 		this.initAccount(this.accountAds, domain);
 
 		if (isSpecialWiki) {
@@ -121,9 +119,7 @@ class UniversalAnalytics {
 			options.name = trackerPrefix;
 		}
 
-		ga('create', this.accounts[trackerName].id, 'auto', options);
-
-		ga(`${prefix}require`, 'linker');
+		UniversalAnalytics.setupAccountOnce(this.accounts[trackerName].id, prefix, options);
 
 		if (domain) {
 			ga(`${prefix}linker:autoLink`, domain);
@@ -133,6 +129,23 @@ class UniversalAnalytics {
 			ga(`${prefix}set`, `dimension${idx}`, UniversalAnalytics.getDimension(idx)));
 
 		this.tracked.push(this.accounts[trackerName]);
+	}
+
+	/**
+	 * We create new tracker instance every time mercury/utils/track #track or #trackPageView is called
+	 * Google wants us to call methods below just once per account
+	 *
+	 * @param id
+	 * @param prefix
+	 * @param options
+	 */
+	static setupAccountOnce(id, prefix, options) {
+		if (!UniversalAnalytics.createdAccounts.contains(id)) {
+			ga('create', id, 'auto', options);
+			ga(`${prefix}require`, 'linker');
+
+			UniversalAnalytics.createdAccounts.push(id);
+		}
 	}
 
 	/**
@@ -261,4 +274,6 @@ class UniversalAnalytics {
 }
 
 UniversalAnalytics.dimensions = [];
+UniversalAnalytics.createdAccounts = [];
+
 export default UniversalAnalytics;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-716

We create new tracker instance every time `mercury/utils/track`'s `track()` or `trackPageView()` is called.
Google wants us to call some methods just once per account.

We should rethink this whole concept but it's out of this ticket's scope.