### PR TITLE
XW-1480 | Add new header to mobile article preview

### DIFF
--- a/front/main/app/components/article-content.js
+++ b/front/main/app/components/article-content.js
@@ -30,7 +30,7 @@ export default Ember.Component.extend(
 			this.destroyChildComponents();
 
 			Ember.run.scheduleOnce('afterRender', this, () => {
-				if (content) {
+				if (!Ember.isBlank(content)) {
 					this.hackIntoEmberRendering(content);
 
 					this.handleInfoboxes();

--- a/front/main/app/components/article-content.js
+++ b/front/main/app/components/article-content.js
@@ -54,7 +54,7 @@ export default Ember.Component.extend(
 
 					Ember.run.later(this, () => this.replaceMediaPlaceholdersWithMediaComponents(this.get('media')), 0);
 				} else {
-					this.hackIntoEmberRendering(i18n.t('app.article-empty-label'));
+					this.hackIntoEmberRendering(`<p>${i18n.t('app.article-empty-label')}</p>`);
 				}
 
 				this.injectAds();

--- a/front/main/app/components/article-wrapper.js
+++ b/front/main/app/components/article-wrapper.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import HeroImageMixin from '../mixins/hero-image';
 import LanguagesMixin from '../mixins/languages';
 import ViewportMixin from '../mixins/viewport';
 import {track, trackActions} from 'common/utils/track';
@@ -13,6 +14,7 @@ import {track, trackActions} from 'common/utils/track';
  */
 
 export default Ember.Component.extend(
+	HeroImageMixin,
 	LanguagesMixin,
 	ViewportMixin,
 	{
@@ -101,18 +103,6 @@ export default Ember.Component.extend(
 		 */
 		addPhotoAllowed: Ember.computed(function () {
 			return this.get('currentUser.isAuthenticated');
-		}),
-
-		heroImage: Ember.computed('model.media', function () {
-			let heroImage;
-
-			this.get('model.media.media').forEach((current) => {
-				if (current.hasOwnProperty('context') && current.context === 'infobox-hero-image') {
-					heroImage = current;
-				}
-			});
-
-			return heroImage;
 		}),
 
 		actions: {

--- a/front/main/app/components/article-wrapper.js
+++ b/front/main/app/components/article-wrapper.js
@@ -1,6 +1,6 @@
 import Ember from 'ember';
-import HeroImageMixin from '../mixins/hero-image';
 import LanguagesMixin from '../mixins/languages';
+import PortableInfoboxHeroImageMixin from '../mixins/portable-infobox-hero-image';
 import ViewportMixin from '../mixins/viewport';
 import {track, trackActions} from 'common/utils/track';
 
@@ -14,7 +14,7 @@ import {track, trackActions} from 'common/utils/track';
  */
 
 export default Ember.Component.extend(
-	HeroImageMixin,
+	PortableInfoboxHeroImageMixin,
 	LanguagesMixin,
 	ViewportMixin,
 	{

--- a/front/main/app/controllers/article-preview.js
+++ b/front/main/app/controllers/article-preview.js
@@ -1,16 +1,6 @@
 import Ember from 'ember';
-export default Ember.Controller.extend({
+import HeroImageMixin from '../mixins/hero-image';
+
+export default Ember.Controller.extend(HeroImageMixin, {
 	application: Ember.inject.controller(),
-
-	heroImage: Ember.computed('model.media', function () {
-		let heroImage;
-
-		this.get('model.media.media').forEach((current) => {
-			if (current.hasOwnProperty('context') && current.context === 'infobox-hero-image') {
-				heroImage = current;
-			}
-		});
-
-		return heroImage;
-	})
 });

--- a/front/main/app/controllers/article-preview.js
+++ b/front/main/app/controllers/article-preview.js
@@ -1,6 +1,4 @@
 import Ember from 'ember';
-import HeroImageMixin from '../mixins/hero-image';
+import PortableInfoboxHeroImageMixin from '../mixins/portable-infobox-hero-image';
 
-export default Ember.Controller.extend(HeroImageMixin, {
-	application: Ember.inject.controller(),
-});
+export default Ember.Controller.extend(PortableInfoboxHeroImageMixin, {});

--- a/front/main/app/controllers/article-preview.js
+++ b/front/main/app/controllers/article-preview.js
@@ -1,0 +1,16 @@
+import Ember from 'ember';
+export default Ember.Controller.extend({
+	application: Ember.inject.controller(),
+
+	heroImage: Ember.computed('model.media', function () {
+		let heroImage;
+
+		this.get('model.media.media').forEach((current) => {
+			if (current.hasOwnProperty('context') && current.context === 'infobox-hero-image') {
+				heroImage = current;
+			}
+		});
+
+		return heroImage;
+	})
+});

--- a/front/main/app/mixins/hero-image.js
+++ b/front/main/app/mixins/hero-image.js
@@ -1,0 +1,17 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+	heroImage: Ember.computed('model.media', function () {
+		const media = this.get('model.media.media');
+
+		if (Ember.isArray(media)) {
+			for (let i = 0; i < media.length; i++) {
+				if (media[i].hasOwnProperty('context') && media[i].context === 'infobox-hero-image') {
+					return media[i];
+				}
+			}
+		}
+
+		return null;
+	})
+});

--- a/front/main/app/mixins/portable-infobox-hero-image.js
+++ b/front/main/app/mixins/portable-infobox-hero-image.js
@@ -6,7 +6,7 @@ export default Ember.Mixin.create({
 
 		if (Ember.isArray(media)) {
 			for (let i = 0; i < media.length; i++) {
-				if (media[i].hasOwnProperty('context') && media[i].context === 'infobox-hero-image') {
+				if (media[i].context === 'infobox-hero-image') {
 					return media[i];
 				}
 			}

--- a/front/main/app/mixins/portable-infobox-hero-image.js
+++ b/front/main/app/mixins/portable-infobox-hero-image.js
@@ -6,7 +6,7 @@ export default Ember.Mixin.create({
 
 		if (Ember.isArray(media)) {
 			for (let i = 0; i < media.length; i++) {
-				if (media[i].context === 'infobox-hero-image') {
+				if (media[i] && media[i].context === 'infobox-hero-image') {
 					return media[i];
 				}
 			}

--- a/front/main/app/styles/component/wikia-ui-components/_wiki-page-header.scss
+++ b/front/main/app/styles/component/wikia-ui-components/_wiki-page-header.scss
@@ -9,50 +9,6 @@
 .wiki-page-header {
 	background: $color-blue-light;
 	color: #fff;
-
-	.wiki-page-header__wrapper {
-		display: flex;
-	}
-
-	// component modifier-related changes to elements
-	&.has-hero-image {
-		background-color: #fff;
-		background-position: center center;
-		background-repeat: no-repeat;
-
-		.wiki-page-header__wrapper {
-			background: linear-gradient(to bottom, transparent 70%, rgba(0, 0, 0, .6) 100%);
-			height: 100%;
-		}
-	}
-
-	&.has-hero-image-preload {
-		animation: wiki-page-header-preload-preloading 2s infinite;
-		height: 0;
-		padding-bottom: 100%;
-		position: relative;
-		width: 100%;
-
-		.wiki-page-header__wrapper {
-			bottom: 0;
-			left: 0;
-			position: absolute;
-			right: 0;
-		}
-	}
-
-	.wiki-page-header__main {
-		align-self: flex-end;
-		flex: 1;
-	}
-
-	.contribution-container {
-		margin-bottom: -8px;
-
-		.icon {
-			fill: #fff;
-		}
-	}
 }
 
 // component elements
@@ -87,10 +43,6 @@
 	a:hover svg {
 		fill: #081e3a;
 	}
-
-	~ .wiki-page-header__title {
-		  margin-top: 3px;
-	}
 }
 
 .wiki-page-header__site-link {
@@ -111,11 +63,59 @@
 	word-break: break-word;
 }
 
+.wiki-page-header__site-name-block ~ .wiki-page-header__title {
+	margin-top: 3px;
+}
+
 .wiki-page-header__subtitle {
 	@extend %wiki-page-header-element;
 
 	font-size: 14px;
 	margin-top: 15px;
+}
+
+// component modifier-related changes to elements
+.wiki-page-header .wiki-page-header__wrapper {
+	display: flex;
+}
+
+.wiki-page-header.has-hero-image {
+	background-color: #fff;
+	background-repeat: no-repeat;
+	background-position: center center;
+}
+
+.wiki-page-header.has-hero-image .wiki-page-header__wrapper {
+	background: linear-gradient(to bottom, transparent 70%, rgba(0, 0, 0,.6) 100%);
+	height: 100%;
+}
+
+.wiki-page-header.has-hero-image-preload {
+	animation: wiki-page-header-preload-preloading 2s infinite;
+	height: 0;
+	padding-bottom: 100%;
+	position: relative;
+	width: 100%;
+}
+
+.wiki-page-header.has-hero-image-preload .wiki-page-header__wrapper {
+	bottom: 0;
+	left: 0;
+	position: absolute;
+	right: 0;
+}
+
+.wiki-page-header .wiki-page-header__main {
+	align-self: flex-end;
+	flex: 1;
+}
+
+.wiki-page-header .contribution-container {
+	margin-bottom: -8px;
+
+	.icon {
+		fill: #fff;
+	}
 }
 
 // animations

--- a/front/main/app/styles/component/wikia-ui-components/_wiki-page-header.scss
+++ b/front/main/app/styles/component/wikia-ui-components/_wiki-page-header.scss
@@ -75,7 +75,7 @@
 }
 
 // component modifier-related changes to elements
-.wiki-page-header.has-action .wiki-page-header__wrapper {
+.wiki-page-header .wiki-page-header__wrapper {
 	display: flex;
 }
 
@@ -105,12 +105,12 @@
 	right: 0;
 }
 
-.wiki-page-header.has-action .wiki-page-header__main {
+.wiki-page-header .wiki-page-header__main {
 	align-self: flex-end;
 	flex: 1;
 }
 
-.wiki-page-header.has-action .contribution-container {
+.wiki-page-header .contribution-container {
 	margin-bottom: -8px;
 
 	.icon {

--- a/front/main/app/styles/component/wikia-ui-components/_wiki-page-header.scss
+++ b/front/main/app/styles/component/wikia-ui-components/_wiki-page-header.scss
@@ -9,6 +9,50 @@
 .wiki-page-header {
 	background: $color-blue-light;
 	color: #fff;
+
+	.wiki-page-header__wrapper {
+		display: flex;
+	}
+
+	// component modifier-related changes to elements
+	&.has-hero-image {
+		background-color: #fff;
+		background-position: center center;
+		background-repeat: no-repeat;
+
+		.wiki-page-header__wrapper {
+			background: linear-gradient(to bottom, transparent 70%, rgba(0, 0, 0, .6) 100%);
+			height: 100%;
+		}
+	}
+
+	&.has-hero-image-preload {
+		animation: wiki-page-header-preload-preloading 2s infinite;
+		height: 0;
+		padding-bottom: 100%;
+		position: relative;
+		width: 100%;
+
+		.wiki-page-header__wrapper {
+			bottom: 0;
+			left: 0;
+			position: absolute;
+			right: 0;
+		}
+	}
+
+	.wiki-page-header__main {
+		align-self: flex-end;
+		flex: 1;
+	}
+
+	.contribution-container {
+		margin-bottom: -8px;
+
+		.icon {
+			fill: #fff;
+		}
+	}
 }
 
 // component elements
@@ -43,6 +87,10 @@
 	a:hover svg {
 		fill: #081e3a;
 	}
+
+	~ .wiki-page-header__title {
+		  margin-top: 3px;
+	}
 }
 
 .wiki-page-header__site-link {
@@ -63,59 +111,11 @@
 	word-break: break-word;
 }
 
-.wiki-page-header__site-name-block ~ .wiki-page-header__title {
-	margin-top: 3px;
-}
-
 .wiki-page-header__subtitle {
 	@extend %wiki-page-header-element;
 
 	font-size: 14px;
 	margin-top: 15px;
-}
-
-// component modifier-related changes to elements
-.wiki-page-header .wiki-page-header__wrapper {
-	display: flex;
-}
-
-.wiki-page-header.has-hero-image {
-	background-color: #fff;
-	background-repeat: no-repeat;
-	background-position: center center;
-}
-
-.wiki-page-header.has-hero-image .wiki-page-header__wrapper {
-	background: linear-gradient(to bottom, transparent 70%, rgba(0, 0, 0,.6) 100%);
-	height: 100%;
-}
-
-.wiki-page-header.has-hero-image-preload {
-	animation: wiki-page-header-preload-preloading 2s infinite;
-	height: 0;
-	padding-bottom: 100%;
-	position: relative;
-	width: 100%;
-}
-
-.wiki-page-header.has-hero-image-preload .wiki-page-header__wrapper {
-	bottom: 0;
-	left: 0;
-	position: absolute;
-	right: 0;
-}
-
-.wiki-page-header .wiki-page-header__main {
-	align-self: flex-end;
-	flex: 1;
-}
-
-.wiki-page-header .contribution-container {
-	margin-bottom: -8px;
-
-	.icon {
-		fill: #fff;
-	}
 }
 
 // animations

--- a/front/main/app/styles/component/wikia-ui-components/_wiki-page-header.scss
+++ b/front/main/app/styles/component/wikia-ui-components/_wiki-page-header.scss
@@ -13,6 +13,7 @@
 
 // component elements
 .wiki-page-header__wrapper {
+	display: flex;
 	padding: {
 		bottom: 12px;
 		left: $article-horizontal-padding;
@@ -75,14 +76,12 @@
 }
 
 // component modifier-related changes to elements
-.wiki-page-header .wiki-page-header__wrapper {
-	display: flex;
-}
-
 .wiki-page-header.has-hero-image {
-	background-color: #fff;
-	background-repeat: no-repeat;
-	background-position: center center;
+	background: {
+		color: #fff;
+		position: center center;
+		repeat: no-repeat;
+	}
 }
 
 .wiki-page-header.has-hero-image .wiki-page-header__wrapper {
@@ -105,7 +104,7 @@
 	right: 0;
 }
 
-.wiki-page-header .wiki-page-header__main {
+.wiki-page-header__main {
 	align-self: flex-end;
 	flex: 1;
 }

--- a/front/main/app/styles/layout/_article-preview.scss
+++ b/front/main/app/styles/layout/_article-preview.scss
@@ -2,8 +2,4 @@
 	.ember-container {
 		pointer-events: none;
 	}
-
-	.page-wrapper {
-		margin-top: 20px;
-	}
 }

--- a/front/main/app/templates/article-preview.hbs
+++ b/front/main/app/templates/article-preview.hbs
@@ -1,4 +1,5 @@
 <div class="page-wrapper">
+	{{wikia-ui-components/wiki-page-header title=model.documentTitle heroImage=heroImage}}
 	<section class="article-body">
 		{{article-content
 			content=model.content

--- a/front/main/app/templates/components/wikia-ui-components/wiki-page-header.hbs
+++ b/front/main/app/templates/components/wikia-ui-components/wiki-page-header.hbs
@@ -1,5 +1,5 @@
-<div class="wiki-page-header{{if hasBlock ' has-action'}}{{if heroImage ' has-hero-image'}}" style={{computedStyle}}>
-    <div class="wiki-page-header__wrapper">
+<div class="wiki-page-header{{if heroImage ' has-hero-image'}}" style={{computedStyle}}>
+	<div class="wiki-page-header__wrapper">
 		<div class="wiki-page-header__main">
 			{{#if isMainPage}}
 				<h1 class="wiki-page-header__title">{{mainPageName}}</h1>


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/XW-1480
* PR to release-239: https://github.com/Wikia/mercury/pull/2434

## Description

Redesign of the top of the article implementation, header to be more precise, changes how the header + infobox is handled. This fixes the issue when no hero image and title was shown.

## Reviewers

@Wikia/x-wing @Wikia/west-wing