### PR TITLE
XW | Relax .eslintrc on-var rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -165,7 +165,7 @@
     "no-underscore-dangle": 0,
     "no-unneeded-ternary": 2,
     "object-curly-spacing": [2, "never"],
-    "one-var": [2, "always"],
+    "one-var": 0,
     "operator-assignment": [0, "never"],
     "operator-linebreak": [2, "after"],
     "padded-blocks": 0,


### PR DESCRIPTION
## Links

* https://github.com/Wikia/guidelines/pull/110

## Description

As per discussion in guidelines https://github.com/Wikia/guidelines/pull/110, we're relaxing `.eslintrc` rules to allow multiple `let` and `consts`. Developers should still produce sane code with provided examples.

## Reviewers

/cc @Wikia/x-wing @hakubo 

