### PR TITLE
fix abtest module import by lowercasing its path

### DIFF
--- a/front/main/app/components/feedback-form.js
+++ b/front/main/app/components/feedback-form.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import UserFeedbackStorageMixin from '../mixins/user-feedback-storage';
 import BottomBannerMixin from '../mixins/bottom-banner';
-import {getGroup} from 'common/modules/AbTest';
+import {getGroup} from 'common/modules/abtest';
 import {track, trackActions} from 'common/utils/track';
 
 const variations = {


### PR DESCRIPTION
## Description

JS console was throwing this error:
```
Uncaught Error: Could not find module `common/modules/AbTest` imported from `main/components/feedback-form`
```

All filenames, paths and the imports have to be lowercase. Linux machines, on which our app works, are case sensitive.

## Reviewers

@Wikia/x-wing @adamkarminski @lukaszkonieczny @kamilkoterba 