### PR TITLE
Revert "SOC-1966 | Hiding delete all button"

### DIFF
--- a/front/main/app/models/discussion-user.js
+++ b/front/main/app/models/discussion-user.js
@@ -1,6 +1,7 @@
 import DiscussionBaseModel from './discussion-base';
 import DiscussionDeleteModelMixin from '../mixins/discussion-delete-model';
 import ajaxCall from '../utils/ajax-call';
+import {checkPermissions} from 'common/utils/discussionPermissions';
 
 
 const DiscussionUserModel = DiscussionBaseModel.extend(DiscussionDeleteModelMixin, {
@@ -9,10 +10,16 @@ const DiscussionUserModel = DiscussionBaseModel.extend(DiscussionDeleteModelMixi
 	replyLimit: 10,
 	userId: null,
 	userName: null,
+	posts: null,
 	totalPosts: null,
 	userProfileUrl: null,
 
-	canDeleteAll: false,
+	canDeleteAll: Ember.computed('posts', function () {
+		const posts = this.get('posts');
+
+		// TODO fix me when API starts sending permissions for bulk operations
+		return posts && checkPermissions(posts[0], 'canDelete');
+	}),
 
 	loadPage(pageNum = 0) {
 		this.set('pageNum', pageNum);


### PR DESCRIPTION
This reverts commit f43b51ee3e7f7e1bea1d4e96b010e17e9a94d7b0.

It is a part of the fix for this P2: https://wikia-inc.atlassian.net/browse/SOC-1966

It removes a temporarily hidden "delete-all" button.