### PR TITLE
Revert "enable ember-cli-html-minifier"

### DIFF
--- a/front/main/package.json
+++ b/front/main/package.json
@@ -31,7 +31,6 @@
     "ember-cli-bidi": "git+https://github.com/Wikia/ember-cli-bidi.git#dd6fd681c29eb02ab21eda53a16bf3f779183fc4",
     "ember-cli-content-security-policy": "0.4.0",
     "ember-cli-dependency-checker": "1.2.0",
-    "ember-cli-html-minifier": "0.1.3",
     "ember-cli-htmlbars": "1.0.1",
     "ember-cli-htmlbars-inline-precompile": "0.3.1",
     "ember-cli-inject-live-reload": "1.4.0",


### PR DESCRIPTION
Reverts Wikia/mercury#1972

After enabling this lib, Ember doesn't finish the building process. When I tried to deploy the latest dev it got stucked for 30 minutes.

@hakubo we need to investigate before merging again.