### PR TITLE
XW | clean up encoding

### DIFF
--- a/front/main/app/controllers/main-page.js
+++ b/front/main/app/controllers/main-page.js
@@ -21,15 +21,10 @@ export default Ember.Controller.extend({
 		 * @returns {void}
 		 */
 		openCuratedContentItem(item) {
-			/**
-			 * We have to double encode because Ember's RouteRecognizer does decodeURI while processing path.
-			 * If we didn't do encodeURI then it would do decodeURI on a result of our encodeURIComponent
-			 * and the title would be malformed.
-			 */
 			if (item.type === 'section') {
-				this.transitionToRoute('mainPageSection', encodeURI(encodeURIComponent(item.label)));
+				this.transitionToRoute('mainPageSection', item.label);
 			} else if (item.type === 'category') {
-				this.transitionToRoute('mainPageCategory', encodeURI(encodeURIComponent(item.categoryName)));
+				this.transitionToRoute('mainPageCategory', item.categoryName);
 			} else {
 				Ember.Logger.error('Can\'t open curated content item with type other than section or category', item);
 			}

--- a/front/main/app/mixins/main-page-route.js
+++ b/front/main/app/mixins/main-page-route.js
@@ -96,15 +96,10 @@ export default Ember.Mixin.create({
 		 * @returns {void}
 		 */
 		openCuratedContentItem(item) {
-			/**
-			 * We have to double encode because Ember's RouteRecognizer does decodeURI while processing path.
-			 * If we didn't do encodeURI then it would do decodeURI on a result of our encodeURIComponent
-			 * and the title would be malformed.
-			 */
 			if (item.type === 'section') {
-				this.transitionTo('mainPageSection', encodeURI(encodeURIComponent(item.label)));
+				this.transitionTo('mainPageSection', item.label);
 			} else if (item.type === 'category') {
-				this.transitionTo('mainPageCategory', encodeURI(encodeURIComponent(item.categoryName)));
+				this.transitionTo('mainPageCategory', item.categoryName);
 			} else {
 				Ember.Logger.error('Can\'t open curated content item with type other than section or category', item);
 			}

--- a/front/main/app/models/curated-content.js
+++ b/front/main/app/models/curated-content.js
@@ -38,7 +38,7 @@ function getURL(title, type, offset) {
 			query: {
 				controller: 'MercuryApi',
 				method: 'getCuratedContentSection',
-				section: decodeURIComponent(title)
+				section: title
 			}
 		});
 	} else if (type === 'category') {
@@ -49,7 +49,7 @@ function getURL(title, type, offset) {
 			abstract: 0,
 			width: 300,
 			height: 300,
-			category: decodeURIComponent(title),
+			category: title,
 			limit: 24
 		};
 

--- a/front/main/app/routes/application.js
+++ b/front/main/app/routes/application.js
@@ -155,7 +155,7 @@ export default Route.extend(
 				ArticleModel
 					.getArticleRandomTitle()
 					.then((articleTitle) => {
-						this.transitionTo('wiki-page', encodeURIComponent(normalizeToUnderscore(articleTitle)));
+						this.transitionTo('wiki-page', normalizeToUnderscore(articleTitle));
 					})
 					.catch((err) => {
 						this.send('error', err);

--- a/front/main/app/utils/wiki-handlers/wiki-page.js
+++ b/front/main/app/utils/wiki-handlers/wiki-page.js
@@ -12,11 +12,13 @@ function getURL(params) {
 	const query = {
 		controller: 'MercuryApi',
 		method: 'getPage',
-		title: params.title,
+		// We need to decode title because MW sends encoded content
+		// It's only necessary in case of in-content links
+		title: decodeURIComponent(params.title),
 	};
 
 	if (params.redirect) {
-		query.redirect = `?redirect=${encodeURIComponent(params.redirect)}`;
+		query.redirect = params.redirect;
 	}
 
 	return M.buildUrl({


### PR DESCRIPTION
## Description

Hapi was doing some special encoding/decoding when passing data to client. Because of that we had a lot of encoding/decoding on the client side. Without Hapi we can remove this logic.
All encoding is handled by:
* `M.buildUrl` when it comes to creating URLs
* Ember when it comes to transitions to different routes
* Handlebars when it comes to displaying data to user

## Reviewers

@Wikia/x-wing 

