### PR TITLE
XW-1216 | Unify labels for events related with categories menu under the article

### DIFF
--- a/front/main/app/components/collapsible-menu.js
+++ b/front/main/app/components/collapsible-menu.js
@@ -27,7 +27,7 @@ export default Ember.Component.extend(
 					track({
 						action: trackActions.click,
 						category: this.get('trackingEvent'),
-						label: this.get('isCollapsed') ? 'close' : 'open'
+						label: this.get('isCollapsed') ? 'collapsed' : 'expanded'
 					});
 				}
 			}

--- a/front/main/app/templates/category.hbs
+++ b/front/main/app/templates/category.hbs
@@ -38,27 +38,6 @@
 			setupAds=true
 			loadBatch=(action 'loadBatch')
 		}}
-
-		<section class="article-footer">
-		{{#if model.categories}}
-			{{#collapsible-menu
-				showMenuIcon=false
-				tLabel='app.article-categories-list-label'
-				ordered=false
-				observe=model.displayTitle
-				trackingEvent='category'
-			}}
-				{{#each model.categories as |category|}}
-					<li class="mw-content" {{action 'trackClick' 'category' 'link'}}>
-						{{#link-to 'wiki-page' category.title}}
-							{{category.title}}
-							{{svg 'chevron' viewBox='0 0 12 7' class='icon chevron'}}
-						{{/link-to}}
-					</li>
-				{{/each}}
-			{{/collapsible-menu}}
-		{{/if}}
-		</section>
 	{{/if}}
 
 	{{wikia-footer}}

--- a/front/main/app/templates/components/article-wrapper.hbs
+++ b/front/main/app/templates/components/article-wrapper.hbs
@@ -85,10 +85,10 @@
 			tLabel='app.article-categories-list-label'
 			ordered=false
 			observe=model.displayTitle
-			trackingEvent='category'
+			trackingEvent='category-menu'
 		}}
 			{{#each model.categories as |category|}}
-				<li class="mw-content" {{action 'trackClick' 'category' 'link'}}><a href="{{unbound category.url}}" title="{{unbound category.title}}">
+				<li class="mw-content" {{action 'trackClick' 'category-menu' 'open-category'}}><a href="{{unbound category.url}}" title="{{unbound category.title}}">
 					{{unbound category.title}}
 					{{svg 'chevron' viewBox='0 0 12 7' class='icon chevron'}}
 				</a></li>


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/XW-1216
* https://wikia-inc.atlassian.net/browse/XW-1232

## Description
Unify labels for events related with categories menu under the article. I spotted some not reachable code and I decided to remove it (more details here - https://wikia-inc.atlassian.net/browse/XW-1232)

## Reviewers
@Wikia/x-wing 