### PR TITLE
RECIRC-168: Add placement test to renderedComponents for proper teardown

### DIFF
--- a/front/main/app/components/article-content.js
+++ b/front/main/app/components/article-content.js
@@ -633,6 +633,8 @@ export default Ember.Component.extend(
 				location.after(view.$());
 				view.trigger('didInsertElement');
 				view.trackImpression();
+
+				this.renderedComponents.push(view);
 			}
 		},
 

--- a/front/main/app/mixins/recirculation-experiment.js
+++ b/front/main/app/mixins/recirculation-experiment.js
@@ -18,7 +18,7 @@ export default Ember.Mixin.create(
 			return getGroup(this.get('experimentName'));
 		}),
 
-		items: Ember.computed('model.items', 'shouldBeLoaded', function () {
+		items: Ember.computed('model.items', function () {
 			return this.get('model.items').map((item) => {
 				if (this.get('externalLink')) {
 					const params = {
@@ -66,8 +66,8 @@ export default Ember.Mixin.create(
 					label: this.get('label')
 				});
 
+				this.set('isLoading', true);
 				if (this.get('externalLink')) {
-					this.set('isLoading', true);
 					setTimeout(() => {
 						window.location.assign(url);
 					}, 200);

--- a/front/main/app/models/top-links.js
+++ b/front/main/app/models/top-links.js
@@ -8,6 +8,7 @@ import request from 'ember-ajax/request';
  * used as a baseline to correlate with the results we've seen on desktop.
  */
 const TopLinksModel = Ember.Object.extend({
+	title: 'Top Links',
 	article: null,
 	init() {
 		this._super(...arguments);

--- a/front/main/app/styles/component/_recirculation-experiment.scss
+++ b/front/main/app/styles/component/_recirculation-experiment.scss
@@ -10,7 +10,7 @@ $recirculation-e3-fandom-thumbnail-height: 55px;
 		@extend %image-placeholder;
 	}
 
-	.footer {
+	&.footer {
 		p {
 			margin: 0.5rem 0 1.5rem;
 		}

--- a/front/main/app/templates/components/recirculation/footer.hbs
+++ b/front/main/app/templates/components/recirculation/footer.hbs
@@ -3,7 +3,7 @@
 		<h2>{{model.title}}</h2>
 		<ul class="thumbnails">
 			{{#each items as |item|}}
-				<li class="title-thumbnail" {{action 'trackExperimentClick' item.url}}>
+				<li class="title-thumbnail" {{action 'trackExperimentClick' item.url preventDefault=(if externalLink true false)}}>
 					<a href="{{if externalLink '#' item.url}}">
 						<div class="image image-thumbnail">
 							{{#if shouldBeLoaded }}


### PR DESCRIPTION
## Links
* https://wikia-inc.atlassian.net/browse/RECIRC-168

## Description
Placement test components were not getting properly torn down in-between article transitions causing duplication to occur. We fix this by adding that component to article-contents `renderedComponents` array.

## Reviewers
@Wikia/x-wing 

