### PR TITLE
INT-299 | Invalidate cache when signing out

### DIFF
--- a/homepage/server/facets/signout.js
+++ b/homepage/server/facets/signout.js
@@ -6,6 +6,11 @@
 
 function signout(request, reply) {
 	reply.unstate('access_token');
+
+	if (request.response) {
+		// Make sure to invalidate cache
+		request.response.vary('cookie');
+	}
 	reply.redirect('/');
 }
 

--- a/homepage/server/facets/signout.js
+++ b/homepage/server/facets/signout.js
@@ -6,11 +6,6 @@
 
 function signout(request, reply) {
 	reply.unstate('access_token');
-
-	if (request.response) {
-		// Make sure to invalidate cache
-		request.response.vary('cookie');
-	}
 	reply.redirect('/');
 }
 

--- a/homepage/server/index.js
+++ b/homepage/server/index.js
@@ -37,6 +37,15 @@ server.state('session', {
 	encoding: 'base64json'
 });
 
+server.ext('onPreResponse', function (request, reply) {
+	if (request.response.variety !== 'file') {
+		request.response.vary('cookie');
+	}
+
+	return reply.continue();
+});
+
+
 server.route(routes);
 
 server.views({


### PR DESCRIPTION
When logging out from the Japan HP, the logged in UI state would remain for a few minutes due to caching. This fixes the issue by forcefully refreshing the cookie when logging out.