### PR TITLE
DAT-4206 | hide hero image/title even if first infobox fails to be moved to top

### DIFF
--- a/front/main/app/styles/component/wikia-ui-components/_wiki-page-header.scss
+++ b/front/main/app/styles/component/wikia-ui-components/_wiki-page-header.scss
@@ -1,8 +1,8 @@
 // disable portable infobox hero image and title
 // @todo XW-1478 Remove the rule below when the first title/hero image of the first infobox is removed from markup.
-.article-content .portable-infobox:first-child {
+.article-content .portable-infobox:first-of-type {
 	.pi-hero,
-	.pi-title:first-child {
+	.pi-title:first-of-type {
 		display: none;
 	}
 }


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/DAT-4206

## Description

Using old app code (without moving portable infobox to top of the article) revealed a flaw, that stuff that should be hidden is not in such case. This updated selector fixes that. Still true fix for hiding it is on the way with the cleanup.

## Reviewers

@Wikia/x-wing @nikodamn 