### PR TITLE
Fix styles when running Ember tests in a browser

### DIFF
--- a/front/main/tests/index.html
+++ b/front/main/tests/index.html
@@ -10,8 +10,6 @@
 	{{content-for 'head'}}
 	{{content-for 'test-head'}}
 
-	<link rel="stylesheet" href="assets/vendor.css">
-	<link rel="stylesheet" href="assets/app.css">
 	<link rel="stylesheet" href="assets/test-support.css">
 
 	{{content-for 'head-footer'}}


### PR DESCRIPTION
Those styles are not needed for tests and they break some colors.