### PR TITLE
SOC-3023 | fix: hiding clear button on IE and Edge

### DIFF
--- a/front/main/app/styles/component/discussion/_discussion-categories-edit.scss
+++ b/front/main/app/styles/component/discussion/_discussion-categories-edit.scss
@@ -125,6 +125,10 @@ $success-icon-size: 80px;
 
 	input[type=text] {
 		border-bottom-color: $discussion-categories-edit-border-bottom-color;
+
+		&::-ms-clear {
+			display: none;
+		}
 	}
 
 	.discussion-categories-input,


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/SOC-3023

## Description

IE/Edge adds clear button in inputs. I hided it.

## Reviewers

@Wikia/social-frontend 

