### PR TITLE
INT-303: Add condition to retrieve avatar url from user attribute to …

### DIFF
--- a/homepage/server/util.js
+++ b/homepage/server/util.js
@@ -92,7 +92,7 @@ exports.renderWithGlobalData = function (request, reply, data, view) {
 
 		return auth.getUserAvatar(userId);
 	}).then(function (data) {
-		avatarUrl = (data.value === undefined) ? defaultLoggedInAvatarUrl : data.value;
+		avatarUrl = (data.value === undefined || data.value == false) ? defaultLoggedInAvatarUrl : data.value;
 		request.log('info', 'Retrieved avatar url for logged in user: ' + avatarUrl);
 
 		renderView(true, userName, avatarUrl);

--- a/homepage/server/util.js
+++ b/homepage/server/util.js
@@ -92,7 +92,7 @@ exports.renderWithGlobalData = function (request, reply, data, view) {
 
 		return auth.getUserAvatar(userId);
 	}).then(function (data) {
-		avatarUrl = (data.value === undefined || data.value == false) ? defaultLoggedInAvatarUrl : data.value;
+		avatarUrl = data.value || defaultLoggedInAvatarUrl;
 		request.log('info', 'Retrieved avatar url for logged in user: ' + avatarUrl);
 
 		renderView(true, userName, avatarUrl);


### PR DESCRIPTION
…cover when a value is empty string.
"Avatar" data in user-attribute response can be 3 ways:
https://services.wikia.com/user-attribute/user/1111111 (1111111 is your user id).
1. No "avatar" field
2. "avatar" field but its data value is empty ("").
3. "avatar" field is there and data value is there ("http://static.wikia.nocookie.net/20fa2272-b213-4351-9d81-cf9fa3acb3dd")
If the case is num.1 or num.2, then we have to supply default avatar url. This task covers case num2.