### PR TITLE
XW | stop calling quantserve twice on auth

### DIFF
--- a/front/auth/views/_layouts/auth.hbs
+++ b/front/auth/views/_layouts/auth.hbs
@@ -63,6 +63,7 @@
 			M.loadDOMResource('/front/common/symbols.svg');
 			M.prop('tracking', {{{json trackingConfig}}});
 			M.prop('isGASpecialWiki', true);
+			M.prop('initialPageView', true, true);
 
 			require('auth/app/main').init();
 		</script>


### PR DESCRIPTION
## Description
Quantserve was called twice on auth pages because the initialPageView was not set
## Reviewers
@Wikia/x-wing 

