### PR TITLE
DAT-4289 | header upload/edit icons fixed on Safari

### DIFF
--- a/front/main/app/styles/module/edit/_edit-common.scss
+++ b/front/main/app/styles/module/edit/_edit-common.scss
@@ -10,7 +10,6 @@ h2[section] {
 .contribution-container {
 	align-self: flex-end;
 	display: flex;
-	flex: 0;
 	margin-bottom: -7px;
 	margin-right: -13px;
 


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/DAT-4289

## Description

Setting flex properties to default ones (by removing the declaration) should make the icons show in the viewport.

## Reviewers

@Wikia/x-wing @Wikia/west-wing 

