### PR TITLE
XW-1449 call displayTitle only when it's set

### DIFF
--- a/front/main/app/models/wiki/article.js
+++ b/front/main/app/models/wiki/article.js
@@ -193,8 +193,8 @@ ArticleModel.reopenClass({
 			 * For main pages, title is wiki name, so we don't want to have duplicated text in documentTitle
 			 */
 			articleProperties.documentTitle = articleProperties.isMainPage ?
-					'' :
-					articleProperties.documentTitle = articleProperties.displayTitle || articleProperties.title;
+				'' :
+				articleProperties.displayTitle || articleProperties.title;
 		}
 
 		model.setProperties(articleProperties);

--- a/front/main/app/models/wiki/category.js
+++ b/front/main/app/models/wiki/category.js
@@ -135,7 +135,7 @@ CategoryModel.reopenClass({
 			 * This is necessary to avoid having duplicated title on Category pages
 			 * This should be removed in XW-1442
 			 */
-			if (pageProperties.displayTitle.indexOf(prefix) === 0) {
+			if (pageProperties.displayTitle && pageProperties.displayTitle.indexOf(prefix) === 0) {
 				pageProperties.displayTitle = pageProperties.displayTitle.substring(prefix.length);
 			}
 
@@ -143,7 +143,7 @@ CategoryModel.reopenClass({
 			 * This is necessary to avoid having duplicated title on Category pages
 			 * This should be removed in XW-1442
 			 */
-			if (pageProperties.title.indexOf(prefix) === 0) {
+			if (pageProperties.title && pageProperties.title.indexOf(prefix) === 0) {
 				pageProperties.title = pageProperties.title.substring(prefix.length);
 			}
 


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/XW-1449
* https://github.com/Wikia/mercury/pull/2423

## Description

We are calling `indexOf` on `displayTitle` and `title` when they are not set.
This case happens when category page has no article and on main pages

## Reviewers
@Wikia/x-wing 