### PR TITLE
XW-816 | Disable Ember performance sender

### DIFF
--- a/front/main/app/initializers/performance-monitoring.js
+++ b/front/main/app/initializers/performance-monitoring.js
@@ -1,36 +1,17 @@
-import * as trackPerf from 'common/utils/trackPerf';
+import Ember from 'ember';
+import {sendPagePerformance} from 'common/utils/trackPerf';
 
 /**
  * @returns {void}
  */
 export function initialize() {
-	if (typeof EmPerfSender === 'undefined') {
-		return;
-	}
-
 	// Send page performance stats after window is loaded
 	// Since we load our JS async this code may execute post load event
 	if (document.readyState === 'complete') {
-		trackPerf.sendPagePerformance();
+		sendPagePerformance();
 	} else {
-		$(window).load(() => trackPerf.sendPagePerformance());
+		Ember.$(window).on('load', sendPagePerformance);
 	}
-
-	EmPerfSender.initialize({
-		enableLogging: (M.prop('environment') === 'dev'),
-
-		// Specify a specific function for EmPerfSender to use when it has captured metrics
-		send(events, metrics) {
-			// This is where we connect EmPerfSender with our persistent metrics adapter, in this case, trackPerf
-			// is our instance of a Weppy interface
-			trackPerf.trackPerf({
-				module: metrics.klass.split('.')[0].toLowerCase(),
-				name: metrics.klass,
-				type: 'timer',
-				value: metrics.duration
-			});
-		}
-	});
 }
 
 export default {

--- a/front/main/bower.json
+++ b/front/main/bower.json
@@ -7,7 +7,6 @@
     "ember-cli-test-loader": "0.2.2",
     "ember-hammer": "1.0.2",
     "ember-load-initializers": "0.1.7",
-    "ember-performance-sender": "Wikia/ember-performance-sender#ember-2.0",
     "ember-qunit-notifications": "0.1.0",
     "fastclick": "1.0.6",
     "foundation": "5.5.1",

--- a/front/main/ember-cli-build.js
+++ b/front/main/ember-cli-build.js
@@ -83,7 +83,6 @@ module.exports = function (defaults) {
 	app.import(app.bowerDirectory + '/weppy/dist/weppy.js');
 	app.import(app.bowerDirectory + '/visit-source/dist/visit-source.js');
 	app.import(app.bowerDirectory + '/Autolinker.js/dist/Autolinker.min.js');
-	app.import(app.bowerDirectory + '/ember-performance-sender/dist/ember-performance-sender.js');
 	app.import('vendor/common.js');
 
 	// Assets which are lazy loaded


### PR DESCRIPTION
We do not use this data at all right now
and it's a hit on performance on our users

~8KB gzipped code less 
We don't hook into every View on every page load