### PR TITLE
XW-1173 | ASAP send an event to UA that user opened a page

### DIFF
--- a/front/main/app/index.html
+++ b/front/main/app/index.html
@@ -48,6 +48,7 @@
 	{{content-for 'baseline'}}
 	{{> server-data}}
 	{{> tracking}}
+	{{> tracking-experiment}}
 
 	{{content-for 'head-footer'}}
 </head>

--- a/server/app/views/_partials/tracking-experiment.hbs
+++ b/server/app/views/_partials/tracking-experiment.hbs
@@ -30,7 +30,7 @@
 			hitType: 'event',
 			eventCategory: 'mercury-app',
 			eventAction: 'impression',
-			eventLabel: 'article-visible',
+			eventLabel: 'analytics-loaded',
 			eventValue: 0,
 			nonInteraction: true
 		});

--- a/server/app/views/_partials/tracking-experiment.hbs
+++ b/server/app/views/_partials/tracking-experiment.hbs
@@ -1,0 +1,38 @@
+{{!-- This is an experiment to see how many pageviews we lose
+	because we track them only after Ember is fully loaded
+	@see XW-1173 --}}
+{{#unless queryParams.noexternals}}
+	<script>
+		var id = '{{localSettings.tracking.ua.primary.id}}',
+			gaUserIdHash = '{{gaUserIdHash}}',
+			options = {
+				name: '',
+				allowLinker: true,
+				sampleRate: {{localSettings.tracking.ua.primary.sampleRate}},
+				userId: (gaUserIdHash.length > 0 ? gaUserIdHash : null)
+			},
+			autoLinkDomain = [
+				'wikia.com', 'ffxiclopedia.org', 'jedipedia.de',
+				'marveldatabase.com', 'memory-alpha.org', 'uncyclopedia.org',
+				'websitewiki.de', 'wowwiki.com', 'yoyowiki.org'
+			].filter(function (domain) {
+				return document.location.hostname.indexOf(domain) > -1;
+			})[0];
+
+		ga('create', id, 'auto', options);
+		ga(`require`, 'linker');
+
+		if (autoLinkDomain) {
+			ga(`linker:autoLink`, autoLinkDomain);
+		}
+
+		ga('send', {
+			hitType: 'event',
+			eventCategory: 'mercury-app',
+			eventAction: 'impression',
+			eventLabel: 'article-visible',
+			eventValue: 0,
+			nonInteraction: true
+		});
+	</script>
+{{/unless}}

--- a/server/app/views/_partials/tracking-experiment.hbs
+++ b/server/app/views/_partials/tracking-experiment.hbs
@@ -20,10 +20,10 @@
 			})[0];
 
 		ga('create', id, 'auto', options);
-		ga(`require`, 'linker');
+		ga('require', 'linker');
 
 		if (autoLinkDomain) {
-			ga(`linker:autoLink`, autoLinkDomain);
+			ga('linker:autoLink', autoLinkDomain);
 		}
 
 		ga('send', {


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/XW-1173

## Description

We want to verify how many page views are we missing in analytics because of the fact that we track them only after Ember is fully loaded. This experiment will send
```
category: 'mercury-app',
action: 'impression',
label: 'analytics-loaded'
```
event to UA as soon as possible. Then we'll compare its number with the one that we already send as soon as Ember is loaded.

## Reviewers

@Wikia/x-wing 