### PR TITLE
DAT-3924, remove captions from infobox builder preview

### DIFF
--- a/front/common/public/locales/en/infobox-builder.json
+++ b/front/common/public/locales/en/infobox-builder.json
@@ -8,7 +8,6 @@
     "label-default": "Label __index__",
     "image-default": "Image __index__",
     "section-header-default": "Header __index__",
-    "caption-default": "Example caption",
     "alt-default": "Alt",
     "row-default": "Example value",
     "row-label": "Label",

--- a/front/main/app/components/infobox-builder-item-image.js
+++ b/front/main/app/components/infobox-builder-item-image.js
@@ -11,8 +11,7 @@ export default Ember.Component.extend(
 		thumbnail: '/front/common/images/infobox-builder-image-placeholder.png',
 		// cannot be 'height' & 'width' because sortable-item uses height & width props for its own purposes
 		imgWidth: 270,
-		imgHeight: 152,
-		caption: i18n.t('infobox-builder:main.caption-default')
+		imgHeight: 152
 	}
 );
 

--- a/front/main/app/templates/components/infobox-builder-item-image.hbs
+++ b/front/main/app/templates/components/infobox-builder-item-image.hbs
@@ -13,6 +13,3 @@
 		<span class="play-circle"></span>
 	{{/if}}
 </a>
-{{#if caption}}
-	<figcaption class="pi-item-spacing pi-caption">{{caption}}</figcaption>
-{{/if}}


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/DAT-3924

## Description

Remove image captions from infobox builder preview in order not to confuse users.

## Reviewers

@dianafa, @SebastianMarzjan, @idradm, @rybmat, @nikodamn 

