### PR TITLE
XW-840 | Don't use $.trim

### DIFF
--- a/front/main/app/models/article.js
+++ b/front/main/app/models/article.js
@@ -118,7 +118,7 @@ ArticleModel.reopenClass({
 
 		if (article.data && article.data.article) {
 			// On the first page load the article content is available only in HTML
-			article.data.article.content = $.trim($('#preloadedContent').html());
+			article.data.article.content = $('#preloadedContent').html();
 		}
 
 		Mercury.article = null;


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-840

It turns out to be very expensive in some cases, e.g. on http://zh.inuyasha.wikia.com/wiki/%E7%8A%AC%E5%A4%9C%E5%8F%89%EF%BC%9A%E5%9C%A8%E5%9C%B0%E7%8B%B1%E9%87%8C%E7%AD%89%E5%BE%85%E7%9A%84%E4%B8%83%E4%BA%BA%E5%B8%AE it blocked rendering for 7 seconds.

Now it's done on server side, see https://github.com/Wikia/app/commit/2b1ec86ffd0b661c0ff2419efd60d03baa9aec84