### PR TITLE
XW | Fix cache control in article preview

### DIFF
--- a/server/app/facets/article-preview.js
+++ b/server/app/facets/article-preview.js
@@ -1,5 +1,5 @@
 import {PageRequestHelper} from '../lib/mediawiki-page';
-import disableCache from '../lib/caching';
+import {disableCache} from '../lib/caching';
 import {getCachedWikiDomainName, getCDNBaseUrl, getHtmlTitle} from '../lib/utils';
 import localSettings from '../../config/localSettings';
 import Logger from '../lib/logger';


### PR DESCRIPTION
## Description

Fixes https://kibana.wikia-inc.com/#dashboard/temp/AVOo4zfEtlVOnUfDkxgN

```
TypeError: undefined is not a function
    at /usr/wikia/mercury/3246/server/app/facets/article-preview.js:107:32
    at bound (domain.js:291:14)
    at runBound (domain.js:304:12)
    at tryCatcher (/usr/wikia/mercury/3246/server/node_modules/bluebird/js/main/util.js:26:23)
    at Promise._settlePromiseFromHandler (/usr/wikia/mercury/3246/server/node_modules/bluebird/js/main/promise.js:507:31)
    at Promise._settlePromiseAt (/usr/wikia/mercury/3246/server/node_modules/bluebird/js/main/promise.js:581:18)
    at Promise._settlePromises (/usr/wikia/mercury/3246/server/node_modules/bluebird/js/main/promise.js:697:14)
    at Async._drainQueue (/usr/wikia/mercury/3246/server/node_modules/bluebird/js/main/async.js:123:16)
    at Async._drainQueues (/usr/wikia/mercury/3246/server/node_modules/bluebird/js/main/async.js:133:10)
    at Immediate.Async.drainQueues [as _onImmediate] (/usr/wikia/mercury/3246/server/node_modules/bluebird/js/main/async.js:15:14)
    at processImmediate [as _immediateCallback] (timers.js:367:17)
```

## Reviewers

@Wikia/x-wing 