### PR TITLE
RECIRC-86: Add utm tracking code to Fandom links in footer

### DIFF
--- a/front/main/app/components/fandom-posts.js
+++ b/front/main/app/components/fandom-posts.js
@@ -25,6 +25,18 @@ export default Ember.Component.extend({
 		});
 	},
 
+	posts: Ember.computed.map('model.posts', (post, index) => {
+		const params = {
+			utm_source: 'wikia',
+			utm_campaign: 'recirc',
+			utm_medium: 'footer',
+			utm_content: index + 1
+		};
+
+		post.url = `${post.url}?${Ember.$.param(params)}`;
+		return post;
+	}),
+
 	actions: {
 		trackExperimentClick(url) {
 			trackExperiment(this.get('experimentName'), {

--- a/front/main/app/templates/components/fandom-posts.hbs
+++ b/front/main/app/templates/components/fandom-posts.hbs
@@ -2,7 +2,7 @@
 <section class="fandom-posts content-recommendations">
 	<h2>{{model.title}}</h2>
 	<ul class="thumbnails">
-		{{#each model.posts as |post|}}
+		{{#each posts as |post|}}
 			<li class="title-thumbnail" {{action 'trackExperimentClick' post.url}}>
 				<a href="{{post.url}}">
 					<div class="image image-thumbnail">


### PR DESCRIPTION
## Links
https://wikia-inc.atlassian.net/browse/RECIRC-86

## Description
We want to add UTM tracking information to Fandom links so we can better track from the Fandom side which traffic is coming from our Recirculation efforts


