### PR TITLE
XW | Environment Fix

### DIFF
--- a/server/lib/Utils.js
+++ b/server/lib/Utils.js
@@ -267,7 +267,7 @@ export function shouldAsyncArticle(localSettings, host) {
  */
 export function createServerData(localSettings, wikiDomain = '') {
 	// if no environment, pass dev
-	const env = typeof localSettings.environment === 'number' ? localSettings.environment : Environment.Dev,
+	const env = localSettings.environment || Environment.Dev,
 		data = {
 			mediawikiDomain: getWikiDomainName(localSettings, wikiDomain),
 			apiBase: localSettings.apiBase,


### PR DESCRIPTION
Correct environment value returned on sandbox
```
>>> M.prop('environment');
>>> "sandbox"
```

@rogatty @vforge 