### PR TITLE
Remove article-edit-highlighted-entrypoint from article-wrapper

### DIFF
--- a/front/main/app/templates/components/article-wrapper.hbs
+++ b/front/main/app/templates/components/article-wrapper.hbs
@@ -121,10 +121,3 @@
 {{#if displayRecentEdit}}
 	{{recent-edit-banner}}
 {{/if}}
-{{article-edit-highlighted-entrypoint
-	section=highlightedSectionIndex
-	highlightedText=highlightedText
-	title=model.title
-	editAllowed=editAllowed
-	edit=(action 'edit')
-}}


### PR DESCRIPTION
## Links

* https://github.com/Wikia/mercury/pull/2360

## Description

Remove leftover which prevents Ember from starting.

## Reviewers

@Wikia/x-wing @adamkarminski 

