### PR TITLE
SOC-1863 - corrected top margin of forum

### DIFF
--- a/front/styles/main/module/_discussion.scss
+++ b/front/styles/main/module/_discussion.scss
@@ -311,7 +311,7 @@ body.discussions {
 	}
 
 	&.forum {
-		margin-top: $discussion-header-height - $theme-bar-height;
+		margin-top: $discussion-header-height;
 
 		.discussion-content {
 			@include clamp(3);


### PR DESCRIPTION
After removing the correction of `$theme-bar-height`, the entire first post is now in view on mobile.
https://wikia-inc.atlassian.net/browse/SOC-1863