### PR TITLE
ADEN-2846 Prevent throwing JS error on pages without adsContext

### DIFF
--- a/front/common/modules/Ads.js
+++ b/front/common/modules/Ads.js
@@ -188,7 +188,8 @@ class Ads {
 	 * @returns {void}
 	 */
 	turnOffAdsForLoggedInUsers(adsContext) {
-		adsContext = adsContext || {}; // TODO: Refactor/remove while working on ADEN-2189
+		// TODO: Refactor/remove while working on ADEN-2189
+		adsContext = adsContext || {};
 		if (M.prop('userId')) {
 			adsContext.opts = adsContext.opts || {};
 			adsContext.opts.showAds = false;

--- a/front/common/modules/Ads.js
+++ b/front/common/modules/Ads.js
@@ -188,6 +188,7 @@ class Ads {
 	 * @returns {void}
 	 */
 	turnOffAdsForLoggedInUsers(adsContext) {
+		adsContext = adsContext || {}; // TODO: Refactor/remove while working on ADEN-2189
 		if (M.prop('userId')) {
 			adsContext.opts = adsContext.opts || {};
 			adsContext.opts.showAds = false;


### PR DESCRIPTION
Prevent throwing JS error (`Uncaught TypeError: Cannot read property 'opts' of null`) on pages without adsContext (i.e. discussions) for logged in users