### PR TITLE
XW-1490 | Fix eslint configuration for homepage

### DIFF
--- a/homepage/.eslintrc
+++ b/homepage/.eslintrc
@@ -1,0 +1,3 @@
+{
+  "root": true // prevent looking in parent folders for rules
+}

--- a/homepage/front/.eslintrc
+++ b/homepage/front/.eslintrc
@@ -1,4 +1,13 @@
 {
+  "ecmaFeatures": {
+    "arrowFunctions": true,
+    "classes": true,
+    "defaultParams": true,
+    "forOf": true,
+    "modules": true,
+    "superInFunction": true,
+    "templateStrings": true
+  },
   "env": {
     "es6": true,
     "browser": true,


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/XW-1490

## Description

Automatic Mercury's deployment to stable fails because it's coupled with homepage which fails with:
```
/data/deploytools/build/homepage.jenkins.3bdaa440-1b7a-11e6-bd09-0cc47abb551a/homepage/node_modules/gulp-eslint/node_modules/eslint/lib/config/config-validator.js:102
        throw new Error(message.join(""));
              ^
Error: /data/deploytools/build/homepage.jenkins.3bdaa440-1b7a-11e6-bd09-0cc47abb551a/.eslintrc:
	Configuration for rule "quotes" is invalid:
	Value "[object Object]" must be an enum value.
```
This PR fixes eslint configuration and therefore should fix the stable's deploy.

## Reviewers

@Wikia/x-wing @kvas-damian 