### PR TITLE
(CE-3331) Do not show undo button to blocked users

### DIFF
--- a/front/main/app/components/article-diff.js
+++ b/front/main/app/components/article-diff.js
@@ -3,6 +3,9 @@ import Ember from 'ember';
 export default Ember.Component.extend({
 	classNames: ['diff-page'],
 	currentUser: Ember.inject.service(),
+	showUndoButton: Ember.computed('currentUser.isAuthenticated', 'currentUser.isBlocked', function () {
+		return this.get('currentUser.isAuthenticated') && !this.get('currentUser.isBlocked');
+	}),
 	showDiffLink: false,
 
 	actions: {

--- a/front/main/app/services/current-user.js
+++ b/front/main/app/services/current-user.js
@@ -116,7 +116,7 @@ export default Ember.Service.extend({
 	 * @returns {Ember.RSVP.Promise<QueryUserInfoResponse>}
 	 */
 	loadBlockedStatus(result) {
-		return new Ember.RSVP.Promise((resolve, reject) => {
+		return new Ember.RSVP.Promise((resolve) => {
 			const blockId = Ember.get(result, 'query.userinfo.blockid');
 
 			if (blockId) {

--- a/front/main/app/services/current-user.js
+++ b/front/main/app/services/current-user.js
@@ -23,6 +23,7 @@ import UserModel from '../models/user';
 export default Ember.Service.extend({
 	rights: {},
 	isAuthenticated: Ember.computed.bool('userId'),
+	isBlocked: false,
 	language: null,
 
 	userId: Ember.computed(() => {
@@ -48,6 +49,7 @@ export default Ember.Service.extend({
 
 			this.loadUserInfo()
 				.then(this.loadUserLanguage.bind(this))
+				.then(this.loadBlockedStatus.bind(this))
 				.then(this.loadUserRights.bind(this))
 				.catch((err) => {
 					this.setUserLanguage();
@@ -110,6 +112,22 @@ export default Ember.Service.extend({
 	},
 
 	/**
+	 * @param {QueryUserInfoResponse} result
+	 * @returns {Ember.RSVP.Promise<QueryUserInfoResponse>}
+	 */
+	loadBlockedStatus(result) {
+		return new Ember.RSVP.Promise((resolve, reject) => {
+			const blockId = Ember.get(result, 'query.userinfo.blockid');
+
+			if (blockId) {
+				this.set('isBlocked', true);
+			}
+
+			resolve(result);
+		});
+	},
+
+	/**
 	 * @returns {Ember.RSVP.Promise<QueryUserInfoResponse>}
 	 */
 	loadUserInfo() {
@@ -119,7 +137,7 @@ export default Ember.Service.extend({
 				data: {
 					action: 'query',
 					meta: 'userinfo',
-					uiprop: 'rights|options',
+					uiprop: 'rights|options|blockinfo',
 					format: 'json'
 				},
 				dataType: 'json',

--- a/front/main/app/templates/components/article-diff.hbs
+++ b/front/main/app/templates/components/article-diff.hbs
@@ -24,6 +24,6 @@
 	{{/each}}
 {{/each}}
 
-{{#if currentUser.isAuthenticated}}
+{{#if showUndoButton}}
 	<button {{action 'undo'}} class="diff-page__undo">{{i18n 'main.undo-label' ns='recent-wiki-activity'}}</button>
 {{/if}}


### PR DESCRIPTION
Add blocked status to current user service and make use of it when
deciding whether or not to show the undo button.

Requires https://github.com/Wikia/app/pull/9674

/cc @Wikia/community-engineering 