### PR TITLE
(DAT-4579) Treat local URLs with query parameters as external URLs

### DIFF
--- a/front/main/app/routes/application.js
+++ b/front/main/app/routes/application.js
@@ -106,7 +106,8 @@ export default Route.extend(
 					Mercury.wiki.basePath,
 					title,
 					target.hash,
-					target.href
+					target.href,
+					target.search
 				);
 
 				/**

--- a/front/main/app/utils/article-link.js
+++ b/front/main/app/utils/article-link.js
@@ -20,13 +20,16 @@
  * @param {string} hash - jumplink, either '#something' (to indicate
  *   there is a jumplink) or '' or undefined
  * @param {string} uri - the absolute link
+ * @param {string} queryString - the query string
  *
  * @returns {LinkInfo}
  */
-export default function getLinkInfo(basePath, title, hash, uri) {
+export default function getLinkInfo(basePath, title, hash, uri, queryString) {
 	const localPathMatch = uri.match(`^${window.location.origin}(.*)$`);
 
-	if (localPathMatch) {
+	// We treat local URLs with query params that aren't handled elsewhere
+	// as external links rather than as articles
+	if (localPathMatch && !queryString) {
 		const local = localPathMatch[1],
 
 			/**

--- a/front/main/tests/unit/utils/article-link-test.js
+++ b/front/main/tests/unit/utils/article-link-test.js
@@ -47,6 +47,38 @@ module('Unit | Utility | article link', () => {
 		});
 	});
 
+	test('getLinkInfo links with query params', (assert) => {
+		const linkTitle = 'article',
+			linkHref = `${window.location.origin}/wiki/${linkTitle}`,
+			testCases = [
+				{
+					queryString: '',
+					expectedArticle: linkTitle,
+					expectedUri: null
+				},
+				{
+					queryString: '?action=history',
+					expectedArticle: null,
+					expectedUri: `${linkHref}?action=history`
+				},
+				{
+					queryString: '?curid=509986&diff=6318659&oldid=6318638',
+					expectedArticle: null,
+					expectedUri: `${linkHref}?curid=509986&diff=6318659&oldid=6318638`
+				}
+			];
+
+		assert.expect(testCases.length * 2);
+		testCases.forEach((testCase) => {
+			// 'pageTitle' is distinct from the tests, we're transitioning from a different page
+			const result = getLinkInfo('http://lastofus.wikia.com', 'pageTitle', '',
+				`${linkHref}${testCase.queryString}`, testCase.queryString);
+
+			assert.equal(result.article, testCase.expectedArticle);
+			assert.equal(result.url, testCase.expectedUri);
+		});
+	});
+
 	test('getLinkInfo jump links', (assert) => {
 		const res = getLinkInfo(
 			'http://lastofus.wikia.com',


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/DAT-4579
* https://github.com/Wikia/app/pull/10787

## Description

If a local article URL has a query param, we should treat it as a full external
URL if it is not handled elsewhere. Manual local URLs with query params created by
users are already handled as the MediaWiki parser adds the external class which
is already checked in Mercury.

This is an extra safety check in case any extensions add URLs with query params
(as TabView did) so that they don't result in a broken page when clicked.

action=render is removed from the TabView links in https://github.com/Wikia/app/pull/10787.

## Reviewers

@Wikia/x-wing 