### PR TITLE
StyleGuide | Update to 1.8.3

### DIFF
--- a/front/auth/bower.json
+++ b/front/auth/bower.json
@@ -8,7 +8,7 @@
     "jquery": "2.1.4",
     "loader.js": "3.5.0",
     "visit-source": "Wikia/visit-source#0.1.1",
-    "wikia-style-guide": "Wikia/style-guide#v1.8.2"
+    "wikia-style-guide": "Wikia/style-guide#v1.8.3"
   },
   "devDependencies": {
     "sinonjs": "1.17.1"

--- a/front/main/bower.json
+++ b/front/main/bower.json
@@ -24,7 +24,7 @@
     "vignette": "wikia/vignette-js#2.2.1",
     "visit-source": "Wikia/visit-source#0.1.1",
     "weppy": "Wikia/weppy#0.9.3",
-    "wikia-style-guide": "Wikia/style-guide#v1.8.2"
+    "wikia-style-guide": "Wikia/style-guide#v1.8.3"
   },
   "resolutions": {
     "ember": "2.0.3",


### PR DESCRIPTION
## Links

https://github.com/Wikia/style-guide/releases/tag/v1.8.3

## Description

Let's update the dependency to use the newest style-guide version

## Reviewers
@vforge @Warkot  @rafalkalinski 

