### PR TITLE
XW-2208 | Stop using `performance` global directly

### DIFF
--- a/front/auth/app/common/auth-utils.js
+++ b/front/auth/app/common/auth-utils.js
@@ -31,10 +31,10 @@ export default class AuthUtils {
 
 				window.location.reload();
 			},
-			preferencesRequestStartTime = performance.now();
+			preferencesRequestStartTime = window.performance.now();
 
 		xhr.onload = () => {
-			const preferencesRequestEndTime = performance.now();
+			const preferencesRequestEndTime = window.performance.now();
 
 			authLogger.info({
 				message: 'Check if account is scheduled to be closed XHR time',

--- a/front/auth/app/signup/signup-form.js
+++ b/front/auth/app/signup/signup-form.js
@@ -198,10 +198,10 @@ export default class SignupForm {
 						challengeStartTime,
 						challengeEndTime;
 
-					challengeStartTime = performance.now();
+					challengeStartTime = window.performance.now();
 					currentChallengeValue = challengeResponse.challenge +
 						ProofOfWork.proof(challengeResponse.challenge, challengeResponse.bits).counter;
-					challengeEndTime = performance.now();
+					challengeEndTime = window.performance.now();
 
 					this.authLogger.info({
 						message: 'Proof of Work challenge solving time',

--- a/server/app/views/_partials/first-render-time.hbs
+++ b/server/app/views/_partials/first-render-time.hbs
@@ -37,9 +37,9 @@
 	var testElement = document.getElementsByClassName('render-time-test')[0],
 			transitionEnd = whichTransitionEnd();
 
-	if (transitionEnd && performance && typeof performance.now === 'function') {
+	if (transitionEnd && window.performance && typeof window.performance.now === 'function') {
 		testElement.addEventListener(transitionEnd, function () {
-			M.prop('firstRenderTime', performance.now());
+			M.prop('firstRenderTime', window.performance.now());
 		});
 
 		// Transition isn't triggered without setTimeout because of browser optimizations


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/XW-2208

## Description

Use `window.performance` instead of `performance`. This should fix `Can't find variable` issue in Safari 9.

## Reviewers

@Wikia/x-wing