### PR TITLE
XW-1786 | get google script from http instead of https (temporary)

### DIFF
--- a/server/config/localSettings.base.js
+++ b/server/config/localSettings.base.js
@@ -238,7 +238,7 @@ const localSettings = {
 				id: 'UA-32132943-1',
 				sampleRate: 100
 			},
-			scriptUrl: 'https://www.google-analytics.com/analytics.js'
+			scriptUrl: 'http://www.google-analytics.com/analytics.js'
 		},
 		quantserve: 'p-8bG6eLqkH6Avk',
 		comscore: {


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/XW-1786

## Description

Our selenium tests are using library which intercepts all browser requests, but because we are using also some kind of proxy, this library is not catching https requests but just http.

## Reviewers

@Wikia/x-wing 
