### PR TITLE
DAT-4334 | pass error to isForbiddenError not error.status which is undefined

### DIFF
--- a/front/main/app/routes/curated-content-editor.js
+++ b/front/main/app/routes/curated-content-editor.js
@@ -181,7 +181,7 @@ export default Ember.Route.extend(
 			 * @returns {Boolean} returns true
 			 */
 			error(error) {
-				if (isForbiddenError(error.status)) {
+				if (isForbiddenError(error)) {
 					this.controllerFor('application').addAlert({
 						message: i18n.t('app.curated-content-editor-error-no-access-permissions'),
 						type: 'warning'


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/DAT-4334

## Description

isForbiddenError expects an error as an argument, not error.status which is undefined.

## Reviewers

@Wikia/x-wing @hakubo 