### PR TITLE
enable ember-cli-html-minifier

### DIFF
--- a/front/main/package.json
+++ b/front/main/package.json
@@ -31,6 +31,7 @@
     "ember-cli-bidi": "git+https://github.com/Wikia/ember-cli-bidi.git#dd6fd681c29eb02ab21eda53a16bf3f779183fc4",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "1.2.0",
+    "ember-cli-html-minifier": "0.1.3",
     "ember-cli-htmlbars": "1.0.1",
     "ember-cli-htmlbars-inline-precompile": "0.3.1",
     "ember-cli-inject-live-reload": "1.4.0",


### PR DESCRIPTION
Yes it's that simple
Why we haven't enabled that before? ...

on June_Dolloway on glee

not gzipped
148050 vs 97052
it almost 60kB less - https://www.google.pl/webhp?sourceid=chrome-instant&ion=1&espv=2&es_th=1&ie=UTF-8#q=148050b%20-%2097052b%20in%20kb&es_th=1

gzipped
24186 vs 19381
it 4.8kB less - https://www.google.pl/webhp?sourceid=chrome-instant&ion=1&espv=2&es_th=1&ie=UTF-8#q=24186b+-+19381b+in+kb

Same ration is visible on other pages
![](http://i.giphy.com/3WyaE6QpdoJTa.gif)
