### PR TITLE
SOC-1924 | new text for the top of reply card

### DIFF
--- a/front/common/public/locales/en/discussion.json
+++ b/front/common/public/locales/en/discussion.json
@@ -39,7 +39,7 @@
     "modal-dialog-delete-all-header": "Delete All Posts?",
     "modal-dialog-delete-all-message": "Are you sure you want to delete all posts by __userName__ on __wikiName__? Note that only individual posts can be restored and that you cannot undelete posts in bulk.",
     "modal-dialog-log-in": "Sign in",
-    "user-replied-to": "__userName__ replied to __linkToThread__",
+    "user-replied-to": "A reply to __userName__",
     "delete-all": "Delete All",
     "user-post-list-header": "Posts by __userName__",
     "empty-forum-text": "No posts yet. Get the discussion started, create the first post now!"

--- a/front/main/app/templates/components/post-reply.hbs
+++ b/front/main/app/templates/components/post-reply.hbs
@@ -1,7 +1,7 @@
 <div class="discussion-reply">
 	{{#if showRepliedTo}}
 		<div class="user-replied-to">
-			{{i18n 'main.user-replied-to' userName=author.name linkToThread=post.threadCreatedBy.name ns='discussion'}}
+			{{i18n 'main.user-replied-to' userName=post.threadCreatedBy.name ns='discussion'}}
 		</div>
 	{{/if}}
 	<div>


### PR DESCRIPTION
Lost commit from here:
https://github.com/Wikia/mercury/pull/1915