### PR TITLE
SOC-2838 | Hide categories UI for communities with 1 category

### DIFF
--- a/front/main/app/components/discussion-entities-list-layout.js
+++ b/front/main/app/components/discussion-entities-list-layout.js
@@ -1,7 +1,13 @@
 import DiscussionModalDialogMixin from '../mixins/discussion-modal-dialog';
+import DiscussionCategoriesVisibilityMixin from '../mixins/discussion-categories-visibility';
 
-export default Ember.Component.extend(DiscussionModalDialogMixin, {
-	discussionSort: Ember.inject.service(),
+export default Ember.Component.extend(
+	DiscussionModalDialogMixin,
+	DiscussionCategoriesVisibilityMixin,
+	{
+		currentUser: Ember.inject.service(),
+		discussionSort: Ember.inject.service(),
 
-	hasNewPostButton: true,
-});
+		hasNewPostButton: true,
+	}
+);

--- a/front/main/app/components/discussion-filters.js
+++ b/front/main/app/components/discussion-filters.js
@@ -1,13 +1,16 @@
 import Ember from 'ember';
 import nearestParent from 'ember-pop-over/computed/nearest-parent';
 import DiscussionReportedFilterMixin from '../mixins/discussion-reported-filter';
+import DiscussionCategoriesVisibilityMixin from '../mixins/discussion-categories-visibility';
 import {track, trackActions} from '../utils/discussion-tracker';
 
 export default Ember.Component.extend(
 	DiscussionReportedFilterMixin,
+	DiscussionCategoriesVisibilityMixin,
 	{
 		changedCategories: [],
 		classNames: ['discussion-filters'],
+		currentUser: Ember.inject.service(),
 		discussionSort: Ember.inject.service(),
 		popover: nearestParent('pop-over'),
 		showApplyButton: false,

--- a/front/main/app/components/discussion-post-card-detail.js
+++ b/front/main/app/components/discussion-post-card-detail.js
@@ -1,20 +1,26 @@
 import Ember from 'ember';
 import DiscussionPostCardBaseComponent from './discussion-post-card-base';
+import DiscussionCategoriesVisibilityMixin from '../mixins/discussion-categories-visibility';
 
-export default DiscussionPostCardBaseComponent.extend({
-	classNames: ['post-detail'],
+export default DiscussionPostCardBaseComponent.extend(
+	DiscussionCategoriesVisibilityMixin,
+	{
+		classNames: ['post-detail'],
 
-	postId: Ember.computed.oneWay('post.threadId'),
+		currentUser: Ember.inject.service(),
 
-	routing: Ember.inject.service('-routing'),
+		postId: Ember.computed.oneWay('post.threadId'),
 
-	// Whether the component is displayed on the post details discussion page
-	isDetailsView: false,
+		routing: Ember.inject.service('-routing'),
 
-	// URL passed to the ShareFeatureComponent for sharing a post
-	sharedUrl: Ember.computed('postId', function () {
-		const localPostUrl = this.get('routing').router.generate('discussion.post', this.get('postId'));
+		// Whether the component is displayed on the post details discussion page
+		isDetailsView: false,
 
-		return `${Ember.getWithDefault(Mercury, 'wiki.basePath', window.location.origin)}${localPostUrl}`;
-	}),
-});
+		// URL passed to the ShareFeatureComponent for sharing a post
+		sharedUrl: Ember.computed('postId', function () {
+			const localPostUrl = this.get('routing').router.generate('discussion.post', this.get('postId'));
+
+			return `${Ember.getWithDefault(Mercury, 'wiki.basePath', window.location.origin)}${localPostUrl}`;
+		}),
+	}
+);

--- a/front/main/app/controllers/discussion/base.js
+++ b/front/main/app/controllers/discussion/base.js
@@ -5,7 +5,6 @@ export default Ember.Controller.extend(
 		application: Ember.inject.controller(),
 
 		smartBannerVisible: Ember.computed.oneWay('application.smartBannerVisible'),
-		showCategories: true,
 
 		actions: {
 			/**

--- a/front/main/app/mixins/discussion-categories-visibility.js
+++ b/front/main/app/mixins/discussion-categories-visibility.js
@@ -2,9 +2,9 @@ import Ember from 'ember';
 
 export default Ember.Mixin.create({
 	canShowCategories: Ember.computed('categories', 'currentUser.permissions.discussions.canEditCategories', function () {
-		const categories = this.get('categories'),
+		const categoriesLength = this.getWithDefault('categories.length', 0),
 			canEditCategories = this.get('currentUser.permissions.discussions.canEditCategories');
 
-		return (categories && categories.length > 1) || canEditCategories;
+		return categoriesLength > 1 || canEditCategories;
 	})
 });

--- a/front/main/app/mixins/discussion-categories-visibility.js
+++ b/front/main/app/mixins/discussion-categories-visibility.js
@@ -1,0 +1,10 @@
+import Ember from 'ember';
+
+export default Ember.Mixin.create({
+	canShowCategories: Ember.computed('categories', 'currentUser.permissions.discussions.canEditCategories', function () {
+		const categories = this.get('categories'),
+			canEditCategories = this.get('currentUser.permissions.discussions.canEditCategories');
+
+		return (categories && categories.length > 1) || canEditCategories;
+	})
+});

--- a/front/main/app/templates/components/discussion-entities-list-layout.hbs
+++ b/front/main/app/templates/components/discussion-entities-list-layout.hbs
@@ -8,7 +8,6 @@
 		hasNewPostButton=hasNewPostButton
 		hasSiteName=true
 		setEditorActive=(action this.attrs.setEditorActive)
-		showCategories=showCategories
 		smartBannerVisible=smartBannerVisible
 		updateCategories=(action this.attrs.updateCategories)
 	}}
@@ -29,8 +28,7 @@
 	<div class="discussion-page row">
 		<div class="rail left large-3 columns">
 			{{community-badge}}
-			{{#if showCategories}}
-				{{#if categories}}
+			{{#if canShowCategories}}
 					{{discussion-categories
 						categories=categories
 						inputIdPrefix='rail'
@@ -38,7 +36,6 @@
 						updateCategoriesSelection=(action this.attrs.updateCategoriesSelection)
 						visibleCategoriesCount=10
 					}}
-				{{/if}}
 			{{/if}}
 			{{#if model.canModerate}}
 				{{discussion-reported-filter

--- a/front/main/app/templates/components/discussion-entities-list-layout.hbs
+++ b/front/main/app/templates/components/discussion-entities-list-layout.hbs
@@ -29,13 +29,13 @@
 		<div class="rail left large-3 columns">
 			{{community-badge}}
 			{{#if canShowCategories}}
-					{{discussion-categories
-						categories=categories
-						inputIdPrefix='rail'
-						updateCategories=(action this.attrs.updateCategories)
-						updateCategoriesSelection=(action this.attrs.updateCategoriesSelection)
-						visibleCategoriesCount=10
-					}}
+				{{discussion-categories
+					categories=categories
+					inputIdPrefix='rail'
+					updateCategories=(action this.attrs.updateCategories)
+					updateCategoriesSelection=(action this.attrs.updateCategoriesSelection)
+					visibleCategoriesCount=10
+				}}
 			{{/if}}
 			{{#if model.canModerate}}
 				{{discussion-reported-filter

--- a/front/main/app/templates/components/discussion-filters.hbs
+++ b/front/main/app/templates/components/discussion-filters.hbs
@@ -1,15 +1,13 @@
 <form name="discussion-filters">
 	<div class="discussion-filters-fields-wrapper">
-		{{#if showCategories}}
-			{{#if categories}}
-				{{discussion-categories
-					categories=categories
-					disabled=onlyReported
-					inputIdPrefix='filters'
-					updateCategories=(action this.attrs.updateCategories)
-					updateCategoriesSelection=(action 'updateCategoriesSelection')
-				}}
-			{{/if}}
+		{{#if canShowCategories}}
+			{{discussion-categories
+				categories=categories
+				disabled=onlyReported
+				inputIdPrefix='filters'
+				updateCategories=(action this.attrs.updateCategories)
+				updateCategoriesSelection=(action 'updateCategoriesSelection')
+			}}
 		{{/if}}
 		{{#if showSortSection}}
 			<fieldset class="discussion-fieldset sortby-fieldset" disabled={{trendingDisabled}}>

--- a/front/main/app/templates/components/discussion-forum-wrapper.hbs
+++ b/front/main/app/templates/components/discussion-forum-wrapper.hbs
@@ -18,6 +18,7 @@
 	{{discussion-post-card-detail
 		approve=(action this.attrs.approve)
 		author=entity.createdBy
+		categories=categories
 		delete=(action this.attrs.deletePost)
 		lock=(action this.attrs.lockPost)
 		openEditEditor=(action this.attrs.openEditEditor)
@@ -25,7 +26,6 @@
 		replyCount=entity.repliesCount
 		report=(action this.attrs.report)
 		setEditorActive=(action this.attrs.setEditorActive)
-		showCategories=showCategories
 		undelete=(action this.attrs.undeletePost)
 		unlock=(action this.attrs.unlockPost)
 		upvote=(action this.attrs.upvote)

--- a/front/main/app/templates/components/discussion-header.hbs
+++ b/front/main/app/templates/components/discussion-header.hbs
@@ -30,7 +30,6 @@
 					showApplyButton=true
 					showSortSection=true
 					updateCategories=(action this.attrs.updateCategories)
-					showCategories=showCategories
 					showReportedFilter=true
 					showSortSection=true
 				}}

--- a/front/main/app/templates/components/discussion-post-card-detail.hbs
+++ b/front/main/app/templates/components/discussion-post-card-detail.hbs
@@ -65,7 +65,7 @@
 		}}
 	{{/if}}
 	<div class="row post-bottom-row">
-		{{#if showCategories}}
+		{{#if canShowCategories}}
 			{{#if post.categoryName}}
 				<span class="post-category-name">
 					{{i18n 'main.in-category-label' ns='discussion' categoryName=post.categoryName}}

--- a/front/main/app/templates/components/discussion-post-details-layout.hbs
+++ b/front/main/app/templates/components/discussion-post-details-layout.hbs
@@ -5,7 +5,6 @@
 		hasBackButton=true
 		hasFilters=false
 		hasNewPostButton=false
-		showCategories=showCategories
 		smartBannerVisible=smartBannerVisible
 	}}
 {{/ember-wormhole}}

--- a/front/main/app/templates/components/discussion-post.hbs
+++ b/front/main/app/templates/components/discussion-post.hbs
@@ -1,6 +1,7 @@
 {{discussion-post-card-detail
 	approve=(action this.attrs.approve)
 	author=model.createdBy
+	categories=categories
 	delete=(action this.attrs.deletePost)
 	isDetailsView=true
 	lock=(action this.attrs.lockPost)
@@ -9,7 +10,6 @@
 	replyCount=model.repliesCount
 	report=(action this.attrs.report)
 	setEditorActive=(action this.attrs.setEditorActive)
-	showCategories=showCategories
 	timestamp=model.creationTimestamp
 	undelete=(action this.attrs.undeletePost)
 	unlock=(action this.attrs.unlockPost)

--- a/front/main/app/templates/components/discussion-reported-posts-wrapper.hbs
+++ b/front/main/app/templates/components/discussion-reported-posts-wrapper.hbs
@@ -21,6 +21,7 @@
 		{{discussion-post-card-detail
 			approve=(action this.attrs.approve)
 			author=entity.createdBy
+			categories=categories
 			delete=(action this.attrs.deletePost)
 			lock=(action this.attrs.lockPost)
 			openEditEditor=(action this.attrs.openEditEditor)
@@ -28,7 +29,6 @@
 			replyCount=entity.repliesCount
 			report=(action this.attrs.report)
 			setEditorActive=(action this.attrs.setEditorActive)
-			showCategories=showCategories
 			undelete=(action this.attrs.undeletePost)
 			unlock=(action this.attrs.unlockPost)
 			upvote=(action this.attrs.upvote)

--- a/front/main/app/templates/components/discussion-standalone-layout.hbs
+++ b/front/main/app/templates/components/discussion-standalone-layout.hbs
@@ -7,7 +7,6 @@
 		hasFilters=false
 		hasNewPostButton=false
 		hasSiteName=true
-		showCategories=showCategories
 		siteName=pageTitle
 		smartBannerVisible=smartBannerVisible
 	}}

--- a/front/main/app/templates/components/discussion-user-list-wrapper.hbs
+++ b/front/main/app/templates/components/discussion-user-list-wrapper.hbs
@@ -21,6 +21,7 @@
 		{{discussion-post-card-detail
 			approve=(action this.attrs.approve)
 			author=entity.createdBy
+			categories=categories
 			delete=(action this.attrs.deletePost)
 			lock=(action this.attrs.lockPost)
 			openEditEditor=(action this.attrs.openEditEditor)
@@ -28,7 +29,6 @@
 			replyCount=entity.repliesCount
 			report=(action this.attrs.report)
 			setEditorActive=(action this.attrs.setEditorActive)
-			showCategories=showCategories
 			undelete=(action this.attrs.undeletePost)
 			unlock=(action this.attrs.unlockPost)
 			upvote=(action this.attrs.upvote)

--- a/front/main/app/templates/discussion/forum.hbs
+++ b/front/main/app/templates/discussion/forum.hbs
@@ -56,7 +56,6 @@
 	updateCategoriesSelection=(action 'updateCategoriesSelection')
 	openGuidelines=(action 'openGuidelines')
 	setEditorActive=(action 'setEditorActive')
-	showCategories=showCategories
 }}
 	{{discussion-sort
 		setSortBy=(action 'setSortBy')
@@ -79,7 +78,6 @@
 		postsDisplayed=model.current.data.entities.length
 		report=(action 'report')
 		setEditorActive=(action 'setEditorActive')
-		showCategories=showCategories
 		totalPosts=model.current.data.postCount
 		undeletePost=(action 'undeletePost')
 		unlockPost=(action 'unlockPost')

--- a/front/main/app/templates/discussion/post.hbs
+++ b/front/main/app/templates/discussion/post.hbs
@@ -43,6 +43,7 @@
 }}
 	{{discussion-post
 		approve=(action 'approve')
+		categories=model.index.categories.categories
 		createReply=(action 'createReply')
 		deleteAllPosts=(action 'deleteAllPosts')
 		deletePost=(action 'deletePost')
@@ -59,7 +60,6 @@
 		openEditEditor=(action 'openEditEditor')
 		report=(action 'report')
 		setEditorActive=(action 'setEditorActive')
-		showCategories=showCategories
 		undeletePost=(action 'undeletePost')
 		undeleteReply=(action 'undeleteReply')
 		unlockPost=(action 'unlockPost')

--- a/front/main/app/templates/discussion/reported-posts.hbs
+++ b/front/main/app/templates/discussion/reported-posts.hbs
@@ -34,6 +34,7 @@
 	}}
 	{{discussion-reported-posts-wrapper
 		approve=(action 'approve')
+		categories=model.index.categories.categories
 		createPost=(action 'createPost')
 		deletePost=(action 'deletePost')
 		deleteReply=(action 'deleteReply')
@@ -47,7 +48,6 @@
 		postsDisplayed=model.current.data.entities.length
 		report=(action 'report')
 		setEditorActive=(action 'setEditorActive')
-		showCategories=showCategories
 		totalPosts=model.current.data.postCount
 		undeletePost=(action 'undeletePost')
 		undeleteReply=(action 'undeleteReply')

--- a/front/main/app/templates/discussion/user.hbs
+++ b/front/main/app/templates/discussion/user.hbs
@@ -26,6 +26,7 @@
 }}
 	{{discussion-user-list-wrapper
 		approve=(action 'approve')
+		categories=model.index.categories.categories
 		deletePost=(action 'deletePost')
 		deleteReply=(action 'deleteReply')
 		loadPage=(action 'loadPage')
@@ -35,7 +36,6 @@
 		posts=model.current.data.entities
 		postsDisplayed=model.current.data.entities.length
 		report=(action 'report')
-		showCategories=showCategories
 		totalPosts=model.current.data.postCount
 		undeletePost=(action 'undeletePost')
 		undeleteReply=(action 'undeleteReply')


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/SOC-2838

## Description

We want discussions to look exactly like before if admins don't add any more categories. This code is hiding category UI in desktop rail / mobile filters menu and category names from post cards if there's only one category.

## Reviewers

@Wikia/social-frontend 