### PR TITLE
INT-286 | Adding a missing template file so that wikia-in-your-lang pop up works

### DIFF
--- a/front/templates/main/components/wikia-in-your-lang.hbs
+++ b/front/templates/main/components/wikia-in-your-lang.hbs
@@ -1,0 +1,2 @@
+{{alert-notifications alerts=alertNotifications}}
+


### PR DESCRIPTION
Current Wikia-in-your-lang is not working on Mercury because of this missing template file. We want to release the fix asap. The fix was originally implemented as a part of https://github.com/Wikia/mercury/pull/1730 (INT-183) but I separate a release so this alone can go out asap. 