### PR TITLE
DAT-4277 | Replace loading spinner with pulsating background on images

### DIFF
--- a/front/main/app/components/article-media-thumbnail.js
+++ b/front/main/app/components/article-media-thumbnail.js
@@ -11,7 +11,7 @@ export default Ember.Component.extend(
 	{
 		attributeBindings: ['data-ref', 'data-gallery-ref'],
 		classNames: ['article-media-thumbnail'],
-		classNameBindings: ['itemType', 'isSmall'],
+		classNameBindings: ['itemType', 'isLoading', 'isSmall'],
 		tagName: 'figure',
 
 		smallImageSize: {

--- a/front/main/app/components/content-recommendation-thumbnail.js
+++ b/front/main/app/components/content-recommendation-thumbnail.js
@@ -7,6 +7,7 @@ export default Ember.Component.extend(
 	{
 		// we want to re-use styles from article-media-thumbnail component
 		classNames: ['article-media-thumbnail'],
+		classNameBindings: ['isLoading'],
 		tagName: 'figure',
 
 		/**

--- a/front/main/app/styles/component/_article-media-thumbnail.scss
+++ b/front/main/app/styles/component/_article-media-thumbnail.scss
@@ -50,6 +50,7 @@
 
 .article-media-placeholder {
 	@extend %image-placeholder;
+	@include is-loading;
 
 	display: inline-block;
 	width: 100%;

--- a/front/main/app/styles/component/_article-media-thumbnail.scss
+++ b/front/main/app/styles/component/_article-media-thumbnail.scss
@@ -18,6 +18,12 @@
 		width: 100%;
 	}
 
+	&.is-loading {
+		img {
+			@include is-loading;
+		}
+	}
+
 	&.is-loaded {
 		img {
 			animation: lazyImage .3s;

--- a/front/main/app/styles/component/wikia-ui-components/_wiki-page-header.scss
+++ b/front/main/app/styles/component/wikia-ui-components/_wiki-page-header.scss
@@ -92,7 +92,8 @@
 }
 
 .wiki-page-header.has-hero-image-preload {
-	animation: wiki-page-header-preload-preloading 2s infinite;
+	@include is-loading;
+
 	height: 0;
 	padding-bottom: 100%;
 	position: relative;
@@ -117,11 +118,4 @@
 	.icon {
 		fill: #fff;
 	}
-}
-
-// animations
-@keyframes wiki-page-header-preload-preloading {
-	0%   {background-color: #888;}
-	50%  {background-color: #999;}
-	100% {background-color: #888;}
 }

--- a/front/main/app/styles/mixin/index.scss
+++ b/front/main/app/styles/mixin/index.scss
@@ -1,6 +1,7 @@
 @import 'clamp';
 @import 'ellipsis';
 @import 'image-placeholder';
+@import 'is-loading';
 @import 'perfect-square';
 @import 'play-icon-in-circle';
 @import 'rtl';

--- a/front/main/app/styles/mixin/is-loading.scss
+++ b/front/main/app/styles/mixin/is-loading.scss
@@ -1,0 +1,15 @@
+@mixin is-loading {
+	animation: is-loading 2s infinite;
+}
+
+@keyframes is-loading {
+	0% {
+		background-color: #888;
+	}
+	50% {
+		background-color: #999;
+	}
+	100% {
+		background-color: #888;
+	}
+}

--- a/front/main/app/styles/mixin/is-loading.scss
+++ b/front/main/app/styles/mixin/is-loading.scss
@@ -4,12 +4,12 @@
 
 @keyframes is-loading {
 	0% {
-		background-color: #888;
+		background-color: #e6e6e6;
 	}
 	50% {
-		background-color: #999;
+		background-color: #f6f6f6;
 	}
 	100% {
-		background-color: #888;
+		background-color: #e6e6e6;
 	}
 }

--- a/front/main/app/templates/components/article-media-thumbnail.hbs
+++ b/front/main/app/templates/components/article-media-thumbnail.hbs
@@ -1,4 +1,4 @@
-{{! This wrapper is required so the spinner and chevron are positioned correctly }}
+{{! This wrapper is required so the chevron is positioned correctly }}
 <div class="article-media-thumbnail-image-wrapper">
 	{{#if link}}
 		<a href="{{link}}">
@@ -12,10 +12,6 @@
 			height="{{if forcedHeight forcedHeight height}}"
 			width="{{if forcedWidth forcedWidth width}}">
 	{{/if}}
-	{{loading-spinner
-		active=isLoading
-		overlay=false
-	}}
 </div>
 
 {{! Allow custom captions }}

--- a/front/main/app/templates/components/content-recommendation-thumbnail.hbs
+++ b/front/main/app/templates/components/content-recommendation-thumbnail.hbs
@@ -1,9 +1,5 @@
 <div class="article-media-thumbnail-image-wrapper">
 	<img src="{{thumbnailUrl}}" height="200">
 	{{svg 'chevron-linked' viewBox='0 0 20 20' class='chevron'}}
-	{{loading-spinner
-		active=isLoading
-		overlay=false
-	}}
 </div>
 <figcaption>{{{caption}}}</figcaption>

--- a/server/app/views/_partials/wiki-page-header.hbs
+++ b/server/app/views/_partials/wiki-page-header.hbs
@@ -1,4 +1,4 @@
-<div class="wiki-page-header{{#if hasHeroImage}} has-hero-image-preload{{/if}}">
+<div class="wiki-page-header{{#if hasHeroImage}} has-hero-image has-hero-image-preload{{/if}}">
 	<div class="wiki-page-header__wrapper">
 		<div class="wiki-page-header__main">
 			<h2 class="wiki-page-header__site-name-block">


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/DAT-4277

## Description

Instead of displaying loading spinner on images let's use the same pulsating background which we use on hero image.

## Reviewers

@Warkot @vforge 