### PR TITLE
DAT-3907 | Fix ads on CMP categories

### DIFF
--- a/server/app/routes.js
+++ b/server/app/routes.js
@@ -250,7 +250,7 @@ let routes,
 		{
 			method: 'GET',
 			path: '/main/category/{categoryName*}',
-			handler: showApplication,
+			handler: showCuratedContent,
 			config: {
 				cache: routeCacheConfig
 			}
@@ -259,7 +259,7 @@ let routes,
 			method: 'GET',
 			// We don't care if there is a dynamic segment, Ember router handles that
 			path: '/infobox-builder/{ignore*}',
-			handler: showCuratedContent,
+			handler: showApplication,
 			config: {
 				cache: routeCacheConfig
 			}


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/DAT-3907

## Description

https://github.com/Wikia/mercury/commit/68b0b74afcfdb28e6f2137d857aeb2051f796050 introduced a regression which causes situation where we don't load adsContext properly on pages like http://starwars.wikia.com/main/category/Saga_films.

## Reviewers

@RafLeszczynski 

