### PR TITLE
DAT-4486 experiment: place mobile_top_leaderboard between first and second viewport

### DIFF
--- a/front/main/app/components/portable-infobox.js
+++ b/front/main/app/components/portable-infobox.js
@@ -2,6 +2,7 @@ import Ember from 'ember';
 import ArticleContentMixin from '../mixins/article-content';
 import ViewportMixin from '../mixins/viewport';
 import {track, trackActions} from 'common/utils/track';
+import {inGroup} from 'common/modules/abtest';
 
 export default Ember.Component.extend(
 	ArticleContentMixin,
@@ -45,7 +46,11 @@ export default Ember.Component.extend(
 				deviceHeight = this.get('viewportDimensions.height'),
 				isLandscape = deviceWidth > deviceHeight;
 
-			return Math.floor((isLandscape ? deviceHeight : deviceWidth) * 16 / 9) + 100;
+			if (inGroup('MERCURY_VIEWABILITY_EXPERIMENT', 'AD_ON_PAGE_FOLD')) {
+				return Math.floor(isLandscape ? deviceHeight : deviceWidth) - 200;
+			} else {
+				return Math.floor((isLandscape ? deviceHeight : deviceWidth) * 16 / 9) + 100;
+			}
 		}),
 
 		didInsertElement() {

--- a/front/main/app/components/portable-infobox.js
+++ b/front/main/app/components/portable-infobox.js
@@ -46,6 +46,7 @@ export default Ember.Component.extend(
 				deviceHeight = this.get('viewportDimensions.height'),
 				isLandscape = deviceWidth > deviceHeight;
 
+			// used for ad viability on infobox page experiment, should be removed as part of DAT-4487
 			if (inGroup('MERCURY_VIEWABILITY_EXPERIMENT', 'AD_ON_PAGE_FOLD')) {
 				return Math.floor(isLandscape ? deviceHeight : deviceWidth) - 200;
 			} else {

--- a/front/main/app/components/portable-infobox.js
+++ b/front/main/app/components/portable-infobox.js
@@ -46,7 +46,12 @@ export default Ember.Component.extend(
 				deviceHeight = this.get('viewportDimensions.height'),
 				isLandscape = deviceWidth > deviceHeight;
 
-			// used for ad viability on infobox page experiment, should be removed as part of DAT-4487
+			/**
+			 * If we're in group AD_ON_PAGE_FOLD we want to shorter collapsed infobox to make
+			 * top leaderboard ad be placed on the end of the first page.
+			 *
+			 * used for ad viewability on infobox page experiment, should be removed as part of DAT-4487
+ 			 */
 			if (inGroup('MERCURY_VIEWABILITY_EXPERIMENT', 'AD_ON_PAGE_FOLD')) {
 				return Math.floor(isLandscape ? deviceHeight : deviceWidth) - 200;
 			} else {

--- a/front/main/app/mixins/ads.js
+++ b/front/main/app/mixins/ads.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
 import AdSlotComponent from '../components/ad-slot';
 import Ads from 'common/modules/ads';
-import {inGroup} from 'common/modules/abtest';
+import {getGroup} from 'common/modules/abtest';
 
 export default Ember.Mixin.create({
 	adsData: {
@@ -147,6 +147,7 @@ export default Ember.Mixin.create({
 			$articleBody = $('.article-body'),
 
 			// used for ad viability on infobox page experiment, should be removed as part of DAT-4487
+			viewabilityExperimentGroup = getGroup('MERCURY_VIEWABILITY_EXPERIMENT'),
 			$pi = $('.portable-infobox'),
 			$topPlacement = $('.wiki-container'),
 
@@ -169,7 +170,8 @@ export default Ember.Mixin.create({
 		}
 
 		// used for ad viability on infobox page experiment, should be removed as part of DAT-4487
-		if (inGroup('MERCURY_VIEWABILITY_EXPERIMENT', 'AD_BELOW_INFOBOX')) {
+		if (viewabilityExperimentGroup === 'AD_BELOW_INFOBOX' ||
+			viewabilityExperimentGroup === 'AD_ON_PAGE_FOLD') {
 			if ($pi.length) {
 				// inject after infobox
 				this.appendAd(this.adsData.mobileTopLeaderBoard, 'after', $pi.first());

--- a/front/main/app/mixins/ads.js
+++ b/front/main/app/mixins/ads.js
@@ -146,7 +146,7 @@ export default Ember.Mixin.create({
 		const $firstSection = this.$().children('h2').first(),
 			$articleBody = $('.article-body'),
 
-			// used for ad viability on infobox page experiment, should be removed as part of DAT-4487
+			// used for ad viewability on infobox page experiment, should be removed as part of DAT-4487
 			viewabilityExperimentGroup = getGroup('MERCURY_VIEWABILITY_EXPERIMENT'),
 
 			$pi = $('.portable-infobox'),
@@ -170,7 +170,7 @@ export default Ember.Mixin.create({
 			this.appendAd(this.adsData.mobilePreFooter, 'after', $articleBody);
 		}
 
-		// used for ad viability on infobox page experiment, should be removed as part of DAT-4487
+		// used for ad viewability on infobox page experiment, should be removed as part of DAT-4487
 		if (viewabilityExperimentGroup === 'AD_BELOW_INFOBOX' ||
 			viewabilityExperimentGroup === 'AD_ON_PAGE_FOLD') {
 			if ($pi.length) {

--- a/front/main/app/styles/module/_ads.scss
+++ b/front/main/app/styles/module/_ads.scss
@@ -60,7 +60,7 @@ $ad-background: rgb(44, 52, 61);
 	border: 0;
 }
 
-// used for ad viability on infobox page experiment, should be removed as part of DAT-4487
+// used for ad viewability on infobox page experiment, should be removed as part of DAT-4487
 .article-content .mobile-top-leaderboard .ad-slot {
 	background: $white;
 }

--- a/front/main/app/styles/module/_ads.scss
+++ b/front/main/app/styles/module/_ads.scss
@@ -59,3 +59,8 @@ $ad-background: rgb(44, 52, 61);
 .wikia-ad-iframe {
 	border: 0;
 }
+
+// used for ad viability on infobox page experiment, should be removed as part of DAT-4487
+.article-content .mobile-top-leaderboard .ad-slot {
+	background: $white;
+}


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/DAT-4486

## Description

place mobile_top_leaderboard between first and second viewport

## Reviewers
@Wikia/west-wing  @vforge @bognix 
