### PR TITLE
SOC- remove crumb

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "bunyan-syslog": "^0.3.0",
     "bunyan-prettystream": "^0.1.3",
     "deep-extend": "^0.3.2",
-    "crumb": "4.0.3",
     "handlebars": "2.0.0",
     "hapi": "8.4.0",
     "hapi-i18next": "2.2.0",

--- a/server/app.js
+++ b/server/app.js
@@ -9,7 +9,6 @@ import {routes} from './routes';
 import path from 'path';
 import url from 'url';
 import fs from 'fs';
-import crumb from 'crumb';
 import i18next from 'hapi-i18next';
 import handlebars from 'handlebars';
 
@@ -165,14 +164,6 @@ function getSupportedLangs() {
 }
 
 plugins = [
-	{
-		register: crumb,
-		options: {
-			cookieOptions: {
-				isSecure: false
-			}
-		}
-	},
 	{
 		register: i18next,
 		options: {

--- a/server/app.js
+++ b/server/app.js
@@ -67,7 +67,10 @@ function getOnPreResponseHandler(isDevbox) {
 		if (response && response.header) {
 			response.header('x-backend-response-time', responseTimeSec);
 			response.header('x-served-by', servedBy);
-			response.vary('cookie');
+
+			if (response.variety !== 'file') {
+				response.vary('cookie');
+			}
 		} else if (response.isBoom) {
 			// see https://github.com/hapijs/boom
 			response.output.headers['x-backend-response-time'] = responseTimeSec;

--- a/server/facets/operations/generateCSRFView.js
+++ b/server/facets/operations/generateCSRFView.js
@@ -1,8 +1,0 @@
-/**
- * @param {Hapi.Request} request
- * @param {*} reply
- * @returns {void}
- */
-export default function generateCSRFView(request, reply) {
-	reply.view('breadcrumb', null, {layout: 'empty'});
-}

--- a/server/routes.js
+++ b/server/routes.js
@@ -14,7 +14,6 @@ import searchHandler from './facets/api/search';
 import mainPageSectionHandler from './facets/api/mainPageSection';
 import mainPageCategoryHandler from './facets/api/mainPageCategory';
 import logoutHandler from './facets/auth/logout';
-import generateCSRFView from './facets/operations/generateCSRFView';
 import editorPreview from './facets/editorPreview';
 import joinHandler from './facets/auth/join';
 import {validateRedirect} from './facets/auth/authView';
@@ -120,11 +119,6 @@ let routes,
 			method: 'GET',
 			path: '/logout',
 			handler: logoutHandler
-		},
-		{
-			method: 'GET',
-			path: '/breadcrumb',
-			handler: generateCSRFView
 		},
 		{
 			method: 'POST',

--- a/server/views/breadcrumb.hbs
+++ b/server/views/breadcrumb.hbs
@@ -1,1 +1,0 @@
-<input id="iframeCrumb" type="hidden" value="{{crumb}}">


### PR DESCRIPTION
For better caching let's remove crumb CSRF protection.

We shouldn't pass CSRF tokens in cookies because:
* we break caching assets - ```Vary: cookie```
* users can't use application in many tabs at once

To solve that we should use hidden input in forms.
