### PR TITLE
XW-802 | Disable prototype extensions

### DIFF
--- a/front/main/app/components/ad-slot.js
+++ b/front/main/app/components/ad-slot.js
@@ -10,7 +10,7 @@ export default Ember.Component.extend({
 	name: null,
 
 	nameLowerCase: Ember.computed('name', function () {
-		return this.get('name').toLowerCase().dasherize();
+		return Ember.String.dasherize(this.get('name').toLowerCase());
 	}),
 
 	/**

--- a/front/main/app/components/article-content.js
+++ b/front/main/app/components/article-content.js
@@ -50,7 +50,7 @@ export default Ember.Component.extend(
 				return ImageMediaComponent.create();
 			}
 		},
-		articleContentObserver: Ember.observer('content', function () {
+		articleContentObserver: Ember.on('init', Ember.observer('content', function () {
 			const content = this.get('content');
 
 			Ember.run.scheduleOnce('afterRender', this, () => {
@@ -76,7 +76,7 @@ export default Ember.Component.extend(
 				this.injectAds();
 				this.setupAdsContext(this.get('adsContext'));
 			});
-		}).on('init'),
+		})),
 
 		headerObserver: Ember.observer('headers', function () {
 			if (this.get('contributionEnabled')) {

--- a/front/main/app/components/article-wrapper.js
+++ b/front/main/app/components/article-wrapper.js
@@ -143,11 +143,11 @@ export default Ember.Component.extend(
 
 		curatedContentToolButtonVisible: Ember.computed.and('model.isMainPage', 'currentUser.rights.curatedcontent'),
 
-		articleObserver: Ember.observer('model.article', function () {
+		articleObserver: Ember.on('willInsertElement', Ember.observer('model.article', function () {
 			// This check is here because this observer will actually be called for views wherein the state is actually
 			// not valid, IE, the view is in the process of preRender
 			Ember.run.scheduleOnce('afterRender', this, this.performArticleTransforms);
-		}).on('willInsertElement'),
+		})),
 
 		actions: {
 			/**

--- a/front/main/app/components/featured-content.js
+++ b/front/main/app/components/featured-content.js
@@ -89,12 +89,12 @@ export default Ember.Component.extend(
 		/**
 		 * Keep pagination up to date
 		 */
-		currentItemIndexObserver: Ember.observer('currentItemIndex', function () {
+		currentItemIndexObserver: Ember.on('didInsertElement', Ember.observer('currentItemIndex', function () {
 			const $pagination = this.$('.featured-content-pagination');
 
 			$pagination.find('.current').removeClass('current');
 			$pagination.find(`li[data-index=${this.get('currentItemIndex')}]`).addClass('current');
-		}).on('didInsertElement'),
+		})),
 
 		/**
 		 * @returns {void}

--- a/front/main/app/components/gallery-media.js
+++ b/front/main/app/components/gallery-media.js
@@ -35,21 +35,18 @@ export default MediaComponent.extend(
 		/**
 		 * @returns {void}
 		 */
-		setUp() {
-			const mediaArray = Ember.A(),
-				emptyGif = this.get('emptyGif');
-
+		setup() {
 			/**
 			 * @property {ArticleMedia} media
 			 * @property {number} index
 			 * @return {void}
 			 */
-			this.get('media').forEach((media, index) => {
+			const mediaArray = this.get('media').map((media, index) => {
 				media.galleryRef = index;
-				media.thumbUrl = emptyGif;
+				media.thumbUrl = this.emptyGif;
 				media.captionClass = Ember.get(media, 'caption.length') > 0 ? ' has-caption' : '';
 
-				mediaArray.pushObject(Ember.Object.create(media));
+				return Ember.Object.create(media);
 			});
 
 			this.setProperties({
@@ -108,7 +105,7 @@ export default MediaComponent.extend(
 				thumbSize = this.get('thumbSize'),
 				maxImages = Math.ceil(galleryWidth / thumbSize);
 
-			this.setUp();
+			this.setup();
 			this.loadImages(0, maxImages);
 
 			$this.on('scroll', () => {

--- a/front/main/app/components/infobox-image-collection.js
+++ b/front/main/app/components/infobox-image-collection.js
@@ -58,23 +58,20 @@ export default MediaComponent.extend(
 		 * @returns {void}
 		 */
 		setup() {
-			const mediaArray = Ember.A(),
-				emptyGif = this.get('emptyGif');
+			const emptyGif = this.emptyGif;
 
 			/**
 			 * @param {ArticleMedia} image
 			 * @param {number} index
 			 * @returns {void}
 			 */
-			this.get('media').forEach((image, index) => {
+			this.set('media', this.get('media').map((image, index) => {
 				image.galleryRef = index;
 				image.thumbUrl = emptyGif;
 				image.isActive = (index === this.get('activeRef'));
 
-				mediaArray.pushObject(Ember.Object.create(image));
-			});
-
-			this.set('media', mediaArray);
+				return Ember.Object.create(image);
+			}));
 		},
 
 		/**

--- a/front/main/app/components/lightbox-image.js
+++ b/front/main/app/components/lightbox-image.js
@@ -32,7 +32,7 @@ export default Ember.Component.extend(
 				y = this.get('newY').toFixed(2),
 				transform = `transform: scale(${scale}) translate3d(${x}px,${y}px,0);`;
 
-			return (`-webkit-${transform}${transform}`).htmlSafe();
+			return Ember.String.htmlSafe(`-webkit-${transform}${transform}`);
 		}),
 
 		viewportSize: Ember.computed(() => {

--- a/front/main/app/mixins/curated-content-editor-sortable-items.js
+++ b/front/main/app/mixins/curated-content-editor-sortable-items.js
@@ -6,11 +6,7 @@ export default Ember.Mixin.create(
 	TrackClickMixin,
 	{
 		persistentSort: false,
-		sortableItems: Ember.computed('model.items', function () {
-			const items = this.get('model.items') || [];
-
-			return Ember.A().pushObjects(items);
-		}),
+		sortableItems: Ember.computed.reads('model.items'),
 
 		actions: {
 			/**

--- a/front/main/app/mixins/discussion-upvote-component.js
+++ b/front/main/app/mixins/discussion-upvote-component.js
@@ -10,7 +10,7 @@ export default Ember.Mixin.create({
 	post: null,
 	hasUpvoted: Ember.computed('post._embedded.userData.@each.hasUpvoted', function () {
 		if (Ember.isArray(this.get('post._embedded.userData'))) {
-			return this.get('post._embedded.userData')[0].hasUpvoted;
+			return this.get('post._embedded.userData.0.hasUpvoted');
 		}
 
 		return false;

--- a/front/main/app/mixins/languages.js
+++ b/front/main/app/mixins/languages.js
@@ -30,7 +30,7 @@ export default Ember.Mixin.create({
 		if (!lang) {
 			return this.get('defaultLanguage');
 		} else {
-			lang = lang.dasherize();
+			lang = Ember.String.dasherize(lang);
 
 			// pt-br is the only one supported share-feature language with dash and 5 characters
 			if (lang !== 'pt-br') {

--- a/front/main/config/environment.js
+++ b/front/main/config/environment.js
@@ -7,7 +7,11 @@ module.exports = function (environment) {
 		environment: environment,
 		locationType: 'auto',
 		EmberENV: {
-			EXTEND_PROTOTYPES: false,
+			EXTEND_PROTOTYPES: {
+				Array: true,
+				String: false,
+				Function: false
+			},
 			FEATURES: {
 				// Here you can enable experimental features on an ember canary build
 				// e.g. 'with-controller': true

--- a/front/main/config/environment.js
+++ b/front/main/config/environment.js
@@ -7,6 +7,7 @@ module.exports = function (environment) {
 		environment: environment,
 		locationType: 'auto',
 		EmberENV: {
+			EXTEND_PROTOTYPES: false,
 			FEATURES: {
 				// Here you can enable experimental features on an ember canary build
 				// e.g. 'with-controller': true


### PR DESCRIPTION
https://wikia-inc.atlassian.net/browse/XW-802

I did disable prototype extensions for Functions and Strings
As in this case being explicit is easier to reason about what is happening

A left Array extensions - as this does make it easier to write code
disabling that would mean we'd have to wrap any [] in Ember.A()
I tried it and it did not look good - and I think it would lead us to more bugs than it's worth it