### PR TITLE
SOC-2448 | feat: remember previous categories and sorting in local st…

### DIFF
--- a/front/main/app/mixins/discussion-forum-actions-route.js
+++ b/front/main/app/mixins/discussion-forum-actions-route.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import localStorageConnector from '../utils/local-storage-connector';
 
 export default Ember.Mixin.create(
 	{
@@ -10,7 +11,7 @@ export default Ember.Mixin.create(
 		 */
 		refreshPreviousDiscussionForumQueryParams(catId) {
 			if (Ember.isEmpty(catId)) {
-				localStorage.setItem('discussionForumPreviousQueryParams', null);
+				localStorageConnector.setItem('discussionForumPreviousQueryParams', null);
 			}
 		},
 

--- a/front/main/app/mixins/discussion-forum-actions-route.js
+++ b/front/main/app/mixins/discussion-forum-actions-route.js
@@ -2,6 +2,18 @@ import Ember from 'ember';
 
 export default Ember.Mixin.create(
 	{
+		/**
+		 * When no category is selected, previous categories, present in local
+		 * storage are removed to enable transition to route without categories.
+		 *
+		 * @param {string[]} catId - The array of categories.
+		 */
+		refreshPreviousDiscussionForumQueryParams(catId) {
+			if (Ember.isEmpty(catId)) {
+				localStorage.setItem('discussionForumPreviousQueryParams', null);
+			}
+		},
+
 		actions: {
 			/**
 			 * Attempts transition to a route based on current discussion filters setup
@@ -14,7 +26,8 @@ export default Ember.Mixin.create(
 			 */
 			applyFilters(sortBy, onlyReported, categories) {
 				const discussionSort = this.get('discussionSort'),
-					currentSortBy = discussionSort.get('sortBy');
+					currentSortBy = discussionSort.get('sortBy'),
+					catId = categories.filterBy('selected', true).mapBy('category.id');
 
 				let targetRoute = 'discussion.forum';
 
@@ -26,9 +39,11 @@ export default Ember.Mixin.create(
 					discussionSort.setSortBy(sortBy);
 				}
 
+				this.refreshPreviousDiscussionForumQueryParams(catId);
+
 				const queryParams = {
 					sort: sortBy,
-					catId: categories.filterBy('selected', true).mapBy('category.id'),
+					catId
 				};
 
 				return this.transitionTo(targetRoute, {queryParams});

--- a/front/main/app/routes/discussion/forum.js
+++ b/front/main/app/routes/discussion/forum.js
@@ -5,6 +5,7 @@ import DiscussionForumModel from '../../models/discussion/forum';
 import DiscussionModerationRouteMixin from '../../mixins/discussion-moderation-route';
 import DiscussionForumActionsRouteMixin from '../../mixins/discussion-forum-actions-route';
 import DiscussionModalDialogMixin from '../../mixins/discussion-modal-dialog';
+import localStorageConnector from '../../utils/local-storage-connector';
 
 const {inject} = Ember;
 
@@ -33,14 +34,14 @@ export default DiscussionBaseRoute.extend(
 		beforeModel(transition) {
 			const queryParams = transition.queryParams;
 			if (!queryParams.catId || queryParams.catId.length === 0) {
-				const previousQueryParams = localStorage.getItem('discussionForumPreviousQueryParams');
+				const previousQueryParams = localStorageConnector.getItem('discussionForumPreviousQueryParams');
 				if (previousQueryParams) {
 					this.transitionTo({
 						queryParams: JSON.parse(previousQueryParams)
 					});
 				}
 			} else {
-				localStorage.setItem('discussionForumPreviousQueryParams', JSON.stringify(queryParams));
+				localStorageConnector.setItem('discussionForumPreviousQueryParams', JSON.stringify(queryParams));
 			}
 		},
 

--- a/front/main/app/routes/discussion/forum.js
+++ b/front/main/app/routes/discussion/forum.js
@@ -27,6 +27,24 @@ export default DiscussionBaseRoute.extend(
 		discussionSort: inject.service(),
 
 		/**
+		 * If user was previously on forum and used filters he is transitioned to last chosen filters.
+		 * @param {object} transition
+		 */
+		beforeModel(transition) {
+			const queryParams = transition.queryParams;
+			if (!queryParams.catId || 0 === queryParams.catId.length) {
+				const previousQueryParams = localStorage.getItem('discussionForumPreviousQueryParams');
+				if (previousQueryParams) {
+					this.transitionTo({
+						queryParams: JSON.parse(previousQueryParams)
+					});
+				}
+			} else {
+				localStorage.setItem('discussionForumPreviousQueryParams', JSON.stringify(queryParams));
+			}
+		},
+
+		/**
 		 * @param {object} params
 		 * @returns {Ember.RSVP.hash}
 		 */
@@ -80,6 +98,8 @@ export default DiscussionBaseRoute.extend(
 
 			updateCategoriesSelection(updatedCategories) {
 				const catId = updatedCategories.filterBy('selected', true).mapBy('category.id');
+
+				this.refreshPreviousDiscussionForumQueryParams(catId);
 
 				this.transitionTo({queryParams: {
 					catId,

--- a/front/main/app/routes/discussion/forum.js
+++ b/front/main/app/routes/discussion/forum.js
@@ -32,7 +32,7 @@ export default DiscussionBaseRoute.extend(
 		 */
 		beforeModel(transition) {
 			const queryParams = transition.queryParams;
-			if (!queryParams.catId || 0 === queryParams.catId.length) {
+			if (!queryParams.catId || queryParams.catId.length === 0) {
 				const previousQueryParams = localStorage.getItem('discussionForumPreviousQueryParams');
 				if (previousQueryParams) {
 					this.transitionTo({


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/SOC-2448

## Description

As a user, I want to have my discussion category selections and sort order stored so they are set when I come back to that discussions site

## Reviewers

@bkoval 