### PR TITLE
XW-update-chevron | bring back the thinner style of chevron-linked.svg

### DIFF
--- a/front/main/app/symbols/main/chevron-linked.svg
+++ b/front/main/app/symbols/main/chevron-linked.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20">
-  <polygon points="12 10,8 14,10 16,16 10,10 4,8 6"/>
+  <polygon points="13 10,8.5 14.5,10 16,16 10,10 4,8.5 5.5"/>
 </svg>


### PR DESCRIPTION
## Description

When fixing the visibility and refactoring of the chevron-linked.svg last time, the svg became unnecessarily and unintentionally bolder.

## Reviewers

@vforge 
