### PR TITLE
SOC-2830 | fix: move remove category icon to proper place in edit mode

### DIFF
--- a/front/main/app/styles/component/discussion/_discussion-categories-edit.scss
+++ b/front/main/app/styles/component/discussion/_discussion-categories-edit.scss
@@ -33,7 +33,7 @@ $success-icon-size: 80px;
 		}
 
 		.draggable {
-			align-items: center;
+			align-items: flex-start;
 			cursor: pointer;
 			display: none;
 			height: 100%;
@@ -168,6 +168,8 @@ $success-icon-size: 80px;
 	}
 
 	.icon {
+		margin-bottom: 5px;
+
 		&.lock {
 			margin: 5px 10px 4px 0;
 		}
@@ -182,6 +184,7 @@ $success-icon-size: 80px;
 
 		&.close {
 			height: 20px;
+			margin-left: 3px;
 			width: 20px;
 		}
 


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/SOC-2830
## Description

'x' button and button to reorder categories misplaced on desktop

## Reviewers

@Wikia/social-frontend 

