### PR TITLE
XW | change systemjs/builder version to 0.14.11

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "multipipe": "^0.1.2",
     "qunit": "0.x.x",
     "qunitjs": "1.20.0",
-    "systemjs-builder": "^0.14.11",
+    "systemjs-builder": "0.14.11",
     "through2": "^0.6.3"
   }
 }


### PR DESCRIPTION
Fixing this issue - https://github.com/systemjs/builder/issues/386 - broke our code.
It changed order of loading our dependencies (app was loaded after model/user.js and CurrentUser, instead being loaded before them)