### PR TITLE
Use a fork of broccoli-asset-rev to lock broccoli-asset-rewrite@1.0.9

### DIFF
--- a/front/main/package.json
+++ b/front/main/package.json
@@ -18,7 +18,7 @@
   "author": "",
   "license": "MIT",
   "devDependencies": {
-    "broccoli-asset-rev": "2.4.2",
+    "broccoli-asset-rev": "rogatty/broccoli-asset-rev#broccoli-asset-rewrite-1.0.9",
     "broccoli-babel-transpiler": "5.5.0",
     "broccoli-concat": "2.0.4",
     "broccoli-funnel": "1.0.1",


### PR DESCRIPTION
## Links

* https://github.com/rogatty/broccoli-asset-rev/commit/93dcaf10a730d886333db1c3a6cdc61fedd687bc
* https://github.com/rickharrison/broccoli-asset-rewrite/pull/35

## Description

Fix the issue with assets fingerprinting by using a fork of broccoli-asset-rev which locks the version of broccoli-asset-rewrite.

## Reviewers

@hakubo @kvas-damian 

