### PR TITLE
ADEN | fix mercuryPV key-val not appearing for regular slots

### DIFF
--- a/front/common/modules/ads.js
+++ b/front/common/modules/ads.js
@@ -330,7 +330,7 @@ class Ads {
 				this.adLogicPageViewCounterModule.increment();
 				this.googleTagModule.updateCorrelator();
 				this.mercuryPV = this.mercuryPV + 1;
-				this.adLogicPageParams.add('mercuryPV', this.mercuryPV);
+				this.adLogicPageParams.add('mercuryPV', this.mercuryPV.toString());
 			});
 			if (adsContext) {
 				this.adContextModule.setContext(adsContext);
@@ -370,7 +370,7 @@ class Ads {
 	 */
 	reloadWhenReady() {
 		this.reload(this.currentAdsContext, () => {
-			this.adLogicPageParams.add('mercuryPV', this.mercuryPV);
+			this.adLogicPageParams.add('mercuryPV', this.mercuryPV.toString());
 			this.adMercuryListenerModule.startOnLoadQueue();
 			this.trackKruxPageView();
 			this.adLogicPageViewCounterModule.increment();

--- a/front/common/modules/ads.js
+++ b/front/common/modules/ads.js
@@ -370,9 +370,9 @@ class Ads {
 	 */
 	reloadWhenReady() {
 		this.reload(this.currentAdsContext, () => {
+			this.adLogicPageParams.add('mercuryPV', this.mercuryPV);
 			this.adMercuryListenerModule.startOnLoadQueue();
 			this.trackKruxPageView();
-			this.adLogicPageParams.add('mercuryPV', this.mercuryPV);
 			this.adLogicPageViewCounterModule.increment();
 		});
 	}


### PR DESCRIPTION
## Description

MercuryPV key-val was not sent becasue it was added too late. Moving it three lines above fixes the issue (above `startOnLoadQueue` call)
 
...and it has to be a string not an int.
