### PR TITLE
INT-277 | Rename logout handler to signout

### DIFF
--- a/homepage/server/facets/signout.js
+++ b/homepage/server/facets/signout.js
@@ -4,9 +4,9 @@
  * @author Per Johan Groland <pgroland@wikia-inc.com>
  */
 
-function logout(request, reply) {
+function signout(request, reply) {
 	reply.unstate('access_token');
 	reply.redirect('/');
 }
 
-module.exports = logout;
+module.exports = signout;

--- a/homepage/server/routes.js
+++ b/homepage/server/routes.js
@@ -29,8 +29,8 @@ exports.routes = [
 	},
 	{
 		method: 'GET',
-		path: '/logout',
-		handler: require('./facets/logout')
+		path: '/signout',
+		handler: require('./facets/signout')
 	},
 	{
 		method: 'GET',

--- a/homepage/server/routes.js
+++ b/homepage/server/routes.js
@@ -29,6 +29,11 @@ exports.routes = [
 	},
 	{
 		method: 'GET',
+		path: '/logout',
+		handler: require('./facets/signout')
+	},
+	{
+		method: 'GET',
 		path: '/signout',
 		handler: require('./facets/signout')
 	},

--- a/homepage/server/views/_partials/userinfo.hbs
+++ b/homepage/server/views/_partials/userinfo.hbs
@@ -20,7 +20,7 @@
     </a>
   </li>
   <li class="user-info-item">
-    <a href="/logout">
+    <a href="/signout">
       {{logout}}
     </a>
   </li>


### PR DESCRIPTION
To work around the fact that the /logout route has special handling globally, change the logout for Japan HP to /signout instead.

Note that INT-299 depends on this fix, so right now if you log out it will redirect to / but will still show your status as logged in.
