### PR TITLE
SOC-1549 - fixed loading spinner in firefox

### DIFF
--- a/front/styles/main/module/_loader.scss
+++ b/front/styles/main/module/_loader.scss
@@ -49,6 +49,5 @@ $duration: 1s;
 		stroke: $spinner-color;
 		stroke-dasharray: $offset;
 		stroke-dashoffset: 0;
-		transform-origin: center;
 	}
 }

--- a/front/templates/main/components/loading-spinner.hbs
+++ b/front/templates/main/components/loading-spinner.hbs
@@ -1,3 +1,5 @@
 <svg class='spinner' width='{{fullDiameter}}' height='{{fullDiameter}}' viewBox='0 0 {{fullDiameter}} {{fullDiameter}}' xmlns='http://www.w3.org/2000/svg'>
-	<circle class='path stroke-theme-color' fill='none' stroke-width='{{strokeWidth}}' stroke-linecap='round' cx='{{fullRadius}}' cy='{{fullRadius}}' r='{{radius}}'></circle>
+	<g transform="translate({{fullRadius}}, {{fullRadius}})">
+		<circle class='path stroke-theme-color' fill='none' stroke-width='{{strokeWidth}}' stroke-linecap='round' r='{{radius}}'></circle>
+	</g>
 </svg>

--- a/front/templates/main/components/loading-spinner.hbs
+++ b/front/templates/main/components/loading-spinner.hbs
@@ -1,5 +1,5 @@
 <svg class='spinner' width='{{fullDiameter}}' height='{{fullDiameter}}' viewBox='0 0 {{fullDiameter}} {{fullDiameter}}' xmlns='http://www.w3.org/2000/svg'>
-	<g transform="translate({{fullRadius}}, {{fullRadius}})">
+	<g transform='translate({{fullRadius}}, {{fullRadius}})'>
 		<circle class='path stroke-theme-color' fill='none' stroke-width='{{strokeWidth}}' stroke-linecap='round' r='{{radius}}'></circle>
 	</g>
 </svg>


### PR DESCRIPTION
`transform-origin` is buggy in firefox currently, so I removed it and wrapped the circle in a svg group that is translated, so there is no need for `transform-origin` on the circle.

https://wikia-inc.atlassian.net/browse/SOC-1549