### PR TITLE
SOC-2926 | fix: enable to edit title on posts by user page

### DIFF
--- a/front/main/app/templates/discussion/user.hbs
+++ b/front/main/app/templates/discussion/user.hbs
@@ -10,6 +10,7 @@
 		errorMessage=editEditorState.errorMessage
 		generateOpenGraph=(route-action 'generateOpenGraph')
 		gotoGuidelines=(action 'gotoGuidelines')
+		hasTitle=true
 		isActive=editEditorState.isOpen
 		isEdit=true
 		isLoading=editEditorState.isLoading


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/SOC-2926

## Description

enable to edit title on posts by user page

## Reviewers

@bkoval 

