### PR TITLE
INT-319 | Fix center alignment for category sliders on Japan HP

### DIFF
--- a/homepage/front/scripts/main/main.js
+++ b/homepage/front/scripts/main/main.js
@@ -53,7 +53,7 @@ function hideLoadingIndicator() {
 }
 
 $(() => {
-	const headings = $('.grid-heading');
+	let delta;
 
 	// Hide loading indicator after load complete
 	$(window).load(() => {
@@ -127,17 +127,24 @@ $(() => {
 		]
 	});
 
-	// TODO: The number of carousels should be encoded in a json file
+	// Compensation for responsive spacing between slides. See INT-319 and INT-329
+	// 250 is the fixed pixel width of each slide
+	delta = $('#carousel-1 .slick-slide').width() - 250;
+
 	for (let i = 1; i <= 5; i++) {
 		$(`#carousel-${i}-prev`).detach().appendTo(`#carousel-${i}`);
 		$(`#carousel-${i}-next`).detach().appendTo(`#carousel-${i}`);
+
+		// Set padding for left and right arrow
+		// 10px left padding, and 10px + slide spacing compensation on right
+		$(`#carousel-${i}-prev`).addClass('hero-prev-category');
+		$(`#carousel-${i}-next`).css('right', delta + 10);
 	}
 
-	// Dynamically adjust text size to show community title without text break.
-	// bigText adjusts the size programatically and strips off css padding, so it is
-	// necessary to add it in explicitly afterwards
-	headings.bigText({maximumFontSize: 20, verticalAlign: 'top'});
-	headings.css({padding: '.1rem'});
+	if (delta > 0) {
+		// Compensation for slide not being fully centered due to responsive slider spacing
+		$('.featured').css('padding-left', 54 + delta);
+	}
 
 	globals.loadGlobalData().then((data) => {
 		loadSearch(data.mobileBreakpoint);

--- a/homepage/front/styles/app.scss
+++ b/homepage/front/styles/app.scss
@@ -40,9 +40,9 @@ $desktop: new-breakpoint(min-width 500px);
 section {
 	@include outer-container;
 	clear: both;
-	margin-bottom: 3em;
-	padding-left: 3em;
-	padding-right: 3em;
+	margin-bottom: 54px;
+	padding-left: 54px;
+	padding-right: 54px;
 	// workaround for broken z-index in safari
 	transform: translate3d(0, 0, 0);
 

--- a/homepage/front/styles/component/_hero.scss
+++ b/homepage/front/styles/component/_hero.scss
@@ -251,6 +251,10 @@ $desktop-slider: new-breakpoint(min-width 1001px);
 	}
 }
 
+.hero-prev-category {
+	left: 10px;
+}
+
 .hero-next {
 	right: 30px;
 	top: 50%;


### PR DESCRIPTION
I cannot find a way to fix the padding between slides when using responsive slides for the slider component (http://kenwheeler.github.io/slick/).

To avoid having to change to a different component, or hacking the current component, I've created a workaround for this in software. It is not an ideal solution, but should be good enough for now.