### PR TITLE
(CE-3266) Add the ability to undo an edit from a diff page

### DIFF
--- a/front/common/public/locales/en/recent-wiki-activity.json
+++ b/front/common/public/locales/en/recent-wiki-activity.json
@@ -1,6 +1,10 @@
 {
   "main": {
     "title": "Recent Wiki Activity",
-    "summary": "Summary:"
+    "summary": "Summary:",
+    "undo-label": "Undo",
+    "undo-success": "Successfully undid edit to page __pageTitle__!",
+    "undo-failure": "The edit could not be undone due to conflicting intermediate edits.",
+    "undo-error": "Sorry, it looks like something went wrong while trying to undo the edit. Please try again."
   }
 }

--- a/front/main/app/components/article-diff.js
+++ b/front/main/app/components/article-diff.js
@@ -1,0 +1,14 @@
+import Ember from 'ember';
+
+export default Ember.Component.extend({
+	classNames: ['diff-page'],
+
+	actions: {
+		/**
+		 * @returns {void}
+		 */
+		undo() {
+			this.sendAction('undo');
+		}
+	}
+});

--- a/front/main/app/components/article-diff.js
+++ b/front/main/app/components/article-diff.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 
 export default Ember.Component.extend({
 	classNames: ['diff-page'],
+	currentUser: Ember.inject.service(),
 
 	actions: {
 		/**

--- a/front/main/app/controllers/article-diff.js
+++ b/front/main/app/controllers/article-diff.js
@@ -1,0 +1,70 @@
+import Ember from 'ember';
+import ArticleDiffModel from '../models/article-diff';
+import {track, trackActions} from 'common/utils/track';
+
+export default Ember.Controller.extend({
+	application: Ember.inject.controller(),
+
+	/**
+	 * @returns {void}
+	 */
+	handleUndoSuccess() {
+		this.transitionToRoute('recent-wiki-activity').then(() => {
+			this.get('application').addAlert({
+				message: i18n.t('main.undo-success', {
+					pageTitle: this.get('model.title'),
+					ns: 'recent-wiki-activity'
+				}),
+				type: 'success'
+			});
+		});
+
+		track({
+			action: trackActions.impression,
+			category: 'recent-wiki-activity',
+			label: 'undo-success'
+		});
+	},
+
+	/**
+	 * @param {*} error
+	 * @returns {void}
+	 */
+	handleUndoError(error) {
+		const application = this.get('application'),
+			errorMsg = error === 'undofailure' ? 'main.undo-failure' : 'main.undo-error';
+
+		application.addAlert({
+			message: i18n.t(errorMsg, {ns: 'recent-wiki-activity'}),
+			type: 'alert'
+		});
+
+		application.set('isLoading', false);
+
+		track({
+			action: trackActions.impression,
+			category: 'recent-wiki-activity',
+			label: 'undo-error'
+		});
+	},
+
+	actions: {
+		/**
+		 * @returns {void}
+		 */
+		undo() {
+			this.get('application').set('isLoading', true);
+
+			ArticleDiffModel.undo(this.get('model')).then(
+				this.handleUndoSuccess.bind(this),
+				this.handleUndoError.bind(this)
+			);
+
+			track({
+				action: trackActions.click,
+				category: 'recent-wiki-activity',
+				label: 'undo'
+			});
+		}
+	}
+});

--- a/front/main/app/templates/article-diff.hbs
+++ b/front/main/app/templates/article-diff.hbs
@@ -1,8 +1,1 @@
-<div class="diff-page">
-{{recent-change model=model}}
-{{#each model.diffs as |diffs|}}
-	{{#each diffs as |diff|}}
-		<div class="{{diff.class}}{{if diff.allChanged ' all-changed'}}">{{diff.content}}</div>
-	{{/each}}
-{{/each}}
-</div>
+{{article-diff model=model undo='undo'}}

--- a/front/main/app/templates/components/article-diff.hbs
+++ b/front/main/app/templates/components/article-diff.hbs
@@ -5,4 +5,6 @@
 	{{/each}}
 {{/each}}
 
+{{#if currentUser.isAuthenticated}}
 <button {{action 'undo'}} class="">{{i18n 'main.undo-label' ns='recent-wiki-activity'}}</button>
+{{/if}}

--- a/front/main/app/templates/components/article-diff.hbs
+++ b/front/main/app/templates/components/article-diff.hbs
@@ -1,0 +1,8 @@
+{{recent-change model=model}}
+{{#each model.diffs as |diffs|}}
+	{{#each diffs as |diff|}}
+		<div class="{{diff.class}}{{if diff.allChanged ' all-changed'}}">{{diff.content}}</div>
+	{{/each}}
+{{/each}}
+
+<button {{action 'undo'}} class="">{{i18n 'main.undo-label' ns='recent-wiki-activity'}}</button>


### PR DESCRIPTION
Add the ability to undo an edit from a diff page. This also moves the diff page
to a proper component, and limits displaying the undo button to logged-in users.

/cc @Wikia/community-engineering 