### PR TITLE
(XW-1735) Escape content of wrap-me helper by default

### DIFF
--- a/front/main/app/components/discussion-post-card-top-note.js
+++ b/front/main/app/components/discussion-post-card-top-note.js
@@ -31,7 +31,7 @@ export default Ember.Component.extend({
 			}),
 			count: this.get('post.reportDetails.count'),
 			reporterUserName: wrapMeHelper.compute([
-				Ember.Handlebars.Utils.escapeExpression(this.get('post.reportDetails.users.firstObject.name'))
+				this.get('post.reportDetails.users.firstObject.name')
 			], {
 				tagName: 'a',
 				className: this.get('reportDetailsEntryPointClassName'),

--- a/front/main/app/components/discussion-welcome.js
+++ b/front/main/app/components/discussion-welcome.js
@@ -8,7 +8,7 @@ export default Ember.Component.extend({
 	wasSeen: Boolean(localStorage.getItem('discussionWelcomeMessageSeen')),
 
 	guidelinesLink: wrapMeHelper.compute([
-		Ember.Handlebars.Utils.escapeExpression(i18n.t('main.guidelines-link-title', {ns: 'discussion'}))
+		i18n.t('main.guidelines-link-title', {ns: 'discussion'})
 	], {
 		tagName: 'a',
 		className: 'guidelinesOpener',

--- a/front/main/app/helpers/wrap-me.js
+++ b/front/main/app/helpers/wrap-me.js
@@ -2,10 +2,11 @@ import Ember from 'ember';
 
 /**
  * Helper to generate HTML from passed string and additional options.
- * By default, if no tagName specified, wraps passed string in <div> tags.
+ * The passed string is HTML escaped before being wrapped in the given tags.
+ * By default, if no tagName specified, wraps passed string in <span> tags.
  * Useful ie. when we need to style differently elements of the same string.
  * Options:
- * - tagName - override default div tag name
+ * - tagName - override default span tag name
  * - className - class name to be added to wrapping tag
  *
  * @example
@@ -22,7 +23,7 @@ import Ember from 'ember';
 const {Handlebars, Helper} = Ember;
 
 export default Helper.helper((params, options) => {
-	const content = params[0] || '';
+	const content = Handlebars.Utils.escapeExpression(params[0] || '');
 	let tagName = 'span',
 		className = '';
 

--- a/front/main/tests/unit/helpers/wrap-me-test.js
+++ b/front/main/tests/unit/helpers/wrap-me-test.js
@@ -48,4 +48,11 @@ module('Unit | Helper | wrap-me', () => {
 
 		assert.equal(html, '<span></span>');
 	});
+
+	test('generate html with unsafe content', (assert) => {
+		const options = {},
+			html = wrapMeHelper.compute(['some<script>alert(0);</script>text'], options);
+
+		assert.equal(html, '<span>some&lt;script&gt;alert(0);&lt;/script&gt;text</span>');
+	});
 });


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/XW-1735
* https://github.com/Wikia/mercury/pull/2625

## Description

Make sure the wrap-me helper escapes the content passed to it by default. See ticket
for details.

Reviewed in and backported from https://github.com/Wikia/mercury/pull/2625

## Reviewers

/cc @Wikia/x-wing