### PR TITLE
SOC-2802 | fix: prevent scrolling when edit categories modal is shown…

### DIFF
--- a/front/main/app/styles/state/_full-screen.scss
+++ b/front/main/app/styles/state/_full-screen.scss
@@ -2,6 +2,7 @@
 	.mobile-full-screen {
 		height: 100%;
 		overflow: hidden;
+		position: fixed;
 
 		.site-head {
 			display: none;


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/SOC-2802

Inspired by:
* http://stackoverflow.com/questions/9280258/prevent-body-scrolling-but-allow-overlay-scrolling
## Description

Fix for editing categories display incorrectly on mobile.

## Reviewers

@bkoval 