### PR TITLE
XW-1302 | Add firstRenderTime measurement

### DIFF
--- a/front/common/utils/track-perf.js
+++ b/front/common/utils/track-perf.js
@@ -90,8 +90,6 @@ export function trackPerf(params) {
 		default:
 			throw new Error('This action not supported in Weppy tracker');
 	}
-
-	trackFn.flush();
 }
 
 /**

--- a/front/main/app/index.html
+++ b/front/main/app/index.html
@@ -53,6 +53,7 @@
 <body>
 {{content-for 'body'}}
 
+{{> first-render-time}}
 {{> qualaroo}}
 
 {{!--

--- a/front/main/app/initializers/performance-monitoring.js
+++ b/front/main/app/initializers/performance-monitoring.js
@@ -18,7 +18,7 @@ export function initialize() {
 	if (!Ember.isEmpty(firstRenderTime)) {
 		trackPerf({
 			type: 'timer',
-			name: 'firstRenderTime',
+			name: 'firstRender',
 			value: firstRenderTime
 		});
 	}

--- a/front/main/app/initializers/performance-monitoring.js
+++ b/front/main/app/initializers/performance-monitoring.js
@@ -1,16 +1,26 @@
 import Ember from 'ember';
-import {sendPagePerformance} from 'common/utils/track-perf';
+import {sendPagePerformance, trackPerf} from 'common/utils/track-perf';
 
 /**
  * @returns {void}
  */
 export function initialize() {
+	const firstRenderTime = M.prop('firstRenderTime');
+
 	// Send page performance stats after window is loaded
 	// Since we load our JS async this code may execute post load event
 	if (document.readyState === 'complete') {
 		sendPagePerformance();
 	} else {
 		Ember.$(window).on('load', sendPagePerformance);
+	}
+
+	if (!Ember.isEmpty(firstRenderTime)) {
+		trackPerf({
+			type: 'timer',
+			name: 'firstRenderTime',
+			value: firstRenderTime
+		});
 	}
 }
 

--- a/server/app/views/_partials/first-render-time.hbs
+++ b/server/app/views/_partials/first-render-time.hbs
@@ -4,7 +4,7 @@
 <style type="text/css">
 	.render-time-test {
 		transition-property: opacity;
-		transition-duration: .000001s;
+		transition-duration: 1ms;
 		opacity: 0;
 	}
 

--- a/server/app/views/_partials/first-render-time.hbs
+++ b/server/app/views/_partials/first-render-time.hbs
@@ -1,0 +1,50 @@
+{{! @todo (XW-1374) this should be an Ember addon }}
+{{! Idea from https://davidwalsh.name/css-animation-callback }}
+<span class="render-time-test"></span>
+<style type="text/css">
+	.render-time-test {
+		transition-property: opacity;
+		transition-duration: .000001s;
+		opacity: 0;
+	}
+
+	.render-time-test.measure {
+		opacity: 1;
+	}
+</style>
+<script>
+	/**
+	 * @returns {String|null}
+	 */
+	function whichTransitionEnd() {
+		var fakeElement = document.createElement('fakeelement'),
+				transitions = {
+					'transition': 'transitionend',
+					'OTransition': 'oTransitionEnd',
+					'MozTransition': 'transitionend',
+					'WebkitTransition': 'webkitTransitionEnd'
+				};
+
+		for (var t in transitions) {
+			if (fakeElement.style[t] !== undefined) {
+				return transitions[t];
+			}
+		}
+
+		return null;
+	}
+
+	var testElement = document.getElementsByClassName('render-time-test')[0],
+			transitionEnd = whichTransitionEnd();
+
+	if (transitionEnd && performance && typeof performance.now === 'function') {
+		testElement.addEventListener(transitionEnd, function () {
+			M.prop('firstRenderTime', performance.now());
+		});
+
+		// Transition isn't triggered without setTimeout because of browser optimizations
+		setTimeout(function () {
+			testElement.classList.add('measure');
+		}, 0);
+	}
+</script>


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/XW-1302
* https://davidwalsh.name/css-animation-callback

## Description

We want to know when users actually see the content and it turns out that `domContentLoaded` isn't the correct event to measure that.

Instead, let's use an empty element with CSS transition applied and measure when the transition is finished. I've run some tests on http://webpagetest.org and it seems that this time is the correct one to measure.

## Reviewers

@Wikia/x-wing 