### PR TITLE
DAT-4236 | Fix site head markup

### DIFF
--- a/front/main/app/index.html
+++ b/front/main/app/index.html
@@ -63,11 +63,13 @@
 --}}
 <div id="ember-container" class="ember-container">
 	<div id="preload">
-		<nav class="site-head">
-			<div class="site-logo">
-				{{content-for 'wikia-logo'}}
-			</div>
-		</nav>
+		<div class="site-head-wrapper">
+			<nav class="site-head">
+				<div class="site-logo">
+					{{content-for 'wikia-logo'}}
+				</div>
+			</nav>
+		</div>
 		<div class="page-wrapper" lang="{{wikiVariables.language.content}}" dir="{{wikiVariables.language.contentDir}}">
 			{{{content}}}
 		</div>

--- a/front/main/app/templates/components/site-head.hbs
+++ b/front/main/app/templates/components/site-head.hbs
@@ -1,3 +1,8 @@
+{{!--
+	Keep this in sync with:
+	/front/main/app/index.html
+	/server/app/views/_partials/site-head.hbs
+--}}
 <div class="site-head-wrapper">
 	<nav class="site-head">
 		<div class="site-logo site-logo-2016">

--- a/server/app/views/_layouts/error.hbs
+++ b/server/app/views/_layouts/error.hbs
@@ -19,19 +19,55 @@
 				flex-direction: column;
 			}
 
+			.site-head-container {
+				min-height: 3.4375rem;
+			}
+
+			.site-head-wrapper {
+				height: 3.4375rem;
+			}
+
 			.site-head {
-				border-bottom: 1px solid #E6EBF2;
-				display: block;
-				flex-shrink: 0;
-				padding: 14px 0 7px;
-			}
-
-			.site-head div {
+				background-color: #FFF;
+				border-top: .375rem solid #092344;
+				border-bottom: 1px solid #F6F6F6;
+				direction: ltr;
+				display: -webkit-box;
+				display: -webkit-flex;
+				display: -ms-flexbox;
+				display: flex;
+				-webkit-box-orient: horizontal;
+				-webkit-box-direction: normal;
+				-webkit-flex-direction: row;
+				-ms-flex-direction: row;
+				flex-direction: row;
+				-webkit-flex-wrap: nowrap;
+				-ms-flex-wrap: nowrap;
+				flex-wrap: nowrap;
+				-webkit-box-pack: justify;
+				-webkit-justify-content: space-between;
+				-ms-flex-pack: justify;
+				justify-content: space-between;
+				left: 0;
+				margin: 0 auto;
+				position: fixed;
+				right: 0;
 				text-align: center;
+				-webkit-transition: box-shadow .5s;
+				transition: box-shadow .5s;
+				top: 0;
+				width: 100%;
+				z-index: 700;
 			}
 
-			.site-head img {
-				height: 22px;
+			.site-logo {
+				height: 3.0625rem;
+				margin: auto;
+				-webkit-box-ordinal-group: 3;
+				-webkit-order: 2;
+				-ms-flex-order: 2;
+				order: 2;
+				overflow: hidden;
 			}
 
 			.container {

--- a/server/app/views/_partials/site-head.hbs
+++ b/server/app/views/_partials/site-head.hbs
@@ -3,10 +3,12 @@
 	/front/main/app/components/site-head.js
 	/front/main/app/templates/components/site-head.hbs
 --}}
-<nav class="site-head">
-	<div>
-		<a href="http://www.wikia.com/fandom">
-			<img src="/front/common/symbols/wikia-logo.svg" />
-		</a>
-	</div>
-</nav>
+<div class="site-head-wrapper">
+	<nav class="site-head">
+		<div class="site-logo">
+			<a href="http://www.wikia.com/fandom">
+				<img src="/front/common/symbols/wikia-logo.svg" width="71" height="48" />
+			</a>
+		</div>
+	</nav>
+</div>

--- a/server/app/views/article.hbs
+++ b/server/app/views/article.hbs
@@ -1,6 +1,5 @@
 <section class="article-body">
 	{{#unless preview}}
-		<div class="mobile-top-leaderboard">&nbsp;</div>
 		{{> wiki-page-header}}
 	{{/unless}}
 	<article class="article-content" id="preloadedContent">


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/DAT-4236

## Description

Unify pre-ember site head markup with the final one. Fixes the issue with article header's position.
Also removes the empty ad-slot placeholder because page jumps anyway and it looked bad.

## Reviewers

@Wikia/x-wing 
