### PR TITLE
SOC-2421 | Hide category picker when a community has only 1 category

### DIFF
--- a/front/main/app/components/discussion-standalone-editor.js
+++ b/front/main/app/components/discussion-standalone-editor.js
@@ -67,7 +67,6 @@ export default DiscussionMultipleInputsEditor.extend(
 			}
 
 			this.setProperties({
-				category: this.get('categories').findBy('id', this.get('editEntity.categoryId')),
 				content: editEntity.get('rawContent'),
 				openGraph: editEntity.get('openGraph'),
 				showsOpenGraphCard: Boolean(editEntity.get('openGraph')),

--- a/front/main/app/mixins/discussion-editor-category-picker.js
+++ b/front/main/app/mixins/discussion-editor-category-picker.js
@@ -21,10 +21,20 @@ export default Ember.Mixin.create({
 		return this.get('categories').length === 1;
 	}),
 
-	shouldShowCategoryPicker: Ember.computed('isReply', 'isEdit', 'isActive', 'categoryPickerDisabled', function () {
-		return ((!this.get('isReply') && this.get('isActive')) ||
-			(this.get('isEdit') && this.get('currentUser.permissions.discussions.canChangePostCategory'))) &&
-			!this.get('categoryPickerDisabled');
+	isActivePostEditor: Ember.computed('isReply', 'isActive', function () {
+		return this.get('isActive') && !this.get('isReply');
+	}),
+
+	isEditActionWithPostMovingPermissions: Ember.computed('isEdit', 'currentUser.permissions', function () {
+		return this.get('isEdit') && this.get('currentUser.permissions.discussions.canChangePostCategory');
+	}),
+
+	canEditPostCategory: Ember.computed('isActivePostEditor', 'isEditActionWithPostMovingPermissions', function () {
+		return this.get('isActivePostEditor') || this.get('isEditActionWithPostMovingPermissions')
+	}),
+
+	shouldShowCategoryPicker: Ember.computed('canEditPostCategory', 'categoryPickerDisabled', function () {
+		return !this.get('categoryPickerDisabled') && this.get('canEditPostCategory');
 	}),
 
 	clearCategory: Ember.observer('isActive', function () {

--- a/front/main/app/mixins/discussion-editor-category-picker.js
+++ b/front/main/app/mixins/discussion-editor-category-picker.js
@@ -7,7 +7,7 @@ export default Ember.Mixin.create({
 			editEntity = this.get('editEntity');
 
 		if (this.get('isEdit') && editEntity) {
-			return this.get('categories').findBy('id', this.get('editEntity.categoryId'));
+			return categories.findBy('id', this.get('editEntity.categoryId'));
 		}
 
 		if (categories.length === 1) {
@@ -18,7 +18,7 @@ export default Ember.Mixin.create({
 	}),
 
 	categoryPickerDisabled: Ember.computed('categories', function () {
-		return this.get('categories').length === 1;
+		return this.get('categories.length') === 1;
 	}),
 
 	isActivePostEditor: Ember.computed('isReply', 'isActive', function () {

--- a/front/main/app/mixins/discussion-editor-category-picker.js
+++ b/front/main/app/mixins/discussion-editor-category-picker.js
@@ -2,11 +2,29 @@ import Ember from 'ember';
 import {track, trackActions} from '../utils/discussion-tracker';
 
 export default Ember.Mixin.create({
-	category: null,
+	category: Ember.computed('categories', 'isEdit', 'editEntity', function () {
+		const categories = this.get('categories'),
+			editEntity = this.get('editEntity');
 
-	shouldShowCategoryPicker: Ember.computed('isReply', 'isEdit', 'isActive', function () {
-		return (!this.get('isReply') && this.get('isActive')) ||
-			(this.get('isEdit') && this.get('currentUser.permissions.discussions.canChangePostCategory'));
+		if (this.get('isEdit') && editEntity) {
+			return this.get('categories').findBy('id', this.get('editEntity.categoryId'));
+		}
+
+		if (categories.length === 1) {
+			return categories.get(0);
+		} else {
+			return null;
+		}
+	}),
+
+	categoryPickerDisabled: Ember.computed('categories', function () {
+		return this.get('categories').length === 1;
+	}),
+
+	shouldShowCategoryPicker: Ember.computed('isReply', 'isEdit', 'isActive', 'categoryPickerDisabled', function () {
+		return ((!this.get('isReply') && this.get('isActive')) ||
+			(this.get('isEdit') && this.get('currentUser.permissions.discussions.canChangePostCategory'))) &&
+			!this.get('categoryPickerDisabled');
 	}),
 
 	clearCategory: Ember.observer('isActive', function () {

--- a/front/main/app/styles/component/_discussion-category-picker.scss
+++ b/front/main/app/styles/component/_discussion-category-picker.scss
@@ -39,6 +39,10 @@
 		padding: 8px 12px;
 		margin: 15px 0 4px;
 
+		&.disabled {
+			display: none;
+		}
+
 		svg {
 			fill: $discussion-category-picker-button-color;
 			height: 14px;

--- a/front/main/app/templates/components/discussion-inline-editor.hbs
+++ b/front/main/app/templates/components/discussion-inline-editor.hbs
@@ -22,15 +22,15 @@
 			<div class="discussion-inline-editor-textarea-wrapper">
 				{{#if shouldShowCategoryPicker}}
 					<a id="{{categoryPickerButtonId}}" class="discussion-category-picker-button {{if category 'active-element-background-color'}} {{if categoryPickerDisabled 'disabled'}}">
-					<span class="discussion-category-picker-content-wrapper">
-						{{#if category}}
-							{{category.name}}
-							{{svg 'pencil' viewBox='0 0 70 70' class='icon pencil'}}
-						{{else}}
-							{{svg 'plus-small' viewBox='0 0 34 34' class='icon plus'}}
-							{{i18n 'main.category-picker-button-text' ns='discussion'}}
-						{{/if}}
-					</span>
+						<span class="discussion-category-picker-content-wrapper">
+							{{#if category}}
+								{{category.name}}
+								{{svg 'pencil' viewBox='0 0 70 70' class='icon pencil'}}
+							{{else}}
+								{{svg 'plus-small' viewBox='0 0 34 34' class='icon plus'}}
+								{{i18n 'main.category-picker-button-text' ns='discussion'}}
+							{{/if}}
+						</span>
 					</a>
 					{{#unless category}}
 						<small class="discussion-category-picker-required-message">[{{i18n 'main.category-picker-required-message' ns='discussion'}}]</small>

--- a/front/main/app/templates/components/discussion-inline-editor.hbs
+++ b/front/main/app/templates/components/discussion-inline-editor.hbs
@@ -21,7 +21,7 @@
 		{{else}}
 			<div class="discussion-inline-editor-textarea-wrapper">
 				{{#if shouldShowCategoryPicker}}
-					<a id="{{categoryPickerButtonId}}" class="discussion-category-picker-button {{if category 'active-element-background-color'}}">
+					<a id="{{categoryPickerButtonId}}" class="discussion-category-picker-button {{if category 'active-element-background-color'}} {{if categoryPickerDisabled 'disabled'}}">
 					<span class="discussion-category-picker-content-wrapper">
 						{{#if category}}
 							{{category.name}}

--- a/front/main/app/templates/components/discussion-standalone-editor.hbs
+++ b/front/main/app/templates/components/discussion-standalone-editor.hbs
@@ -20,15 +20,15 @@
 				}}
 			{{/pop-over}}
 			<a id="{{categoryPickerButtonId}}" class="discussion-category-picker-button {{if category 'active-element-background-color'}} {{if categoryPickerDisabled 'disabled'}}">
-			<span class="discussion-category-picker-content-wrapper">
-				{{#if category}}
-					{{category.name}}
-					{{svg 'pencil' viewBox='0 0 70 70' class='icon pencil'}}
-				{{else}}
-					{{svg 'plus-small' viewBox='0 0 34 34' class='icon plus'}}
-					{{i18n 'main.category-picker-button-text' ns='discussion'}}
-				{{/if}}
-			</span>
+				<span class="discussion-category-picker-content-wrapper">
+					{{#if category}}
+						{{category.name}}
+						{{svg 'pencil' viewBox='0 0 70 70' class='icon pencil'}}
+					{{else}}
+						{{svg 'plus-small' viewBox='0 0 34 34' class='icon plus'}}
+						{{i18n 'main.category-picker-button-text' ns='discussion'}}
+					{{/if}}
+				</span>
 			</a>
 			{{#unless category}}
 				<small class="discussion-category-picker-required-message">[{{i18n 'main.category-picker-required-message' ns='discussion'}}]</small>

--- a/front/main/app/templates/components/discussion-standalone-editor.hbs
+++ b/front/main/app/templates/components/discussion-standalone-editor.hbs
@@ -19,7 +19,7 @@
 					setCategory=(action 'setCategory')
 				}}
 			{{/pop-over}}
-			<a id="{{categoryPickerButtonId}}" class="discussion-category-picker-button {{if category 'active-element-background-color'}}">
+			<a id="{{categoryPickerButtonId}}" class="discussion-category-picker-button {{if category 'active-element-background-color'}} {{if categoryPickerDisabled 'disabled'}}">
 			<span class="discussion-category-picker-content-wrapper">
 				{{#if category}}
 					{{category.name}}


### PR DESCRIPTION
## Links
http://wikia-inc.atlassian.net/browse/SOC-2421

## Description
We are supposed to hide category picker from a user when there's just one category on a community

## Reviewers
@Wikia/social-frontend