### PR TITLE
XW-fix-pi-expand-button | increased z-index

### DIFF
--- a/front/main/app/styles/module/article/_portable-infobox.scss
+++ b/front/main/app/styles/module/article/_portable-infobox.scss
@@ -338,6 +338,7 @@ $group-header-font-size: 16px;
 			padding: $infobox-item-margin * 5 0 $infobox-item-margin * 2;
 			text-align: center;
 			width: 100%;
+			z-index: $z-1;
 		}
 
 		.pi-expand-icon {


### PR DESCRIPTION
Increased z-index to cover media component chevrons.

It was a bug and it was causing selenium tests to fail.

@Wikia/x-wing 