### PR TITLE
pre-git installation as dev-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "pre-git": {
       "commit-msg": "validate-commit-msg",
       "pre-commit": [
+        "npm run linter",
         "npm run test-front",
         "npm run test-server"
       ],

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
   },
   "config": {
     "pre-git": {
-      "commit-msg": "validate-commit-msg",
       "pre-commit": [
         "npm run linter",
         "npm run test-front",
@@ -95,7 +94,8 @@
       ],
       "post-commit": [],
       "post-merge": [
-        "npm update"
+        "npm update",
+        "bower update"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "linter": "eslint .",
     "build": "rm -rf www && gulp build --type prod --nosync",
     "build-coverage": "rm -rf www && gulp build --nosync --testing",
-    "build-test": "rm -rf www && gulp build --type prod --nosync --testing"
+    "build-test": "rm -rf www && gulp build --type prod --nosync --testing",
+    "commit": "commit-wizard"
   },
   "repository": "git://github.com/Wikia/mercury.git",
   "license": "MIT",
@@ -75,9 +76,26 @@
     "karma-phantomjs-launcher": "0.x.x",
     "karma-qunit": "0.x.x",
     "multipipe": "^0.1.2",
+    "pre-git": "^2.0.1",
     "qunit": "0.x.x",
     "qunitjs": "1.20.0",
     "systemjs-builder": "^0.14.11",
     "through2": "^0.6.3"
+  },
+  "config": {
+    "pre-git": {
+      "commit-msg": "validate-commit-msg",
+      "pre-commit": [
+        "npm run test-front",
+        "npm run test-server"
+      ],
+      "pre-push": [
+        "npm run test"
+      ],
+      "post-commit": [],
+      "post-merge": [
+        "npm update"
+      ]
+    }
   }
 }


### PR DESCRIPTION
You can see documentation here: https://www.npmjs.com/package/pre-git

For now I have disabled commitizen, but that could nicely enforce commit messages like
`XW-XXX | message with ease`

This way we can be sure'er that our code is more stable.

@Wikia/x-wing @kvas-damian @mari-mcmurtrie what do you think?