### PR TITLE
CE-3446 Add popover

### DIFF
--- a/front/main/app/components/article-content.js
+++ b/front/main/app/components/article-content.js
@@ -568,6 +568,9 @@ export default Ember.Component.extend(
 					break;
 				}
 			}
+			Ember.run.later(function () {
+				$highlightedElement.trigger('mousedown');
+			}, 500);
 		}
 	}
 );

--- a/front/main/app/components/article-content.js
+++ b/front/main/app/components/article-content.js
@@ -14,6 +14,7 @@ import WidgetVKComponent from '../components/widget-vk';
 import WidgetPolldaddyComponent from '../components/widget-polldaddy';
 import WidgetFliteComponent from '../components/widget-flite';
 import {getRenderComponentFor, queryPlaceholders} from '../utils/render-component';
+import {getExperimentVariationNumber} from 'common/utils/variantTesting';
 import {track, trackActions} from 'common/utils/track';
 
 /**
@@ -36,6 +37,9 @@ export default Ember.Component.extend(
 		uploadFeatureEnabled: null,
 		displayTitle: null,
 		headers: null,
+		highlightedEditorDemoEnabled: Ember.computed(() => {
+			return getExperimentVariationNumber({dev: '5170910064', prod: '5164060600'}) === 1;
+		}),
 
 		newFromMedia(media) {
 			if (media.context === 'infobox' || media.context === 'infobox-hero-image') {
@@ -76,7 +80,9 @@ export default Ember.Component.extend(
 					this.replaceMediaPlaceholdersWithMediaComponents(this.get('media'), 4);
 					this.replaceImageCollectionPlaceholdersWithComponents(this.get('media'));
 					this.replaceWikiaWidgetsWithComponents();
-					this.insertHighlightedTextEditorDemo();
+					if (this.get('highlightedEditorDemoEnabled')) {
+						this.insertHighlightedTextEditorDemo();
+					}
 					this.handleWikiaWidgetWrappers();
 					this.handlePollDaddy();
 					this.handleJumpLink();

--- a/front/main/app/components/article-content.js
+++ b/front/main/app/components/article-content.js
@@ -14,6 +14,7 @@ import WidgetVKComponent from '../components/widget-vk';
 import WidgetPolldaddyComponent from '../components/widget-polldaddy';
 import WidgetFliteComponent from '../components/widget-flite';
 import {getRenderComponentFor, queryPlaceholders} from '../utils/render-component';
+import {track, trackActions} from 'common/utils/track';
 
 /**
  * HTMLElement
@@ -573,9 +574,15 @@ export default Ember.Component.extend(
 					selection.removeAllRanges();
 					selection.addRange(range);
 
-					Ember.run.later(function () {
+					Ember.run.later(() => {
 						$highlightedElement.trigger('mousedown');
 					}, 500);
+
+					track({
+						action: trackActions.impression,
+						category: 'highlighted-editor',
+						label: 'popover'
+					});
 					return true;
 				} else {
 					return false;

--- a/front/main/app/styles/component/_article-wrapper.scss
+++ b/front/main/app/styles/component/_article-wrapper.scss
@@ -1,0 +1,28 @@
+.highlighted-text-editor-popover {
+	text-align: center;
+
+	h2 {
+		font-size: $type-smaller;
+		font-weight: normal;
+		line-height: $line-height-smaller;
+	}
+
+	p {
+		font-size: $type-smallest;
+		line-height: $line-height-smallest;
+	}
+
+	.pop-over-compass {
+		left: 20px!important;
+		width: calc(100% - 40px)!important;
+		z-index: $z-6;
+	}
+
+	.pop-over-container {
+		border-top: 7px solid $color-blue-light;
+	}
+
+	.pop-over-pointer {
+		border-color: transparent transparent $color-blue-light;
+	}
+}

--- a/front/main/app/styles/component/_article-wrapper.scss
+++ b/front/main/app/styles/component/_article-wrapper.scss
@@ -23,6 +23,7 @@
 	}
 
 	.pop-over-pointer {
-		border-color: transparent transparent $color-blue-light;
+		//border-color: transparent transparent $color-blue-light; // TODO enable in CE-3464
+		border-color: transparent;
 	}
 }

--- a/front/main/app/styles/component/index.scss
+++ b/front/main/app/styles/component/index.scss
@@ -41,5 +41,6 @@
 @import 'article_diff';
 @import 'recent-edit-banner';
 @import 'date-placeholder';
+@import 'article-wrapper';
 // wikia ui reusable components
 @import 'wikia-ui-components/on-hover-tooltip';

--- a/front/main/app/templates/components/article-wrapper.hbs
+++ b/front/main/app/templates/components/article-wrapper.hbs
@@ -3,6 +3,10 @@
 	{{#if model.exception}}
 		{{render 'not-found'}}
 	{{else}}
+		{{#pop-over for='highlighted-text' on='click' flow='dropdown' class='highlighted-text-editor-popover'}}
+			<h2>Performing small edits on mobile just got easier!</h2>
+			<p>Highlight the word or phrase you want to fix and tap the button below.</p>
+		{{/pop-over}}
 		<section class="article-body">
 			<h1 class="article-title">
 				{{model.displayTitle}}
@@ -66,10 +70,6 @@
 				editAllowed=editAllowed
 				addPhotoAllowed=addPhotoAllowed
 			}}
-			{{#pop-over for='highlighted-text__demo' on='click' flow='flip' class='highlighted-text-editor-popover'}}
-				<h2>Performing small edits on mobile just got easier!</h2>
-				<p>Highlight the word or phrase you want to fix and tap the button below.</p>
-			{{/pop-over}}
 		</section>
 		<section class="article-footer">
 			{{wikia-users

--- a/front/main/app/templates/components/article-wrapper.hbs
+++ b/front/main/app/templates/components/article-wrapper.hbs
@@ -66,6 +66,10 @@
 				editAllowed=editAllowed
 				addPhotoAllowed=addPhotoAllowed
 			}}
+			{{#pop-over for='highlighted-text__demo' on='click' flow='flip' class='highlighted-text-editor-popover'}}
+				<h2>Performing small edits on mobile just got easier!</h2>
+				<p>Highlight the word or phrase you want to fix and tap the button below.</p>
+			{{/pop-over}}
 		</section>
 		<section class="article-footer">
 			{{wikia-users


### PR DESCRIPTION
**This is for ~two week experiment**

## Links
* https://wikia-inc.atlassian.net/browse/CE-3446 Popover
* https://wikia-inc.atlassian.net/browse/CE-3448 Tracking

## Description
* This is ugly! But we don't aim for quality here ;)
* Text is hard coded as it's not going to be translated - test is only on EN wikis.
* Popover is reused from discussions (ember-pop-over) necessary custom styles added. Full width is forced. Properly done it should introduce new flow in flows.js, but for this purpose it's probably enough.
* As we're pinning popover to element within article - again we can't do it ember way and jquery is used to force pop-over opening and `run.later` to wait for pop-over to get aware of element to track click to open

## Reviewers
@Wikia/community-engineering  @Wikia/x-wing