### PR TITLE
CE-3494 Enable the HTE on all EN communities without surfacing it

### DIFF
--- a/front/main/app/components/article-wrapper.js
+++ b/front/main/app/components/article-wrapper.js
@@ -4,8 +4,6 @@ import TextHighlightMixin from '../mixins/text-highlight';
 import TrackClickMixin from '../mixins/track-click';
 import ViewportMixin from '../mixins/viewport';
 import {track, trackActions} from 'common/utils/track';
-import {getExperimentVariationNumber} from 'common/utils/variantTesting';
-
 
 /**
  * @typedef {Object} ArticleSectionHeader

--- a/front/main/app/components/article-wrapper.js
+++ b/front/main/app/components/article-wrapper.js
@@ -152,9 +152,7 @@ export default Ember.Component.extend(
 				!this.get('highlightedEditorEnabled');
 		}),
 
-		highlightedEditorEnabled: Ember.computed(() => {
-			return getExperimentVariationNumber({dev: '5170910064', prod: '5164060600'}) === 1;
-		}),
+		highlightedEditorEnabled: Ember.computed(() => Mercury.wiki.language.content === 'en'),
 
 		actions: {
 			/**


### PR DESCRIPTION
## Links

- https://wikia-inc.atlassian.net/browse/CE-3494

## Description

Since the Optimizely experiment had to be stopped - we want the users we already enabled it for to see the editor when they want to edit. Assuming that the editor is hard to find (low percentage of people selecting text on websites) - we want to enable it for EN communities.

## Reviewers

@Wikia/community-engineering .

