### PR TITLE
DAT-4206 | hide first title/hero image of the first portable infobox only in article context

### DIFF
--- a/front/main/app/styles/component/wikia-ui-components/_wiki-page-header.scss
+++ b/front/main/app/styles/component/wikia-ui-components/_wiki-page-header.scss
@@ -1,6 +1,6 @@
 // disable portable infobox hero image and title
 // @todo XW-1478 Remove the rule below when the first title/hero image of the first infobox is removed from markup.
-article aside:first-child {
+.article-content .portable-infobox:first-child {
 	.pi-hero,
 	.pi-title:first-child {
 		display: none;

--- a/front/main/app/styles/component/wikia-ui-components/_wiki-page-header.scss
+++ b/front/main/app/styles/component/wikia-ui-components/_wiki-page-header.scss
@@ -1,8 +1,10 @@
 // disable portable infobox hero image and title
-
-.pi-hero,
-.pi-title {
-	display: none !important;
+// @todo XW-1478 Remove the rule below when the first title/hero image of the first infobox is removed from markup.
+article aside:first-child {
+	.pi-hero,
+	.pi-title:first-child {
+		display: none;
+	}
 }
 
 // component


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/DAT-4206
* PR to `dev` https://github.com/Wikia/mercury/pull/2449

## Description

P2 fix for broken Special:InfoboxBuilder.

## Reviewers

@Wikia/x-wing @Wikia/west-wing 
