### PR TITLE
XW-2028 Fix label color on dark theme

### DIFF
--- a/front/main/app/styles/component/design-system/_global-navigation.scss
+++ b/front/main/app/styles/component/design-system/_global-navigation.scss
@@ -2,6 +2,12 @@
 // If you look for Global Navigation styles go here:
 // https://github.com/Wikia/design-system/blob/master/components/_global-navigation.scss
 
+@import '../../../../bower_components/design-system/base/colors';
+
 .wds-global-navigation {
 	box-sizing: content-box;
+
+	.dark-theme & label {
+		color: $color-dark-blue-gray;
+	}
 }


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/XW-2028

## Description

Override color set in https://github.com/Wikia/mercury/blob/dev/front/main/app/styles/theme/_dark.scss#L75

## Reviewers

@Wikia/x-wing 