### PR TITLE
INT-248: Global rollout of section editor

### DIFF
--- a/front/scripts/main/components/article-wrapper.js
+++ b/front/scripts/main/components/article-wrapper.js
@@ -72,36 +72,16 @@ export default App.ArticleWrapperComponent = Ember.Component.extend(
 
 		/**
 		 * Checks if contribution component should be enabled
-		 * http://clashofclans.wikia.com/        db: clashofclans
-		 * http://de.clashofclans.wikia.com/     db: declashofclans
-		 * http://zh.clashofclans.wikia.com/     db: zhclashofclans723
-		 * http://fr.clashofclans.wikia.com/     db: frclashofclans
-		 * http://ru.clashofclans.wikia.com/     db: ruclashofclans
-		 * http://es.clash-of-clans.wikia.com/   db: esclashofclans727
-		 * http://pt-br.clashofclans.wikia.com/  db: ptbrclashofclans
 		 *
 		 * @returns {boolean} True if contribution component is enabled for this community
 		 */
 		contributionEnabledForCommunity: Ember.computed(function () {
-			const dbName = Ember.get(Mercury, 'wiki.dbName'),
-				disableMobileSectionEditor = Ember.getWithDefault(Mercury, 'wiki.disableMobileSectionEditor', false),
-				enabledCommunities = [
-					'clashofclans', 'declashofclans', 'zhclashofclans723', 'frclashofclans',
-					'ruclashofclans', 'esclashofclans727', 'ptbrclashofclans'
-				];
-
-			if (disableMobileSectionEditor) {
+			if (Ember.getWithDefault(Mercury, 'wiki.disableMobileSectionEditor', false)) {
 				// When disableMobileSectionEditor is set to true, no contribution tools should show up
 				return false;
-			} else if (this.getWithDefault('isJapaneseWikia', false)) {
-				// Enabled for all Japanese wikias unless disableMobileSectionEditor is set
-				return true;
-			} else if (enabledCommunities.indexOf(dbName) > -1) {
-				// Otherwise check against whitelist
-				return true;
 			}
 
-			return false;
+			return true;
 		}),
 
 		/**

--- a/test/specs/front/scripts/main/components/article-wrapper.js
+++ b/test/specs/front/scripts/main/components/article-wrapper.js
@@ -115,7 +115,7 @@ test('contribution disabled when disableMobileSectionEditor is set', function ()
 	}, 'contributionEnabled');
 });
 
-test('contribution enabled on whitelisted non-Japanese page', function () {
+test('contribution enabled on non-Japanese page 1', function () {
 	contributionTestHelper(this, {
 		isMainPage: false,
 		isJapaneseWikia: false,
@@ -125,13 +125,13 @@ test('contribution enabled on whitelisted non-Japanese page', function () {
 	}, 'contributionEnabled');
 });
 
-test('contribution disabled on non-whitelisted non-Japanese page', function () {
+test('contribution enabled on non-Japanese page 2', function () {
 	contributionTestHelper(this, {
 		isMainPage: false,
 		isJapaneseWikia: false,
 		disableMobileSectionEditor: false,
 		dbName: 'starwars',
-		expected: false
+		expected: true
 	}, 'contributionEnabled');
 });
 


### PR DESCRIPTION
This PR enables the Mercury section editor globally.
It simply removes the whitelist check in place now: All communities will have section editor enabled unless wiki.disableMobileSectionEditor is set to true.

No other rule changes.