### PR TITLE
SOC-3137 | fix: add zero state for user with no posts

### DIFF
--- a/front/main/app/templates/components/discussion-user-list-wrapper.hbs
+++ b/front/main/app/templates/components/discussion-user-list-wrapper.hbs
@@ -34,6 +34,8 @@
 			upvote=(action this.attrs.upvote)
 		}}
 	{{/if}}
+{{else}}
+	{{discussion-not-found-error}}
 {{/each}}
 {{discussion-wrapper-load-more
 	hasMore=hasMore


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/SOC-3137
## Description

Add zero state for /u.

## Reviewers

@Wikia/social-frontend 

