### PR TITLE
JPN-565 | Fix for add photo button broken when logged out

### DIFF
--- a/front/main/app/templates/components/article-contribution.hbs
+++ b/front/main/app/templates/components/article-contribution.hbs
@@ -1,10 +1,14 @@
 {{#if addPhotoIconVisible}}
-	<div class='upload-photo'>
-		{{svg 'camera' role='img' class='icon camera'}}
-		{{#if addPhotoAllowed}}
+	{{#if addPhotoAllowed}}
+		<div class='upload-photo'>
+			{{svg 'camera' role='img' class='icon camera'}}
 			<input class="file-upload-input" type="file" accept="image/*" {{action 'addPhoto' on='change'}}/>
-		{{/if}}
-	</div>
+		</div>
+	{{else}}
+		<div class='upload-photo' {{action 'addPhoto'}}>
+			{{svg 'camera' role='img' class='icon camera'}}
+		</div>
+	{{/if}}
 {{/if}}
 {{#if editIconVisible}}
 	<div class='edit-section' {{action 'edit'}}>


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/JPN-565

## Description

Add photo on mercury does not work when the user is logged out.

{{action 'addPhoto'}} was missing for when the user is logged out (addPhotoAllowed set to false).
When user is logged in, the same action needs to be on the input tag, so I changed the nesting to render differently based on the state of addPhotoAllowed. The event handler addPhoto handles both cases correctly.

## Reviewers

@hakubo 