### PR TITLE
CE-3445: Highlight text on ios

### DIFF
--- a/front/main/app/components/article-content.js
+++ b/front/main/app/components/article-content.js
@@ -576,16 +576,16 @@ export default Ember.Component.extend(
 					$paragraph.html(paragraphHtml.replace(word, `<span id="${highlightedId}">${word}</span>`));
 					$highlightedElement = $paragraph.find(`#${highlightedId}`);
 
+					range.selectNodeContents($highlightedElement[0]);
+					selection.removeAllRanges();
+					selection.addRange(range);
+
 					Ember.$('body').animate({scrollTop: $highlightedElement.offset().top - 150}, () => {
 						Ember.$(document).one('selectionchange', () => {
 							$paragraph.html(paragraphHtml.replace(`<span id="${highlightedId}">${word}</span>`, word));
 						});
 
 					});
-
-					range.selectNodeContents($highlightedElement[0]);
-					selection.removeAllRanges();
-					selection.addRange(range);
 
 					Ember.run.later(() => {
 						$highlightedElement.trigger('mousedown');

--- a/front/main/app/components/article-content.js
+++ b/front/main/app/components/article-content.js
@@ -576,7 +576,12 @@ export default Ember.Component.extend(
 					$paragraph.html(paragraphHtml.replace(word, `<span id="${highlightedId}">${word}</span>`));
 					$highlightedElement = $paragraph.find(`#${highlightedId}`);
 
-					Ember.$(window).scrollTop($highlightedElement.offset().top - 150);
+					Ember.$('body').animate({scrollTop: $highlightedElement.offset().top - 150}, () => {
+						Ember.$(document).one('selectionchange', () => {
+							$paragraph.html(paragraphHtml.replace(`<span id="${highlightedId}">${word}</span>`, word));
+						});
+
+					});
 
 					range.selectNodeContents($highlightedElement[0]);
 					selection.removeAllRanges();

--- a/front/main/app/styles/component/_article-wrapper.scss
+++ b/front/main/app/styles/component/_article-wrapper.scss
@@ -28,6 +28,7 @@
 	}
 }
 
+// iOS quick fix to show that text is highlighted
 #highlighted-text {
 	background-color: rgba(201, 224, 253, 0.8);
 }

--- a/front/main/app/styles/component/_article-wrapper.scss
+++ b/front/main/app/styles/component/_article-wrapper.scss
@@ -27,3 +27,7 @@
 		border-color: transparent;
 	}
 }
+
+#highlighted-text {
+	background-color: rgba(201, 224, 253, 0.8);
+}


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/CE-3445

## Description

Highlight text by setting background (we cannot highlight text in ios from javascript)

## Reviewers

@Wikia/community-engineering 

