### PR TITLE
CE-3531 Use accurate messages and placeholders for different feedback questions

### DIFF
--- a/front/main/app/components/feedback-form.js
+++ b/front/main/app/components/feedback-form.js
@@ -7,27 +7,45 @@ import {track, trackActions} from 'common/utils/track';
 const variations = {
 		SATISFACTION_Q1_TEXT: {
 			question: 'Did you find what you were looking for?',
-			buttons: 'text'
+			buttons: 'text',
+			feedbackQuestion: 'Your input helps to improve this wiki. Every bit of feedback is highly valued. ' +
+				'What information was missing?',
+			placeholder: 'Missing information'
 		},
 		SATISFACTION_Q1_ICON: {
 			question: 'Did you find what you were looking for?',
-			buttons: 'icons'
+			buttons: 'icons',
+			feedbackQuestion: 'Your input helps to improve this wiki. Every bit of feedback is highly valued. ' +
+				'What information was missing?',
+			placeholder: 'Missing information'
 		},
 		SATISFACTION_Q2_TEXT: {
 			question: 'Did this answer your question?',
-			buttons: 'text'
+			buttons: 'text',
+			feedbackQuestion: 'Your input helps to improve this wiki. Every bit of feedback is highly valued. ' +
+				'What information was missing?',
+			placeholder: 'Missing information'
 		},
 		SATISFACTION_Q3_TEXT: {
 			question: 'Was this article accurate?',
-			buttons: 'text'
+			buttons: 'text',
+			feedbackQuestion: 'Your input helps to improve this wiki. Every bit of feedback is highly valued. ' +
+				'What information was inaccurate?',
+			placeholder: 'Inaccurate information'
 		},
 		EMOTIONS_Q1_EMOT: {
 			question: 'What did you think of this article?',
-			buttons: 'emots'
+			buttons: 'emots',
+			feedbackQuestion: 'Your input helps to improve this wiki. Every bit of feedback is highly valued. ' +
+				'What didn\'t you like about the article?',
+			placeholder: 'Your feedback'
 		},
 		EMOTIONS_Q2_EMOT: {
 			question: 'How did this article make you feel?',
-			buttons: 'emots'
+			buttons: 'emots',
+			feedbackQuestion: 'Your input helps to improve this wiki. Every bit of feedback is highly valued. ' +
+				'Why did you feel bad?',
+			placeholder: 'Your feedback'
 		}
 	},
 	completed = {
@@ -40,8 +58,6 @@ const variations = {
 			timeout: 7000
 		}
 	},
-	helpImproveMessage = 'Your input helps to improve this wiki. Every bit of feedback is highly valued. ' +
-		'What information was missing?',
 	offsetLimit = 0.2,
 	cookieName = 'feedback-form',
 	experimentId = 'USER_SATISFACTION_FEEDBACK';
@@ -211,7 +227,7 @@ export default Ember.Component.extend(
 				this.setProperties({
 					displayQuestion: false,
 					displayInput: true,
-					message: helpImproveMessage
+					message: this.get('variation').feedbackQuestion
 				});
 
 				this.trackClick('user-feedback-no');

--- a/front/main/app/components/feedback-form.js
+++ b/front/main/app/components/feedback-form.js
@@ -44,7 +44,7 @@ const variations = {
 			question: 'How did this article make you feel?',
 			buttons: 'emots',
 			feedbackQuestion: 'Your input helps to improve this wiki. Every bit of feedback is highly valued. ' +
-				'Why did you feel bad?',
+				'Why did the article make you feel that way?',
 			placeholder: 'Your feedback'
 		}
 	},

--- a/front/main/app/templates/components/feedback-form.hbs
+++ b/front/main/app/templates/components/feedback-form.hbs
@@ -16,7 +16,7 @@
 		{{input
 			value=userFeedback
 			name="feedback"
-			placeholder="Missing information"
+			placeholder=variation.placeholder
 			focus-out="onFocusOut"
 			focus-in="onFocusIn"
 			autocomplete="off"


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/CE-3531

## Description

We realised that for some initial questions a follow-up questions and a placeholder make no sense. This PR fixes it.

## Reviewers
@Grunny 