### PR TITLE
XW-1737 | Handle wikiVariables non-JSON API response as a redirect

### DIFF
--- a/server/app/facets/mediawiki-page.js
+++ b/server/app/facets/mediawiki-page.js
@@ -69,7 +69,7 @@ function redirectToMainPage(reply, mediaWikiPageHelper) {
 		 * @returns {void}
 		 */
 		.catch(NonJsonApiResponseError, (err) => {
-			reply.redirect(err.url);
+			reply.redirect(err.redirectLocation);
 		})
 		/**
 		 * @param {*} error
@@ -207,7 +207,7 @@ function getMediaWikiPage(request, reply, mediaWikiPageHelper, allowCache) {
 		 * @returns {void}
 		 */
 		.catch(NonJsonApiResponseError, (err) => {
-			reply.redirect(err.url);
+			reply.redirect(err.redirectLocation);
 		})
 		/**
 		 * If request for Wiki Variables succeeds, but request for Page Details fails

--- a/server/app/facets/mediawiki-page.js
+++ b/server/app/facets/mediawiki-page.js
@@ -2,7 +2,7 @@ import {disableCache, setResponseCaching, Interval as CachingInterval, Policy as
 import {
 	PageRequestError,
 	RedirectedToCanonicalHost,
-	WikiVariablesNotValidWikiError,
+	NonJsonApiResponseError,
 	WikiVariablesRequestError
 } from '../lib/custom-errors';
 import Logger from '../lib/logger';
@@ -68,8 +68,8 @@ function redirectToMainPage(reply, mediaWikiPageHelper) {
 		 * If request for Wiki Variables succeeds, but wiki does not exist
 		 * @returns {void}
 		 */
-		.catch(WikiVariablesNotValidWikiError, () => {
-			reply.redirect(localSettings.redirectUrlOnNoData);
+		.catch(NonJsonApiResponseError, (err) => {
+			reply.redirect(err.url);
 		})
 		/**
 		 * @param {*} error
@@ -206,8 +206,8 @@ function getMediaWikiPage(request, reply, mediaWikiPageHelper, allowCache) {
 		 * If request for Wiki Variables succeeds, but wiki does not exist
 		 * @returns {void}
 		 */
-		.catch(WikiVariablesNotValidWikiError, () => {
-			reply.redirect(localSettings.redirectUrlOnNoData);
+		.catch(NonJsonApiResponseError, (err) => {
+			reply.redirect(err.url);
 		})
 		/**
 		 * If request for Wiki Variables succeeds, but request for Page Details fails

--- a/server/app/facets/show-application.js
+++ b/server/app/facets/show-application.js
@@ -120,7 +120,7 @@ export default function showApplication(request, reply, wikiVariables, context =
 		 * @returns {void}
 		 */
 		.catch(NonJsonApiResponseError, (err) => {
-			reply.redirect(err.url);
+			reply.redirect(err.redirectLocation);
 		})
 		/**
 		 * @returns {void}

--- a/server/app/facets/show-application.js
+++ b/server/app/facets/show-application.js
@@ -8,7 +8,7 @@ import localSettings from '../../config/localSettings';
 import discussionsSplashPageConfig from '../../config/discussionsSplashPageConfig';
 import {gaUserIdHash} from '../lib/hashing';
 import {
-	RedirectedToCanonicalHost, WikiVariablesNotValidWikiError, WikiVariablesRequestError
+	RedirectedToCanonicalHost, NonJsonApiResponseError, WikiVariablesRequestError
 } from '../lib/custom-errors';
 import {isRtl, getUserId, getLocalSettings} from './operations/page-data-helper';
 import showServerErrorPage from './operations/show-server-error-page';
@@ -119,8 +119,8 @@ export default function showApplication(request, reply, wikiVariables, context =
 		 * If request for Wiki Variables succeeds, but wiki does not exist
 		 * @returns {void}
 		 */
-		.catch(WikiVariablesNotValidWikiError, () => {
-			reply.redirect(localSettings.redirectUrlOnNoData);
+		.catch(NonJsonApiResponseError, (err) => {
+			reply.redirect(err.url);
 		})
 		/**
 		 * @returns {void}

--- a/server/app/facets/show-curated-content.js
+++ b/server/app/facets/show-curated-content.js
@@ -1,7 +1,7 @@
 import Logger from '../lib/logger';
 import {CuratedMainPageRequestHelper} from '../lib/curated-main-page';
 import {
-	MainPageDataRequestError, RedirectedToCanonicalHost, WikiVariablesNotValidWikiError, WikiVariablesRequestError
+	MainPageDataRequestError, RedirectedToCanonicalHost, NonJsonApiResponseError, WikiVariablesRequestError
 } from '../lib/custom-errors';
 import {getCachedWikiDomainName, redirectToCanonicalHostIfNeeded, setI18nLang} from '../lib/utils';
 import localSettings from '../../config/localSettings';
@@ -109,8 +109,8 @@ export default function showCuratedContent(request, reply) {
 		/**
 		 * @returns {void}
 		 */
-		.catch(WikiVariablesNotValidWikiError, () => {
-			reply.redirect(localSettings.redirectUrlOnNoData);
+		.catch(NonJsonApiResponseError, (err) => {
+			reply.redirect(err.url);
 		})
 		/**
 		 * @returns {void}

--- a/server/app/facets/show-curated-content.js
+++ b/server/app/facets/show-curated-content.js
@@ -110,7 +110,7 @@ export default function showCuratedContent(request, reply) {
 		 * @returns {void}
 		 */
 		.catch(NonJsonApiResponseError, (err) => {
-			reply.redirect(err.url);
+			reply.redirect(err.redirectLocation);
 		})
 		/**
 		 * @returns {void}

--- a/server/app/lib/custom-errors.js
+++ b/server/app/lib/custom-errors.js
@@ -61,15 +61,16 @@ export class WikiVariablesRequestError {
 WikiVariablesRequestError.prototype = Object.create(Error.prototype);
 
 /**
- * @class WikiVariablesNotValidWikiError
+ * @class NonJsonApiResponseError
  */
-export class WikiVariablesNotValidWikiError {
+export class NonJsonApiResponseError {
 	/**
 	 * @returns {void}
 	 */
-	constructor() {
+	constructor(url) {
 		Error.apply(this, arguments);
+		this.url = url;
 	}
 }
 
-WikiVariablesNotValidWikiError.prototype = Object.create(Error.prototype);
+NonJsonApiResponseError.prototype = Object.create(Error.prototype);

--- a/server/app/lib/custom-errors.js
+++ b/server/app/lib/custom-errors.js
@@ -67,9 +67,9 @@ export class NonJsonApiResponseError {
 	/**
 	 * @returns {void}
 	 */
-	constructor(url) {
+	constructor(redirectLocation) {
 		Error.apply(this, arguments);
-		this.url = url;
+		this.redirectLocation = redirectLocation;
 	}
 }
 

--- a/server/app/lib/mediawiki.js
+++ b/server/app/lib/mediawiki.js
@@ -372,9 +372,7 @@ export class PageRequest extends BaseRequest {
 			 * @param {payload, redirectedUrl}
 			 * @returns {Promise}
 			 */
-			.then(({payload}) => {
-				return Promise.resolve(payload);
-			});
+			.then(({payload}) => payload);
 	}
 
 	/*
@@ -391,9 +389,7 @@ export class PageRequest extends BaseRequest {
 			 * @param {payload, redirectedUrl}
 			 * @returns {Promise}
 			 */
-			.then(({payload}) => {
-				return Promise.resolve(payload);
-			});
+			.then(({payload}) => payload);
 	}
 
 	/**
@@ -424,8 +420,6 @@ export class PageRequest extends BaseRequest {
 			 * @param {payload, redirectedUrl}
 			 * @returns {Promise}
 			 */
-			.then(({payload}) => {
-				return Promise.resolve(payload);
-			});
+			.then(({payload}) => payload);
 	}
 }

--- a/server/app/lib/mediawiki.js
+++ b/server/app/lib/mediawiki.js
@@ -67,11 +67,11 @@ export function sanitizeRejectData(payload, response) {
  * @param {Object} response
  * @param {string} url
  * @param {string} host
- * @param {string} redirectLocation
+ * @param {string} [redirectLocation=null]
  *
  * @returns {void}
  */
-function requestCallback({resolve, reject, err, payload, response, url, host, redirectLocation}) {
+function requestCallback({resolve, reject, err, payload, response, url, host, redirectLocation = null}) {
 	if (err) {
 		Logger.error({
 			url,
@@ -200,8 +200,6 @@ export function post(url, formData, host = '', headers = {}) {
 	 * @returns {void}
 	 */
 	return new Promise((resolve, reject) => {
-		let redirectLocation;
-
 		/**
 		 * @param {*} err
 		 * @param {*} response
@@ -210,10 +208,7 @@ export function post(url, formData, host = '', headers = {}) {
 		 */
 		Wreck.request('POST', url, {
 			payload: formData,
-			headers,
-			redirected: (statusCode, location, req) => {
-				redirectLocation = location;
-			}
+			headers
 		}, (err, response) => {
 			Wreck.read(response, null, (err, body) => {
 				return requestCallback({
@@ -223,8 +218,7 @@ export function post(url, formData, host = '', headers = {}) {
 					payload: body.toString(),
 					response,
 					url,
-					host,
-					redirectLocation
+					host
 				});
 			});
 		});

--- a/server/app/lib/mediawiki.js
+++ b/server/app/lib/mediawiki.js
@@ -160,7 +160,7 @@ export function fetch(url, host = '', redirects = 1, headers = {}) {
 			timeout: localSettings.backendRequestTimeout,
 			json: true,
 			beforeRedirect,
-			redirected: (statusCode, location, req) => {
+			redirected: (statusCode, location) => {
 				redirectedUrl = location;
 			}
 		}, (err, response, payload) => {

--- a/server/app/lib/mediawiki.js
+++ b/server/app/lib/mediawiki.js
@@ -67,11 +67,11 @@ export function sanitizeRejectData(payload, response) {
  * @param {Object} response
  * @param {string} url
  * @param {string} host
- * @param {string} redirectedUrl
+ * @param {string} redirectLocation
  *
  * @returns {void}
  */
-function requestCallback({resolve, reject, err, payload, response, url, host, redirectedUrl}) {
+function requestCallback({resolve, reject, err, payload, response, url, host, redirectLocation}) {
 	if (err) {
 		Logger.error({
 			url,
@@ -88,7 +88,7 @@ function requestCallback({resolve, reject, err, payload, response, url, host, re
 	} else if (response.statusCode === 200) {
 		resolve({
 			payload,
-			redirectedUrl
+			redirectLocation
 		});
 	} else {
 		// Don't flood logs with 404s
@@ -145,7 +145,7 @@ export function fetch(url, host = '', redirects = 1, headers = {}) {
 	 * @returns {void}
 	 */
 	return new Promise((resolve, reject) => {
-		let redirectedUrl;
+		let redirectLocation;
 
 		/**
 		 * @param {*} err
@@ -160,7 +160,7 @@ export function fetch(url, host = '', redirects = 1, headers = {}) {
 			json: true,
 			beforeRedirect,
 			redirected: (statusCode, location) => {
-				redirectedUrl = location;
+				redirectLocation = location;
 			}
 		}, (err, response, payload) => {
 			return requestCallback({
@@ -171,7 +171,7 @@ export function fetch(url, host = '', redirects = 1, headers = {}) {
 				response,
 				url,
 				host,
-				redirectedUrl
+				redirectLocation
 			});
 		});
 	});
@@ -200,7 +200,7 @@ export function post(url, formData, host = '', headers = {}) {
 	 * @returns {void}
 	 */
 	return new Promise((resolve, reject) => {
-		let redirectedUrl;
+		let redirectLocation;
 
 		/**
 		 * @param {*} err
@@ -212,7 +212,7 @@ export function post(url, formData, host = '', headers = {}) {
 			payload: formData,
 			headers,
 			redirected: (statusCode, location, req) => {
-				redirectedUrl = location;
+				redirectLocation = location;
 			}
 		}, (err, response) => {
 			Wreck.read(response, null, (err, body) => {
@@ -224,7 +224,7 @@ export function post(url, formData, host = '', headers = {}) {
 					response,
 					url,
 					host,
-					redirectedUrl
+					redirectLocation
 				});
 			});
 		});
@@ -322,15 +322,15 @@ export class WikiRequest extends BaseRequest {
 		return this
 			.fetch(url)
 			/**
-			 * @param {payload, redirectedUrl}
+			 * @param {payload, redirectLocation}
 			 * @returns {Promise}
 			 */
-			.then(({payload, redirectedUrl}) => {
+			.then(({payload, redirectLocation}) => {
 				if (payload.data) {
 					return Promise.resolve(payload.data);
 				} else {
 					// If we got status 200 but not the expected format we handle it as a redirect
-					throw new NonJsonApiResponseError(redirectedUrl);
+					throw new NonJsonApiResponseError(redirectLocation);
 				}
 			}, () => {
 				throw new WikiVariablesRequestError();
@@ -369,7 +369,7 @@ export class PageRequest extends BaseRequest {
 
 		return this.fetch(createUrl(this.wikiDomain, 'wikia.php', urlParams))
 			/**
-			 * @param {payload, redirectedUrl}
+			 * @param {payload, redirectLocation}
 			 * @returns {Promise}
 			 */
 			.then(({payload}) => payload);
@@ -386,7 +386,7 @@ export class PageRequest extends BaseRequest {
 
 		return this.fetch(url)
 			/**
-			 * @param {payload, redirectedUrl}
+			 * @param {payload, redirectLocation}
 			 * @returns {Promise}
 			 */
 			.then(({payload}) => payload);
@@ -417,7 +417,7 @@ export class PageRequest extends BaseRequest {
 
 		return this.post(url, Url.format({query: params}).substr(1))
 			/**
-			 * @param {payload, redirectedUrl}
+			 * @param {payload, redirectLocation}
 			 * @returns {Promise}
 			 */
 			.then(({payload}) => payload);

--- a/server/app/lib/mediawiki.js
+++ b/server/app/lib/mediawiki.js
@@ -373,13 +373,8 @@ export class PageRequest extends BaseRequest {
 			 * @param {payload, redirectedUrl}
 			 * @returns {Promise}
 			 */
-			.then(({payload, redirectedUrl}) => {
-				if (payload) {
-					return Promise.resolve(payload);
-				} else {
-					// If we got status 200 but not the expected format we handle it as a redirect
-					throw new NonJsonApiResponseError(redirectedUrl);
-				}
+			.then(({payload}) => {
+				return Promise.resolve(payload);
 			});
 	}
 
@@ -397,13 +392,8 @@ export class PageRequest extends BaseRequest {
 			 * @param {payload, redirectedUrl}
 			 * @returns {Promise}
 			 */
-			.then(({payload, redirectedUrl}) => {
-				if (payload) {
-					return Promise.resolve(payload);
-				} else {
-					// If we got status 200 but not the expected format we handle it as a redirect
-					throw new NonJsonApiResponseError(redirectedUrl);
-				}
+			.then(({payload}) => {
+				return Promise.resolve(payload);
 			});
 	}
 
@@ -435,13 +425,8 @@ export class PageRequest extends BaseRequest {
 			 * @param {payload, redirectedUrl}
 			 * @returns {Promise}
 			 */
-			.then(({payload, redirectedUrl}) => {
-				if (payload) {
-					return Promise.resolve(payload);
-				} else {
-					// If we got status 200 but not the expected format we handle it as a redirect
-					throw new NonJsonApiResponseError(redirectedUrl);
-				}
+			.then(({payload}) => {
+				return Promise.resolve(payload);
 			});
 	}
 }

--- a/server/app/lib/mediawiki.js
+++ b/server/app/lib/mediawiki.js
@@ -153,7 +153,6 @@ export function fetch(url, host = '', redirects = 1, headers = {}) {
 		 * @param {*} payload
 		 * @returns {void}
 		 */
-
 		Wreck.get(url, {
 			redirects,
 			headers,

--- a/server/tests/acceptance/application.js
+++ b/server/tests/acceptance/application.js
@@ -58,7 +58,7 @@ describe('application', function () {
 
 	it('redirects to community wikia when requested wiki does not exist', function (done) {
 		mediawiki.__Rewire__('Wreck', {
-			get: function(url, options, callback) {
+			get: function (url, options, callback) {
 				if (url.indexOf('getWikiVariables') > -1) {
 					options.redirected(null, 'http://community.wikia.com/wiki/Community_Central:Not_a_valid_Wikia');
 

--- a/server/tests/acceptance/curated-content.js
+++ b/server/tests/acceptance/curated-content.js
@@ -73,7 +73,7 @@ describe('curated-content', function () {
 		}
 	);
 
-	it('redirects to community wikia when requested wiki does not exist', function (done) {
+	it('redirects when requested wiki is redirected', function (done) {
 		mediawiki.__Rewire__('Wreck', {
 			get: function (url, options, callback) {
 				if (url.indexOf('getWikiVariables') > -1) {

--- a/server/tests/acceptance/curated-content.js
+++ b/server/tests/acceptance/curated-content.js
@@ -75,7 +75,7 @@ describe('curated-content', function () {
 
 	it('redirects to community wikia when requested wiki does not exist', function (done) {
 		mediawiki.__Rewire__('Wreck', {
-			get: function(url, options, callback) {
+			get: function (url, options, callback) {
 				if (url.indexOf('getWikiVariables') > -1) {
 					options.redirected(null, 'http://google.com/');
 

--- a/server/tests/acceptance/wiki-page.js
+++ b/server/tests/acceptance/wiki-page.js
@@ -109,7 +109,7 @@ describe('wiki-page', function () {
 
 	it('redirects to community wikia when requested wiki does not exist', function (done) {
 		mediawiki.__Rewire__('Wreck', {
-			get: function(url, options, callback) {
+			get: function (url, options, callback) {
 				if (url.indexOf('getWikiVariables') > -1) {
 					options.redirected(null, 'http://community.wikia.com/wiki/Community_Central:Not_a_valid_Wikia');
 
@@ -201,7 +201,7 @@ describe('wiki-page', function () {
 
 	it('redirects to community wikia on /wiki/ when requested wiki does not exist', function (done) {
 		mediawiki.__Rewire__('Wreck', {
-			get: function(url, options, callback) {
+			get: function (url, options, callback) {
 				if (url.indexOf('getWikiVariables') > -1) {
 					options.redirected(null, 'http://community.wikia.com/wiki/Community_Central:Not_a_valid_Wikia');
 


### PR DESCRIPTION
## Links
* https://wikia-inc.atlassian.net/browse/XW-1737

## Description
While handling `wikiVariables` response we can get redirect to a HTML page instead of JSON API response. Instead of trying to display that page in mercury let's redirect user to that page so browser can render it.

## Reviewers
@Wikia/x-wing 
