### PR TITLE
Revert "XW-1445 | Update headroom"

### DIFF
--- a/front/main/bower.json
+++ b/front/main/bower.json
@@ -12,7 +12,7 @@
     "fastclick": "1.0.6",
     "foundation": "5.5.1",
     "hammerjs": "2.0.4",
-    "headroom.js": "tomasznapieralski/headroom.js#v0.7.0",
+    "headroom.js": "0.7.0",
     "i18next": "1.7.4",
     "jquery": "2.1.4",
     "jquery.cookie": "1.4.1",


### PR DESCRIPTION
Reverts Wikia/mercury#2414 which is no longer required.