### PR TITLE
XW-2013 Use DS API for mobile global navigation

### DIFF
--- a/front/main/app/models/wikia-nav.js
+++ b/front/main/app/models/wikia-nav.js
@@ -7,10 +7,10 @@ export default Object.extend({
 	hubsLinks: computed(function () {
 		return this.get('dsGlobalNavigation.fandom_overview.links');
 	}),
-	exploreWikia: computed(function () {
+	exploreWikis: computed(function () {
 		return this.get('dsGlobalNavigation.wikis');
 	}),
-	exploreWikiaLabel: computed(function () {
+	exploreWikisLabel: computed(function () {
 		return i18n.t(this.get('dsGlobalNavigation.wikis.header.title.key'), {
 			ns: 'design-system'
 		});
@@ -50,7 +50,7 @@ export default Object.extend({
 
 	currentLocalLinks: computed.or('currentLocalNav.children', 'localLinks'),
 
-	header: computed.or('currentLocalNav.text', 'exploreWikiaLabel'),
+	header: computed.or('currentLocalNav.text', 'exploreWikisLabel'),
 
 	inExploreNav: computed('state.[]', function () {
 		const state = this.get('state');
@@ -79,8 +79,8 @@ export default Object.extend({
 			];
 		}),
 
-	exploreItems: computed('inExploreNav', 'exploreWikia', function () {
-		const wikis = this.get('exploreWikia');
+	exploreItems: computed('inExploreNav', 'exploreWikis', function () {
+		const wikis = this.get('exploreWikis');
 
 		return this.get('inExploreNav') &&
 			get(wikis, 'links.length') &&
@@ -112,8 +112,8 @@ export default Object.extend({
 			}) || [];
 	}),
 
-	exploreSubMenuItem: computed('inRoot', 'exploreWikia', function () {
-		const wikis = this.get('exploreWikia');
+	exploreSubMenuItem: computed('inRoot', 'exploreWikis', function () {
+		const wikis = this.get('exploreWikis');
 
 		if (this.get('inRoot') && get(wikis, 'links.length')) {
 			if (wikis.header) {
@@ -121,7 +121,7 @@ export default Object.extend({
 					type: 'nav-menu-root',
 					className: 'nav-menu--explore',
 					index: 0,
-					name: this.get('exploreWikiaLabel'),
+					name: this.get('exploreWikisLabel'),
 					trackLabel: `open-${wikis.header.title.key}`
 				}];
 			} else {

--- a/front/main/app/models/wikia-nav.js
+++ b/front/main/app/models/wikia-nav.js
@@ -5,10 +5,10 @@ const {Object, A, Logger, computed, get} = Ember;
 export default Object.extend({
 	dsGlobalNavigation: M.prop('globalNavigation'),
 	hubsLinks: computed(function () {
-		return this.getWithDefault('dsGlobalNavigation.fandom_overview.links', []);
+		return this.get('dsGlobalNavigation.fandom_overview.links');
 	}),
-	exploreWikiaLinks: computed(function () {
-		return this.getWithDefault('dsGlobalNavigation.wikis.links', []);
+	exploreWikia: computed(function () {
+		return this.get('dsGlobalNavigation.wikis');
 	}),
 	exploreWikiaLabel: computed(function () {
 		return i18n.t(this.get('dsGlobalNavigation.wikis.header.title.key'), {
@@ -79,9 +79,12 @@ export default Object.extend({
 			];
 		}),
 
-	exploreItems: computed('inExploreNav', 'exploreWikiaLinks', function () {
+	exploreItems: computed('inExploreNav', 'exploreWikia', function () {
+		const wikis = this.get('exploreWikia');
+
 		return this.get('inExploreNav') &&
-			this.get('exploreWikiaLinks').map((item) => {
+			get(wikis, 'links.length') &&
+			get(wikis, 'links').map((item) => {
 				return {
 					type: 'nav-menu-external',
 					href: item.href,
@@ -95,6 +98,7 @@ export default Object.extend({
 
 	globalItems: computed('inRoot', 'hubsLinks', function () {
 		return this.get('inRoot') &&
+			this.get('hubsLinks.length') &&
 			this.get('hubsLinks').map((item) => {
 				return {
 					type: 'nav-menu-external',
@@ -108,17 +112,15 @@ export default Object.extend({
 			}) || [];
 	}),
 
-	exploreSubMenuItem: computed('inRoot', 'exploreWikiaLinks', function () {
-		const wikis = this.get('dsGlobalNavigation.wikis');
+	exploreSubMenuItem: computed('inRoot', 'exploreWikia', function () {
+		const wikis = this.get('exploreWikia');
 
-		if (this.get('inRoot') && this.get('exploreWikiaLinks.length')) {
-			const index = 0;
-
+		if (this.get('inRoot') && get(wikis, 'links.length')) {
 			if (wikis.header) {
 				return [{
 					type: 'nav-menu-root',
 					className: 'nav-menu--explore',
-					index,
+					index: 0,
 					name: this.get('exploreWikiaLabel'),
 					trackLabel: `open-${wikis.header.title.key}`
 				}];
@@ -130,7 +132,6 @@ export default Object.extend({
 					type: 'nav-menu-external',
 					className: 'nav-menu--external',
 					href: firstLink.href,
-					index,
 					name: i18n.t(messageKey, {
 						ns: 'design-system'
 					}),

--- a/front/main/tests/unit/models/wikia-nav-test.js
+++ b/front/main/tests/unit/models/wikia-nav-test.js
@@ -13,7 +13,7 @@ const hubsLinksMock = [{
 		href: 'http://fandom.wikia.com/games',
 		brand: 'games'
 	}],
-	exploreWikiaMock = {
+	exploreWikisMock = {
 		header: {
 			title: {
 				key: 'global-navigation-wikis-header'
@@ -27,7 +27,7 @@ const hubsLinksMock = [{
 			trackingLabel: 'global-navigation-wikis-explore'
 		}]
 	},
-	exploreWikiaLabelMock = 'global-navigation-wikis-header';
+	exploreWikisLabelMock = 'global-navigation-wikis-header';
 
 test('test zero state with values from api', (assert) => {
 	const cases = [
@@ -35,8 +35,8 @@ test('test zero state with values from api', (assert) => {
 			mock: {
 				hubsLinks: [],
 				localLinks: [],
-				exploreWikia: [],
-				exploreWikiaLabel: '',
+				exploreWikis: [],
+				exploreWikisLabel: '',
 				discussionsEnabled: false,
 				wikiName: ''
 			},
@@ -61,9 +61,9 @@ test('test zero state with values from api', (assert) => {
 			mock: {
 				hubsLinks: hubsLinksMock,
 				localLinks: [{text: 'Test 1', href: '/wiki/Test_1'}],
-				exploreWikia: exploreWikiaMock,
+				exploreWikis: exploreWikisMock,
 				discussionsEnabled: false,
-				exploreWikiaLabel: exploreWikiaLabelMock,
+				exploreWikisLabel: exploreWikisLabelMock,
 				wikiName: 'Test'
 			},
 			expected: [
@@ -115,9 +115,9 @@ test('test zero state with values from api', (assert) => {
 			mock: {
 				hubsLinks: hubsLinksMock,
 				localLinks: [{text: 'Test 1', href: '/wiki/Test_1'}],
-				exploreWikia: exploreWikiaMock,
+				exploreWikis: exploreWikisMock,
 				discussionsEnabled: true,
-				exploreWikiaLabel: exploreWikiaLabelMock,
+				exploreWikisLabel: exploreWikisLabelMock,
 				wikiName: 'Test'
 			},
 			expected: [
@@ -176,8 +176,8 @@ test('test zero state with values from api', (assert) => {
 			mock: {
 				hubsLinks: [],
 				localLinks: [{text: 'Test 1', href: '/wiki/Test_1'}],
-				exploreWikia: exploreWikiaMock,
-				exploreWikiaLabel: exploreWikiaLabelMock,
+				exploreWikis: exploreWikisMock,
+				exploreWikisLabel: exploreWikisLabelMock,
 				discussionsEnabled: false,
 				wikiName: 'Test'
 			},
@@ -223,7 +223,7 @@ test('test zero state with values from api', (assert) => {
 			mock: {
 				hubsLinks: [],
 				localLinks: [{text: 'Test 1', href: '/wiki/Test_1'}],
-				exploreWikia: {
+				exploreWikis: {
 					links: [{
 						title: {
 							key: 'global-navigation-wikis-explore'
@@ -232,7 +232,7 @@ test('test zero state with values from api', (assert) => {
 						trackingLabel: 'global-navigation-wikis-explore'
 					}]
 				},
-				exploreWikiaLabel: exploreWikiaLabelMock,
+				exploreWikisLabel: exploreWikisLabelMock,
 				discussionsEnabled: false,
 				wikiName: 'Test'
 			},
@@ -295,8 +295,8 @@ test('test local sub nav transitions', (assert) => {
 			mock: {
 				hubsLinks: hubsLinksMock,
 				localLinks: [{text: 'Test 1', href: '/wiki/Test_1'}],
-				exploreWikia: exploreWikiaMock,
-				exploreWikiaLabel: exploreWikiaLabelMock,
+				exploreWikis: exploreWikisMock,
+				exploreWikisLabel: exploreWikisLabelMock,
 				wikiName: 'Test'
 			},
 			path: [0],
@@ -316,8 +316,8 @@ test('test local sub nav transitions', (assert) => {
 				localLinks: [{text: 'Test 1', href: '/wiki/Test_1', children: [
 					{text: 'Test 2', href: '/wiki/Test_2'}, {text: 'Test 3', href: '/wiki/Test_3'}
 				]}],
-				exploreWikia: exploreWikiaMock,
-				exploreWikiaLabel: exploreWikiaLabelMock,
+				exploreWikis: exploreWikisMock,
+				exploreWikisLabel: exploreWikisLabelMock,
 				wikiName: 'Test'
 			},
 			path: [1],
@@ -353,8 +353,8 @@ test('test local sub nav transitions', (assert) => {
 						{text: 'Test 3', href: '/wiki/Test_3'}
 					]
 				}],
-				exploreWikia: exploreWikiaMock,
-				exploreWikiaLabel: exploreWikiaLabelMock,
+				exploreWikis: exploreWikisMock,
+				exploreWikisLabel: exploreWikisLabelMock,
 				wikiName: 'Test'
 			},
 			path: [1, 1],
@@ -404,8 +404,8 @@ test('Header value', (assert) => {
 				localLinks: [{text: 'Test 1', href: '/wiki/Test_1', children: [
 					{text: 'Test 2', href: '/wiki/Test_2'}, {text: 'Test 3', href: '/wiki/Test_3'}
 				]}],
-				exploreWikia: exploreWikiaMock,
-				exploreWikiaLabel: exploreWikiaLabelMock,
+				exploreWikis: exploreWikisMock,
+				exploreWikisLabel: exploreWikisLabelMock,
 				wikiName: 'Test'
 			},
 			path: [1],
@@ -418,8 +418,8 @@ test('Header value', (assert) => {
 				localLinks: [{text: 'Test 1', href: '/wiki/Test_1', children: [
 					{text: 'Test 2', href: '/wiki/Test_2'}, {text: 'Test 3', href: '/wiki/Test_3'}
 				]}],
-				exploreWikia: exploreWikiaMock,
-				exploreWikiaLabel: exploreWikiaLabelMock,
+				exploreWikis: exploreWikisMock,
+				exploreWikisLabel: exploreWikisLabelMock,
 				wikiName: 'Test'
 			},
 			path: [],
@@ -447,8 +447,8 @@ test('Parent value', (assert) => {
 				localLinks: [{text: 'Test 1', href: '/wiki/Test_1', children: [
 					{text: 'Test 2', href: '/wiki/Test_2'}, {text: 'Test 3', href: '/wiki/Test_3'}
 				]}],
-				exploreWikia: exploreWikiaMock,
-				exploreWikiaLabel: exploreWikiaLabelMock,
+				exploreWikis: exploreWikisMock,
+				exploreWikisLabel: exploreWikisLabelMock,
 				wikiName: 'Test'
 			},
 			path: [10],
@@ -461,8 +461,8 @@ test('Parent value', (assert) => {
 				localLinks: [{text: 'Test 1', href: '/wiki/Test_1', children: [
 					{text: 'Test 2', href: '/wiki/Test_2'}, {text: 'Test 3', href: '/wiki/Test_3'}
 				]}],
-				exploreWikia: exploreWikiaMock,
-				exploreWikiaLabel: exploreWikiaLabelMock,
+				exploreWikis: exploreWikisMock,
+				exploreWikisLabel: exploreWikisLabelMock,
 				wikiName: 'Test'
 			},
 			path: [],
@@ -481,8 +481,8 @@ test('Parent value', (assert) => {
 						{text: 'Test 3', href: '/wiki/Test_3'}
 					]
 				}],
-				exploreWikia: exploreWikiaMock,
-				exploreWikiaLabel: exploreWikiaLabelMock,
+				exploreWikis: exploreWikisMock,
+				exploreWikisLabel: exploreWikisLabelMock,
 				wikiName: 'Test'
 			},
 			path: [1],
@@ -509,8 +509,8 @@ test('Parent value', (assert) => {
 						{text: 'Test 3', href: '/wiki/Test_3'}
 					]
 				}],
-				exploreWikia: exploreWikiaMock,
-				exploreWikiaLabel: exploreWikiaLabelMock,
+				exploreWikis: exploreWikisMock,
+				exploreWikisLabel: exploreWikisLabelMock,
 				wikiName: 'Test'
 			},
 			path: [1, 1],
@@ -539,8 +539,8 @@ test('Parent value', (assert) => {
 						{text: 'Test 5', href: '/wiki/Test_5'}
 					]
 				}],
-				exploreWikia: exploreWikiaMock,
-				exploreWikiaLabel: exploreWikiaLabelMock,
+				exploreWikis: exploreWikisMock,
+				exploreWikisLabel: exploreWikisLabelMock,
 				wikiName: 'Test'
 			},
 			path: [1, 1, 1],

--- a/front/main/tests/unit/models/wikia-nav-test.js
+++ b/front/main/tests/unit/models/wikia-nav-test.js
@@ -6,17 +6,39 @@ moduleFor('model:wikia-nav', 'Unit | Model | wikia nav', {
 	unit: true
 });
 
+const hubsLinksMock = [{
+		title: {
+			key: 'global-navigation-fandom-overview-link-vertical-games'
+		},
+		href: 'http://fandom.wikia.com/games',
+		brand: 'games'
+	}],
+	exploreWikiaMock = {
+		header: {
+			title: {
+				key: 'global-navigation-wikis-header'
+			}
+		},
+		links: [{
+			title: {
+				key: 'global-navigation-wikis-explore'
+			},
+			href: 'http://fandom.wikia.com/explore',
+			trackingLabel: 'global-navigation-wikis-explore'
+		}]
+	},
+	exploreWikiaLabelMock = 'global-navigation-wikis-header';
+
 test('test zero state with values from api', (assert) => {
 	const cases = [
 		{
 			mock: {
 				hubsLinks: [],
 				localLinks: [],
-				exploreWikiaLinks: [],
+				exploreWikia: [],
 				exploreWikiaLabel: '',
 				discussionsEnabled: false,
-				wikiName: '',
-				wikiLang: ''
+				wikiName: ''
 			},
 			expected: [
 				{
@@ -37,29 +59,26 @@ test('test zero state with values from api', (assert) => {
 		},
 		{
 			mock: {
-				hubsLinks: [{textEscaped: 'Hub test', href: 'http://test.com/hub', specialAttr: 'tests'}],
+				hubsLinks: hubsLinksMock,
 				localLinks: [{text: 'Test 1', href: '/wiki/Test_1'}],
-				exploreWikiaLinks: [
-					{textEscaped: 'Explore test', href: 'http://test.com/expolore', trackingLabel: 'exp-test'}
-				],
+				exploreWikia: exploreWikiaMock,
 				discussionsEnabled: false,
-				exploreWikiaLabel: 'Explore menu',
-				wikiName: 'Test',
-				wikiLang: 'en'
+				exploreWikiaLabel: exploreWikiaLabelMock,
+				wikiName: 'Test'
 			},
 			expected: [
 				{
-					className: 'nav-menu--external nav-menu--tests',
-					href: 'http://test.com/hub',
-					name: 'Hub test',
-					trackLabel: 'open-hub-tests',
+					className: 'nav-menu--external nav-menu--games',
+					href: 'http://fandom.wikia.com/games',
+					name: 'global-navigation-fandom-overview-link-vertical-games',
+					trackLabel: 'open-hub-global-navigation-fandom-overview-link-vertical-games',
 					type: 'nav-menu-external'
 				},
 				{
 					className: 'nav-menu--explore',
 					index: 0,
-					name: 'Explore menu',
-					trackLabel: 'open-explore-wikia',
+					name: 'global-navigation-wikis-header',
+					trackLabel: 'open-global-navigation-wikis-header',
 					type: 'nav-menu-root'
 				},
 				{
@@ -94,29 +113,26 @@ test('test zero state with values from api', (assert) => {
 		},
 		{
 			mock: {
-				hubsLinks: [{textEscaped: 'Hub test', href: 'http://test.com/hub', specialAttr: 'tests'}],
+				hubsLinks: hubsLinksMock,
 				localLinks: [{text: 'Test 1', href: '/wiki/Test_1'}],
-				exploreWikiaLinks: [
-					{textEscaped: 'Explore test', href: 'http://test.com/expolore', trackingLabel: 'exp-test'}
-				],
+				exploreWikia: exploreWikiaMock,
 				discussionsEnabled: true,
-				exploreWikiaLabel: 'Explore menu',
-				wikiName: 'Test',
-				wikiLang: 'en'
+				exploreWikiaLabel: exploreWikiaLabelMock,
+				wikiName: 'Test'
 			},
 			expected: [
 				{
-					className: 'nav-menu--external nav-menu--tests',
-					href: 'http://test.com/hub',
-					name: 'Hub test',
-					trackLabel: 'open-hub-tests',
+					className: 'nav-menu--external nav-menu--games',
+					href: 'http://fandom.wikia.com/games',
+					name: 'global-navigation-fandom-overview-link-vertical-games',
+					trackLabel: 'open-hub-global-navigation-fandom-overview-link-vertical-games',
 					type: 'nav-menu-external'
 				},
 				{
 					className: 'nav-menu--explore',
 					index: 0,
-					name: 'Explore menu',
-					trackLabel: 'open-explore-wikia',
+					name: 'global-navigation-wikis-header',
+					trackLabel: 'open-global-navigation-wikis-header',
 					type: 'nav-menu-root'
 				},
 				{
@@ -158,19 +174,18 @@ test('test zero state with values from api', (assert) => {
 		},
 		{
 			mock: {
-				hubsLinks: [{textEscaped: 'Hub test', href: 'http://test.com/hub', specialAttr: 'tests'}],
+				hubsLinks: [],
 				localLinks: [{text: 'Test 1', href: '/wiki/Test_1'}],
-				exploreWikiaLinks: [{textEscaped: 'Explore test', href: 'http://test.com/expolore', trackingLabel: 'exp-test'}],
-				exploreWikiaLabel: 'Explore menu',
+				exploreWikia: exploreWikiaMock,
+				exploreWikiaLabel: exploreWikiaLabelMock,
 				discussionsEnabled: false,
-				wikiName: 'Test',
-				wikiLang: 'pl'
+				wikiName: 'Test'
 			},
 			expected: [
 				{
 					index: 0,
-					name: 'Explore menu',
-					trackLabel: 'open-explore-wikia',
+					name: 'global-navigation-wikis-header',
+					trackLabel: 'open-global-navigation-wikis-header',
 					type: 'nav-menu-root',
 					className: 'nav-menu--explore'
 				},
@@ -202,7 +217,62 @@ test('test zero state with values from api', (assert) => {
 					type: 'nav-menu-item'
 				}
 			],
-			message: 'Hubs hidden for non english'
+			message: 'Hubs hidden when not returned from DS API'
+		},
+		{
+			mock: {
+				hubsLinks: [],
+				localLinks: [{text: 'Test 1', href: '/wiki/Test_1'}],
+				exploreWikia: {
+					links: [{
+						title: {
+							key: 'global-navigation-wikis-explore'
+						},
+						href: 'http://fandom.wikia.com/explore',
+						trackingLabel: 'global-navigation-wikis-explore'
+					}]
+				},
+				exploreWikiaLabel: exploreWikiaLabelMock,
+				discussionsEnabled: false,
+				wikiName: 'Test'
+			},
+			expected: [
+				{
+					className: 'nav-menu--external',
+					href: 'http://fandom.wikia.com/explore',
+					name: 'global-navigation-wikis-explore',
+					trackLabel: 'open-global-navigation-wikis-explore',
+					type: 'nav-menu-external'
+				},
+				{
+					name: 'app.explore-wiki',
+					type: 'nav-menu-header',
+					route: 'wiki-page',
+					href: ''
+				},
+				{
+					route: 'recent-wiki-activity',
+					name: 'main.title',
+					trackCategory: 'recent-wiki-activity',
+					trackLabel: 'local-nav',
+					type: 'nav-menu-item'
+				},
+				{
+					href: 'Test_1',
+					index: 1,
+					route: 'wiki-page',
+					name: 'Test 1',
+					trackLabel: 'local-nav-open-link-index-1',
+					type: 'nav-menu-item'
+				},
+				{
+					actionId: 'onRandomPageClick',
+					name: 'app.random-page-label',
+					trackLabel: 'random-page',
+					type: 'nav-menu-item'
+				}
+			],
+			message: 'Show the first link when there is no header for wikis section'
 		}
 	];
 
@@ -223,21 +293,18 @@ test('test local sub nav transitions', (assert) => {
 	const cases = [
 		{
 			mock: {
-				hubsLinks: [{textEscaped: 'Hub test', href: 'http://test.com/hub', specialAttr: 'tests'}],
+				hubsLinks: hubsLinksMock,
 				localLinks: [{text: 'Test 1', href: '/wiki/Test_1'}],
-				exploreWikiaLinks: [
-					{textEscaped: 'Explore test', href: 'http://test.com/explore', trackingLabel: 'exp-test-1'}
-				],
-				exploreWikiaLabel: 'Explore menu',
-				wikiName: 'Test',
-				wikiLang: 'en'
+				exploreWikia: exploreWikiaMock,
+				exploreWikiaLabel: exploreWikiaLabelMock,
+				wikiName: 'Test'
 			},
 			path: [0],
 			expected: [
 				{
-					href: 'http://test.com/explore',
-					name: 'Explore test',
-					trackLabel: 'open-exp-test-1',
+					href: 'http://fandom.wikia.com/explore',
+					name: 'global-navigation-wikis-explore',
+					trackLabel: 'open-global-navigation-wikis-explore',
 					type: 'nav-menu-external'
 				}
 			],
@@ -245,16 +312,13 @@ test('test local sub nav transitions', (assert) => {
 		},
 		{
 			mock: {
-				hubsLinks: [{textEscaped: 'Hub test', href: 'http://test.com/hub', specialAttr: 'tests'}],
+				hubsLinks: hubsLinksMock,
 				localLinks: [{text: 'Test 1', href: '/wiki/Test_1', children: [
 					{text: 'Test 2', href: '/wiki/Test_2'}, {text: 'Test 3', href: '/wiki/Test_3'}
 				]}],
-				exploreWikiaLinks: [
-					{textEscaped: 'Explore test', href: 'http://test.com/explore', trackingLabel: 'exp-test-1'}
-				],
-				exploreWikiaLabel: 'Explore menu',
-				wikiName: 'Test',
-				wikiLang: 'en'
+				exploreWikia: exploreWikiaMock,
+				exploreWikiaLabel: exploreWikiaLabelMock,
+				wikiName: 'Test'
 			},
 			path: [1],
 			expected: [
@@ -279,7 +343,7 @@ test('test local sub nav transitions', (assert) => {
 		},
 		{
 			mock: {
-				hubsLinks: [{textEscaped: 'Hub test', href: 'http://test.com/hub', specialAttr: 'tests'}],
+				hubsLinks: hubsLinksMock,
 				localLinks: [{
 					text: 'Test 1', href: '/wiki/Test_1', children: [
 						{text: 'Test 2', href: '/wiki/Test_2', children: [
@@ -289,12 +353,9 @@ test('test local sub nav transitions', (assert) => {
 						{text: 'Test 3', href: '/wiki/Test_3'}
 					]
 				}],
-				exploreWikiaLinks: [
-					{textEscaped: 'Explore test', href: 'http://test.com/explore', trackingLabel: 'exp-test-1'}
-				],
-				exploreWikiaLabel: 'Explore menu',
-				wikiName: 'Test',
-				wikiLang: 'en'
+				exploreWikia: exploreWikiaMock,
+				exploreWikiaLabel: exploreWikiaLabelMock,
+				wikiName: 'Test'
 			},
 			path: [1, 1],
 			expected: [
@@ -319,6 +380,10 @@ test('test local sub nav transitions', (assert) => {
 		}
 	];
 
+	const i18nStub = sinon.stub(window.i18n, 't');
+
+	i18nStub.returnsArg(0);
+
 	cases.forEach((testCase) => {
 		const nav = WikiaNavModel.create(testCase.mock);
 
@@ -327,22 +392,21 @@ test('test local sub nav transitions', (assert) => {
 		});
 		assert.deepEqual(nav.get('items'), testCase.expected, testCase.message);
 	});
+
+	i18nStub.restore();
 });
 
 test('Header value', (assert) => {
 	const cases = [
 		{
 			mock: {
-				hubsLinks: [{textEscaped: 'Hub test', href: 'http://test.com/hub', specialAttr: 'tests'}],
+				hubsLinks: hubsLinksMock,
 				localLinks: [{text: 'Test 1', href: '/wiki/Test_1', children: [
 					{text: 'Test 2', href: '/wiki/Test_2'}, {text: 'Test 3', href: '/wiki/Test_3'}
 				]}],
-				exploreWikiaLinks: [
-					{textEscaped: 'Explore test', href: 'http://test.com/explore', trackingLabel: 'exp-test-1'}
-				],
-				exploreWikiaLabel: 'Explore menu',
-				wikiName: 'Test',
-				wikiLang: 'en'
+				exploreWikia: exploreWikiaMock,
+				exploreWikiaLabel: exploreWikiaLabelMock,
+				wikiName: 'Test'
 			},
 			path: [1],
 			expected: 'Test 1',
@@ -350,19 +414,16 @@ test('Header value', (assert) => {
 		},
 		{
 			mock: {
-				hubsLinks: [{textEscaped: 'Hub test', href: 'http://test.com/hub', specialAttr: 'tests'}],
+				hubsLinks: hubsLinksMock,
 				localLinks: [{text: 'Test 1', href: '/wiki/Test_1', children: [
 					{text: 'Test 2', href: '/wiki/Test_2'}, {text: 'Test 3', href: '/wiki/Test_3'}
 				]}],
-				exploreWikiaLinks: [
-					{textEscaped: 'Explore test', href: 'http://test.com/explore', trackingLabel: 'exp-test-1'}
-				],
-				exploreWikiaLabel: 'Explore menu',
-				wikiName: 'Test',
-				wikiLang: 'en'
+				exploreWikia: exploreWikiaMock,
+				exploreWikiaLabel: exploreWikiaLabelMock,
+				wikiName: 'Test'
 			},
 			path: [],
-			expected: 'Explore menu',
+			expected: 'global-navigation-wikis-header',
 			message: 'Show parent text'
 		}
 	];
@@ -382,16 +443,13 @@ test('Parent value', (assert) => {
 	const cases = [
 		{
 			mock: {
-				hubsLinks: [{textEscaped: 'Hub test', href: 'http://test.com/hub', specialAttr: 'tests'}],
+				hubsLinks: hubsLinksMock,
 				localLinks: [{text: 'Test 1', href: '/wiki/Test_1', children: [
 					{text: 'Test 2', href: '/wiki/Test_2'}, {text: 'Test 3', href: '/wiki/Test_3'}
 				]}],
-				exploreWikiaLinks: [
-					{textEscaped: 'Explore test', href: 'http://test.com/explore', trackingLabel: 'exp-test-1'}
-				],
-				exploreWikiaLabel: 'Explore menu',
-				wikiName: 'Test',
-				wikiLang: 'en'
+				exploreWikia: exploreWikiaMock,
+				exploreWikiaLabel: exploreWikiaLabelMock,
+				wikiName: 'Test'
 			},
 			path: [10],
 			expected: {},
@@ -399,16 +457,13 @@ test('Parent value', (assert) => {
 		},
 		{
 			mock: {
-				hubsLinks: [{textEscaped: 'Hub test', href: 'http://test.com/hub', specialAttr: 'tests'}],
+				hubsLinks: hubsLinksMock,
 				localLinks: [{text: 'Test 1', href: '/wiki/Test_1', children: [
 					{text: 'Test 2', href: '/wiki/Test_2'}, {text: 'Test 3', href: '/wiki/Test_3'}
 				]}],
-				exploreWikiaLinks: [
-					{textEscaped: 'Explore test', href: 'http://test.com/explore', trackingLabel: 'exp-test-1'}
-				],
-				exploreWikiaLabel: 'Explore menu',
-				wikiName: 'Test',
-				wikiLang: 'en'
+				exploreWikia: exploreWikiaMock,
+				exploreWikiaLabel: exploreWikiaLabelMock,
+				wikiName: 'Test'
 			},
 			path: [],
 			expected: {},
@@ -416,7 +471,7 @@ test('Parent value', (assert) => {
 		},
 		{
 			mock: {
-				hubsLinks: [{textEscaped: 'Hub test', href: 'http://test.com/hub', specialAttr: 'tests'}],
+				hubsLinks: hubsLinksMock,
 				localLinks: [{
 					text: 'Test 1', href: '/wiki/Test_1', children: [
 						{text: 'Test 2', href: '/wiki/Test_2', children: [
@@ -426,12 +481,9 @@ test('Parent value', (assert) => {
 						{text: 'Test 3', href: '/wiki/Test_3'}
 					]
 				}],
-				exploreWikiaLinks: [
-					{textEscaped: 'Explore test', href: 'http://test.com/explore', trackingLabel: 'exp-test-1'}
-				],
-				exploreWikiaLabel: 'Explore menu',
-				wikiName: 'Test',
-				wikiLang: 'en'
+				exploreWikia: exploreWikiaMock,
+				exploreWikiaLabel: exploreWikiaLabelMock,
+				wikiName: 'Test'
 			},
 			path: [1],
 			expected: {
@@ -447,7 +499,7 @@ test('Parent value', (assert) => {
 		},
 		{
 			mock: {
-				hubsLinks: [{textEscaped: 'Hub test', href: 'http://test.com/hub', specialAttr: 'tests'}],
+				hubsLinks: hubsLinksMock,
 				localLinks: [{
 					text: 'Test 1', href: '/wiki/Test_1', children: [
 						{text: 'Test 2', href: '/wiki/Test_2', children: [
@@ -457,12 +509,9 @@ test('Parent value', (assert) => {
 						{text: 'Test 3', href: '/wiki/Test_3'}
 					]
 				}],
-				exploreWikiaLinks: [
-					{textEscaped: 'Explore test', href: 'http://test.com/explore', trackingLabel: 'exp-test-1'}
-				],
-				exploreWikiaLabel: 'Explore menu',
-				wikiName: 'Test',
-				wikiLang: 'en'
+				exploreWikia: exploreWikiaMock,
+				exploreWikiaLabel: exploreWikiaLabelMock,
+				wikiName: 'Test'
 			},
 			path: [1, 1],
 			expected: {
@@ -477,7 +526,7 @@ test('Parent value', (assert) => {
 		},
 		{
 			mock: {
-				hubsLinks: [{textEscaped: 'Hub test', href: 'http://test.com/hub', specialAttr: 'tests'}],
+				hubsLinks: hubsLinksMock,
 				localLinks: [{
 					text: 'Test 1', href: '/wiki/Test_1', children: [
 						{text: 'Test 2', href: '/wiki/Test_2', children: [
@@ -490,12 +539,9 @@ test('Parent value', (assert) => {
 						{text: 'Test 5', href: '/wiki/Test_5'}
 					]
 				}],
-				exploreWikiaLinks: [
-					{textEscaped: 'Explore test', href: 'http://test.com/explore', trackingLabel: 'exp-test-1'}
-				],
-				exploreWikiaLabel: 'Explore menu',
-				wikiName: 'Test',
-				wikiLang: 'en'
+				exploreWikia: exploreWikiaMock,
+				exploreWikiaLabel: exploreWikiaLabelMock,
+				wikiName: 'Test'
 			},
 			path: [1, 1, 1],
 			expected: {


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/XW-2013

## Description

Instead of using the old Global Navigation API (data from it comes to Mercury together with the wiki variables) for the mobile navigation we want to use a mix:
- hubs and global links controlled by the Design System API
- local nav controlled by the old API

This is only a temporary solution until we rewrite the mobile nav to be compliant with the Design System.

## Reviewers

@Wikia/x-wing 