### PR TITLE
Maintenance | Removing unused getLanguage method

### DIFF
--- a/front/scripts/main/mixins/languages.js
+++ b/front/scripts/main/mixins/languages.js
@@ -40,19 +40,6 @@ export default Ember.Mixin.create({
 	},
 
 	/**
-	 * Obtains a localized language (browser lang for anons,
-	 * user lang for logged-in users)
-	 * @returns {string}
-	 */
-	getLanguage() {
-		if (this.get('currentUser', 'isAuthenticated')) {
-			return this.get('currentUser', 'language');
-		} else {
-			return this.getBrowserLanguage();
-		}
-	},
-
-	/**
 	 * Creates an escaped uselang querystring param
 	 * @returns {string}
 	 */


### PR DESCRIPTION
@rogatty @kvas-damian 

To avoid confusion, let's delete this method (since it's not used anywhere)