### PR TITLE
Stop using mirror for PhantomJS

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,1 @@
 save-exact=true
-phantomjs_cdnurl=http://cnpmjs.org/downloads


### PR DESCRIPTION
## Links

* https://github.com/Wikia/mercury/pull/2227

## Description

Mirror that we use is sometimes very slow and it takes few minutes to download PhantomJS. It doesn't make much sense to use it.

## Reviewers

@tomasznapieralski 
