### PR TITLE
SOC-2911 | fix: inline editor textarea is readonly if editor isn't active

### DIFF
--- a/front/main/app/components/discussion-inline-editor.js
+++ b/front/main/app/components/discussion-inline-editor.js
@@ -28,6 +28,10 @@ export default DiscussionMultipleInputsEditor.extend(
 			return !this.get('isReply');
 		}),
 
+		isReadonly: Ember.computed('isActive', function () {
+			return !this.get('isActive') ? 'readonly' : undefined;
+		}),
+
 		/**
 		 * Returns true if textarea is the only textarea in editor and should appear as first/only one in
 		 * collapsed inline editor.

--- a/front/main/app/components/discussion-textarea-with-counter.js
+++ b/front/main/app/components/discussion-textarea-with-counter.js
@@ -22,6 +22,10 @@ export default Ember.Component.extend({
 
 	isCollapsed: Ember.computed.not('isActive'),
 
+	isReadonly: Ember.computed('isActive', function () {
+		return !this.get('isActive') ? 'readonly' : undefined;
+	}),
+
 	dynamicPlaceholder: Ember.computed('isCollapsed', 'placeholder', 'collapsedPlaceholder', function () {
 		return this.get('isCollapsed') ? this.get('collapsedPlaceholder') : this.get('placeholder');
 	}),

--- a/front/main/app/templates/components/discussion-inline-editor.hbs
+++ b/front/main/app/templates/components/discussion-inline-editor.hbs
@@ -79,6 +79,7 @@
 						placeholder=(i18n messagePlaceholderKey ns='discussion')
 						required=true
 						value=content
+						readonly=isReadonly
 					}}
 				</label>
 				{{#if showsOpenGraphCard}}

--- a/front/main/app/templates/components/discussion-textarea-with-counter.hbs
+++ b/front/main/app/templates/components/discussion-textarea-with-counter.hbs
@@ -12,6 +12,7 @@
 		placeholder=dynamicPlaceholder
 		required=required
 		value=text
+		readonly=isReadonly
 	}}
 	{{#if showCharactersCounter}}
 		<span class="discussion-textarea-counter">


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/SOC-2911

## Description

Textareas in inline editor is readonly by default. It's editable only when editor is active.

## Reviewers

@Wikia/social-frontend 