### PR TITLE
ADEN-2707 | Added window.wgNow - adTracker dependency

### DIFF
--- a/server/views/_layouts/ember-main.hbs
+++ b/server/views/_layouts/ember-main.hbs
@@ -34,6 +34,7 @@
 
 		<style><!-- @include ../../../www/front/styles/main/baseline.css --></style>
 
+		<script>var wgNow = new Date();</script>
 		{{> nirvana }}
 		<script>
 			<!-- @include ../../../www/front/scripts/baseline.js -->

--- a/server/views/_layouts/ember-main.hbs
+++ b/server/views/_layouts/ember-main.hbs
@@ -34,7 +34,6 @@
 
 		<style><!-- @include ../../../www/front/styles/main/baseline.css --></style>
 
-		<script>var wgNow = new Date();</script>
 		{{> nirvana }}
 		<script>
 			<!-- @include ../../../www/front/scripts/baseline.js -->

--- a/server/views/_partials/nirvana.hbs
+++ b/server/views/_partials/nirvana.hbs
@@ -3,4 +3,5 @@
 	Wikia = {};
 	// initialize objects needed for AdEngine
 	mw = { loader: { state: function() {} } };
+	wgNow = new Date();
 </script>


### PR DESCRIPTION
In order to make `ext.wikia.adEngine.adTracker` work properly we need to add `window.wgNow` with date when page was initialised (like it's on oasis).

https://wikia-inc.atlassian.net/browse/ADEN-2707