### PR TITLE
ADEN-2820 Use AdEngineRunner and move onLoad callback

### DIFF
--- a/front/common/modules/Ads.js
+++ b/front/common/modules/Ads.js
@@ -221,7 +221,9 @@ class Ads {
 			} else {
 				this.sourcePointDetectionModule.initDetection();
 			}
-			delayEnabled = Boolean(adsContext.opts.delayEngine);
+			if (adsContext.opts) {
+				delayEnabled = Boolean(adsContext.opts.delayEngine);
+			}
 			this.adLogicPageViewCounterModule.increment();
 			this.adEngineRunnerModule.run(this.adConfigMobile, this.slotsQueue, 'queue.mercury', delayEnabled);
 		}

--- a/front/common/modules/Ads.js
+++ b/front/common/modules/Ads.js
@@ -27,7 +27,7 @@ import load from '../utils/load';
  * @property {boolean|null} blocking
  * @property {Array<string[]>} adSlots
  * @property {Object} adsContext
- * @property {*} adEngineModule
+ * @property {*} adEngineRunnerModule
  * @property {*} adContextModule
  * @property {SourcePointDetectionModule} sourcePointDetectionModule
  * @property {*} adConfigMobile
@@ -74,21 +74,21 @@ class Ads {
 		load(adsUrl, () => {
 			if (window.require) {
 				window.require([
-					'ext.wikia.adEngine.adEngine',
 					'ext.wikia.adEngine.adContext',
-					'ext.wikia.adEngine.config.mobile',
+					'ext.wikia.adEngine.adEngineRunner',
 					'ext.wikia.adEngine.adLogicPageViewCounter',
-					'ext.wikia.adEngine.sourcePointDetection',
+					'ext.wikia.adEngine.config.mobile',
 					'ext.wikia.adEngine.mobile.mercuryListener',
+					'ext.wikia.adEngine.sourcePointDetection',
 					'wikia.krux'
-				], (adEngineModule,
-					adContextModule,
-					adConfigMobile,
+				], (adContextModule,
+					adEngineRunnerModule,
 					adLogicPageViewCounterModule,
-					sourcePointDetectionModule,
+					adConfigMobile,
 					adMercuryListener,
+					sourcePointDetectionModule,
 					krux) => {
-					this.adEngineModule = adEngineModule;
+					this.adEngineRunnerModule = adEngineRunnerModule;
 					this.adContextModule = adContextModule;
 					this.sourcePointDetectionModule = sourcePointDetectionModule;
 					this.adConfigMobile = adConfigMobile;
@@ -204,6 +204,8 @@ class Ads {
 	 * @returns {void}
 	 */
 	reload(adsContext) {
+		let delayEnabled = false;
+
 		this.turnOffAdsForLoggedInUsers(adsContext);
 		// Store the context for external reuse
 		this.setContext(adsContext);
@@ -213,13 +215,15 @@ class Ads {
 
 		if (this.isLoaded && adsContext) {
 			this.adContextModule.setContext(adsContext);
+			this.onLoad();
 			if (Ads.blocking !== null) {
 				this.trackBlocking(Ads.blocking ? 'Yes' : 'No');
 			} else {
 				this.sourcePointDetectionModule.initDetection();
 			}
+			delayEnabled = Boolean(adsContext.opts.delayEngine);
 			this.adLogicPageViewCounterModule.increment();
-			this.adEngineModule.run(this.adConfigMobile, this.slotsQueue, 'queue.mercury');
+			this.adEngineRunnerModule.run(this.adConfigMobile, this.slotsQueue, 'queue.mercury', delayEnabled);
 		}
 	}
 
@@ -230,7 +234,6 @@ class Ads {
 	 */
 	reloadWhenReady() {
 		this.reload(this.currentAdsContext);
-		this.onLoad();
 	}
 
 	/**

--- a/front/common/tests/unit/modules/Ads.js
+++ b/front/common/tests/unit/modules/Ads.js
@@ -51,16 +51,20 @@ QUnit.module('mercury/modules/Ads', function (hooks) {
 			runSpy = sinon.spy(),
 			incrementSpy = sinon.spy(),
 			initDetectionSpy = sinon.spy(),
+			startOnLoadQueue = sinon.spy(),
 			instance = Ads.getInstance();
 
 		instance.adContextModule = {
 			setContext: setContextSpy
 		};
-		instance.adEngineModule = {
+		instance.adEngineRunnerModule = {
 			run: runSpy
 		};
 		instance.sourcePointDetectionModule = {
 			initDetection: initDetectionSpy
+		};
+		instance.adMercuryListenerModule = {
+			startOnLoadQueue: startOnLoadQueue
 		};
 		instance.adConfigMobile = {
 			test: 2
@@ -79,9 +83,10 @@ QUnit.module('mercury/modules/Ads', function (hooks) {
 		assert.ok(initDetectionSpy.calledOnce);
 		assert.ok(runSpy.calledWith(instance.adConfigMobile, instance.adSlots, 'queue.mercury'));
 		instance.adContextModule = undefined;
-		instance.adEngineModule = undefined;
+		instance.adEngineRunnerModule = undefined;
 		instance.adConfigMobile = undefined;
 		instance.adLogicPageViewCounterModule = undefined;
+		instance.adMercuryListenerModule = undefined;
 		instance.adSlots = [];
 	});
 


### PR DESCRIPTION
Delay AdEngine run using new AdEngineRunner module which is waiting for bidder responses or hardcoded timeout.

**Please, don't merge it before 2/3/2016 (https://github.com/Wikia/app/pull/9553)**