### PR TITLE
(MAIN-6507) Only load user info if the user is not an anon

### DIFF
--- a/front/main/app/services/current-user.js
+++ b/front/main/app/services/current-user.js
@@ -51,18 +51,21 @@ export default Ember.Service.extend({
 	 */
 	init() {
 		this._super(...arguments);
+		const userId = this.get('userId');
 
-		Ember.RSVP.all([this.get('userModel'), this.loadUserInfo()]).then(([userModel, userInfo]) => {
-			if (userModel) {
-				this.setProperties(userModel);
-			}
+		if (userId !== null) {
+			Ember.RSVP.all([this.get('userModel'), this.loadUserInfo()]).then(([userModel, userInfo]) => {
+				if (userModel) {
+					this.setProperties(userModel);
+				}
 
-			if (userInfo) {
-				this.setUserLanguage(userInfo);
-				this.setBlockedStatus(userInfo);
-				this.setUserRights(userInfo);
-			}
-		});
+				if (userInfo) {
+					this.setUserLanguage(userInfo);
+					this.setBlockedStatus(userInfo);
+					this.setUserRights(userInfo);
+				}
+			});
+		}
 	},
 
 	/**


### PR DESCRIPTION
Reviewed in https://github.com/Wikia/mercury/pull/2044.

## Links

* https://wikia-inc.atlassian.net/browse/MAIN-6507

## Description

The check for userId being null was moved out of the load method in
this release, leading to this API call being made for anons as well.
This has caused large performance problems, so putting the check
back in as a quick fix.

## Reviewers

@owend @hakubo 