### PR TITLE
XW-812 Use indexOf instead of contains

### DIFF
--- a/front/scripts/mercury/modules/Trackers/UniversalAnalytics.js
+++ b/front/scripts/mercury/modules/Trackers/UniversalAnalytics.js
@@ -141,7 +141,7 @@ class UniversalAnalytics {
 	 * @returns {void}
 	 */
 	static setupAccountOnce(id, prefix, options) {
-		if (!UniversalAnalytics.createdAccounts.contains(id)) {
+		if (UniversalAnalytics.createdAccounts.indexOf(id) === -1) {
 			ga('create', id, 'auto', options);
 			ga(`${prefix}require`, 'linker');
 


### PR DESCRIPTION
It works when Ember is loaded (it extends array prototype, see http://guides.emberjs.com/v1.10.0/configuring-ember/disabling-prototype-extensions/) but it doesn't on auth pages. Let's drop the fanciness for now.