### PR TITLE
SOC-2843 | fix: categories are preserved on mobile when sorting is ch…

### DIFF
--- a/front/main/app/components/discussion-filters.js
+++ b/front/main/app/components/discussion-filters.js
@@ -81,11 +81,15 @@ export default Ember.Component.extend(
 
 				// No need for applying already applied filters again
 				if (changeState.filtersChanged) {
+					let catId = changeState.categoriesChanged
+						? this.get('changedCategories').filterBy('selected', true).mapBy('category.id')
+						: this.get('categories').filterBy('selected', true).mapBy('id');
+
 					this.trackSortByTapped(sortBy);
 					this.get('applyFilters')(
 						this.get('sortBy'),
 						this.get('onlyReported'),
-						this.get('changedCategories'),
+						catId,
 						changeState
 					);
 				}

--- a/front/main/app/mixins/discussion-forum-actions-controller.js
+++ b/front/main/app/mixins/discussion-forum-actions-controller.js
@@ -31,13 +31,13 @@ export default Ember.Mixin.create(
 			/**
 			 * @param {string} sortBy
 			 * @param {boolean} shouldShowReported
-			 * @param {Object} categories
+			 * @param {Object} catId
 			 * @param {Object} changeState
 			 *
 			 * @returns {void}
 			 */
-			applyFilters(sortBy, shouldShowReported, categories, changeState) {
-				this.get('target').send('applyFilters', sortBy, shouldShowReported, categories, changeState);
+			applyFilters(sortBy, shouldShowReported, catId, changeState) {
+				this.get('target').send('applyFilters', sortBy, shouldShowReported, catId, changeState);
 			}
 		}
 	}

--- a/front/main/app/mixins/discussion-forum-actions-route.js
+++ b/front/main/app/mixins/discussion-forum-actions-route.js
@@ -36,15 +36,14 @@ export default Ember.Mixin.create(
 			 *
 			 * @param {string} sortBy
 			 * @param {boolean} onlyReported
-			 * @param {Object} categories
+			 * @param {Object} catId
 			 * @param {Object} changeState
 			 *
 			 * @returns {EmberStates.Transition}
 			 */
-			applyFilters(sortBy, onlyReported, categories, changeState) {
+			applyFilters(sortBy, onlyReported, catId, changeState) {
 				const discussionSort = this.get('discussionSort'),
-					currentSortBy = discussionSort.get('sortBy'),
-					catId = categories.filterBy('selected', true).mapBy('category.id');
+					currentSortBy = discussionSort.get('sortBy');
 
 				let targetRoute = 'discussion.forum';
 


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/SOC-2843

## Description

Selected categories are reset to 'All' on mobile when sort order is changed

## Reviewers

@bkoval 