### PR TITLE
SOC-2974 | fix: change discussions community badge dimensions

### DIFF
--- a/front/main/app/styles/component/_discussion-community-badge.scss
+++ b/front/main/app/styles/component/_discussion-community-badge.scss
@@ -1,5 +1,6 @@
 $badge-image-dimensions-small: 79px;
 $badge-image-dimensions-big: 125px;
+$badge-image-frame-dimensions-big: $badge-image-dimensions-big + 4px;
 $badge-image-tools-width: 210px;
 
 .post-list-view {
@@ -7,11 +8,12 @@ $badge-image-tools-width: 210px;
 		margin-top: -62px;
 
 		.community-badge-image {
-			height: $badge-image-dimensions-big + 4px;
-			width: $badge-image-dimensions-big;
+			height: $badge-image-frame-dimensions-big;
+			width: $badge-image-frame-dimensions-big;
 
 			.badge-image-display {
 				height: $badge-image-dimensions-big;
+				max-width: $badge-image-dimensions-big;
 				width: $badge-image-dimensions-big;
 			}
 		}


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/SOC-2974

## Description

Discussions: community avatars are stretched on preview

## Reviewers

@bkoval
