### PR TITLE
SOC-2946 | fix: add check for permission in guidelines editor

### DIFF
--- a/front/main/app/components/discussion-guidelines-editor.js
+++ b/front/main/app/components/discussion-guidelines-editor.js
@@ -12,6 +12,10 @@ export default DiscussionStandaloneEditor.extend({
 
 	layoutName: 'components/discussion-standalone-editor',
 
+	editTextDisabled: Ember.computed('isEdit', 'guidelines.permissions.canEdit', function () {
+		return this.get('isEdit') && !this.get('guidelines.permissions.canEdit');
+	}),
+
 	// first time it is triggered by the 'guidelines' property, and later by the 'isActive' property
 	targetObjectObserver: Ember.observer('guidelines', function () {
 		const guidelines = this.get('guidelines');


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/SOC-2946

## Description

Staff, Helper, Admin, Discussions Moderator can not edit Discussions Guidelines

## Reviewers

@bkoval 

