### PR TITLE
ADEN-3584 Ported tested changes from dev branch

### DIFF
--- a/front/common/modules/ads.js
+++ b/front/common/modules/ads.js
@@ -48,11 +48,6 @@ class Ads {
 		this.uapCalled = false;
 		this.uapCallbacks = [];
 		this.noUapCallbacks = [];
-		this.btfSlots = [
-			'MOBILE_IN_CONTENT',
-			'MOBILE_PREFOOTER',
-			'MOBILE_BOTTOM_LEADERBOARD'
-		];
 	}
 
 	/**
@@ -137,10 +132,6 @@ class Ads {
 		} else {
 			noUapCallback();
 		}
-	}
-
-	getBtfSlots() {
-		return this.btfSlots;
 	}
 
 	/**

--- a/front/main/app/components/ad-slot.js
+++ b/front/main/app/components/ad-slot.js
@@ -12,6 +12,8 @@ export default Component.extend(
 		// This component is created dynamically, and this won't work without it
 		layoutName: 'components/ad-slot',
 
+		disableManualInsert: false,
+		isAboveTheFold: false,
 		name: null,
 
 		nameLowerCase: computed('name', function () {
@@ -41,12 +43,16 @@ export default Component.extend(
 			const ads = Ads.getInstance(),
 				name = this.get('name');
 
+			if (this.get('disableManualInsert')) {
+				return;
+			}
+
 			if (this.get('noAds')) {
 				Logger.info('Ad disabled for:', name);
 				return;
 			}
 
-			if (ads.getBtfSlots().indexOf(name) === -1) {
+			if (this.get('isAboveTheFold')) {
 				Logger.info('Injected ad', name);
 				ads.addSlot(name);
 			} else {
@@ -79,7 +85,7 @@ export default Component.extend(
 				return;
 			}
 
-			if (ads.getBtfSlots().indexOf(name) > -1) {
+			if (!this.get('isAboveTheFold')) {
 				ads.waitForUapResponse(
 					() => {
 						Logger.info('Injected ad on scroll:', name);

--- a/front/main/app/mixins/ads.js
+++ b/front/main/app/mixins/ads.js
@@ -3,6 +3,15 @@ import Ads from 'common/modules/ads';
 
 export default Ember.Mixin.create({
 	adsData: {
+		additionalConfig: {
+			MOBILE_TOP_LEADERBOARD: {
+				// ATF slot is pushed immediately (without any delay/in single request with other slots)
+				isAboveTheFold: true
+			},
+			MOBILE_BOTTOM_LEADERBOARD: {
+				disableManualInsert: true
+			}
+		},
 		minZerothSectionLength: 700,
 		minPageLength: 2000,
 		mobileBottomLeaderBoard: 'MOBILE_BOTTOM_LEADERBOARD',
@@ -39,11 +48,15 @@ export default Ember.Mixin.create({
 	 * @returns {void}
 	 */
 	appendAd(adSlotName, place, element) {
-		const component = this.get('container').lookup(`component:ad-slot`, {
-			singleton: false
-		});
+		const adsData = this.get('adsData'),
+			component = this.get('container').lookup(`component:ad-slot`, {
+				singleton: false
+			}),
+			config = adsData.additionalConfig[adSlotName] || {};
 
 		component.setProperties({
+			disableManualInsert: !!config.disableManualInsert,
+			isAboveTheFold: !!config.isAboveTheFold,
 			name: adSlotName,
 			noAds: this.get('noAds')
 		});

--- a/front/main/app/templates/article.hbs
+++ b/front/main/app/templates/article.hbs
@@ -1,4 +1,4 @@
-{{ad-slot name='INVISIBLE_HIGH_IMPACT' noAds=noAds}}
+{{ad-slot isAboveTheFold=true name='INVISIBLE_HIGH_IMPACT' noAds=noAds}}
 <div class="wiki-container">
 	{{article-wrapper
 		commentsPage=commentsPage

--- a/front/main/app/templates/category.hbs
+++ b/front/main/app/templates/category.hbs
@@ -1,4 +1,4 @@
-{{ad-slot name='INVISIBLE_HIGH_IMPACT' noAds=noAds}}
+{{ad-slot isAboveTheFold=true name='INVISIBLE_HIGH_IMPACT' noAds=noAds}}
 <div class="wiki-container">
 	{{#if model.hasArticle}}
 		{{#article-wrapper

--- a/front/main/app/templates/components/article-wrapper.hbs
+++ b/front/main/app/templates/components/article-wrapper.hbs
@@ -22,7 +22,7 @@
 	{{/if}}
 {{/ab-test}}
 <section class="article-body">
-	{{ad-slot name='NATIVE_PAID_ASSET_DROP' noAds=noAds}}
+	{{ad-slot isAboveTheFold=true name='NATIVE_PAID_ASSET_DROP' noAds=noAds}}
 	{{article-content
 		adsContext=model.adsContext
 		content=model.content

--- a/front/main/app/templates/components/main-page.hbs
+++ b/front/main/app/templates/components/main-page.hbs
@@ -7,7 +7,7 @@
 	{{#if wikiaStats}}
 		{{wikia-stats model=wikiaStats}}
 	{{/if}}
-	{{ad-slot name='NATIVE_PAID_ASSET_DROP' noAds=noAds class='main-page-pad-slot'}}
+	{{ad-slot isAboveTheFold=true name='NATIVE_PAID_ASSET_DROP' noAds=noAds class='main-page-pad-slot'}}
 	{{#if featuredContent}}
 		{{featured-content model=featuredContent}}
 	{{/if}}

--- a/front/main/app/templates/main-page.hbs
+++ b/front/main/app/templates/main-page.hbs
@@ -1,5 +1,5 @@
-{{ad-slot name='INVISIBLE_HIGH_IMPACT' noAds=noAds}}
-{{ad-slot name='MOBILE_TOP_LEADERBOARD' noAds=noAds}}
+{{ad-slot isAboveTheFold=true name='INVISIBLE_HIGH_IMPACT' noAds=noAds}}
+{{ad-slot isAboveTheFold=true name='MOBILE_TOP_LEADERBOARD' noAds=noAds}}
 {{main-page
 	isRoot=isRoot
 	title=title

--- a/front/main/tests/unit/components/ad-slot-test.js
+++ b/front/main/tests/unit/components/ad-slot-test.js
@@ -96,12 +96,14 @@ test('behaves correctly depending on noAds value', function (assert) {
 	const testCases = [
 		{
 			properties: {
+				isAboveTheFold: true,
 				name: 'Test ad 1'
 			},
 			expectedLength: 1,
 			message: 'Element added to slot because no noAds property was passed'
 		}, {
 			properties: {
+				isAboveTheFold: true,
 				name: 'Test ad 2',
 				noAds: ''
 			},
@@ -109,6 +111,7 @@ test('behaves correctly depending on noAds value', function (assert) {
 			message: 'Element added to slot because of noAds property value set to an empty string'
 		}, {
 			properties: {
+				isAboveTheFold: true,
 				name: 'Test ad 3',
 				noAds: '0'
 			},
@@ -116,6 +119,7 @@ test('behaves correctly depending on noAds value', function (assert) {
 			message: 'Element added to slot because of noAds property value set to \'0\''
 		}, {
 			properties: {
+				isAboveTheFold: true,
 				name: 'Test ad 4',
 				noAds: 'false'
 			},
@@ -123,6 +127,7 @@ test('behaves correctly depending on noAds value', function (assert) {
 			message: 'Element not added to slot because of noAds property value set to \'false\''
 		}, {
 			properties: {
+				isAboveTheFold: true,
 				name: 'Test ad 5',
 				noAds: 'whatever'
 			},
@@ -130,6 +135,7 @@ test('behaves correctly depending on noAds value', function (assert) {
 			message: 'Element not added to slot because of noAds property value set to \'whatever\''
 		}, {
 			properties: {
+				isAboveTheFold: true,
 				name: 'Test ad 6',
 				noAds: '1'
 			},
@@ -137,6 +143,7 @@ test('behaves correctly depending on noAds value', function (assert) {
 			message: 'Element not added to slot because of noAds property value set to \'1\''
 		}, {
 			properties: {
+				isAboveTheFold: true,
 				name: 'Test ad 7',
 				noAds: 'true'
 			},


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/ADEN-3584

## Description

The new slot: BOTTOM_LEADERBOARD is going to be filled only when there is Fan Takeover product visible.

Merge pull request #2645 from Wikia/ADEN-3584-blb-for-uap-only

ADEN-3584 Remove BLB from non-UAP scenarios