### PR TITLE
Remove "work in progress" from PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,3 @@
-**Work in progress. Don't merge!** State it here and use labels.
-
 ## Links
 
 * http://wikia-inc.atlassian.net/browse/JIRA-123
@@ -12,4 +10,3 @@ A description written using complete sentences of the changes being made and any
 ## Reviewers
 
 Use `@` mentions here. Alternatively, assign the pull request to a person.
-


### PR DESCRIPTION
## Description

We already have PR labels "in progress" and "don't merge". It makes this line redundant.
Also, I see a lot of PRs merged with description "don't merge". What's the point, then?

## Reviewers

@Wikia/x-wing 