### PR TITLE
Add version to Ember inspector

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,5 @@
 {
   "name": "Mercury",
-  "version": "0.0.0",
   "description": "Wikia Web Application",
   "main": "www/server/app/server.js",
   "scripts": {


### PR DESCRIPTION
## Links

* https://github.com/embersherpa/ember-cli-app-version

## Description

By removing version from package.json I enabled ember-cli-app-version to do that for us
It already uses git latest commit hash and that is enough for us.

## Reviewers

@Wikia/x-wing 

PS. We actually talked with the team about that recently - when I found out what it takes to make that work - I lol'ed...