### PR TITLE
XW-439 | add favicon to index.html

### DIFF
--- a/front/main/app/index.html
+++ b/front/main/app/index.html
@@ -19,6 +19,10 @@
 		<meta name="robots" content="{{wikiVariables.specialRobotPolicy}}">
 	{{/if}}
 
+	{{#if wikiVariables.favicon}}
+		<link rel="shortcut icon" href="{{wikiVariables.favicon}}">
+	{{/if}}
+
 	{{#if asyncArticle}}
 		<meta name="fragment" content="!">
 	{{/if}}


### PR DESCRIPTION
Unfortunatelly when browser get 500 it retries to get the favicon
and on devboxes this url is broken...
and on sandboxes too

since this is low impact I guess we'll have to test it on production
