### PR TITLE
SOC-3269 | fix: zero state on /d/reported

### DIFF
--- a/front/main/app/templates/components/discussion-reported-posts-wrapper.hbs
+++ b/front/main/app/templates/components/discussion-reported-posts-wrapper.hbs
@@ -43,6 +43,8 @@
 			upvote=(action this.attrs.upvote)
 		}}
 	{{/if}}
+{{else}}
+	{{discussion-reported-not-found-error}}
 {{/each}}
 {{#if showLoadMoreButton}}
 	{{discussion-wrapper-load-more


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/SOC-3269

## Description

Fix for /d/reported zero state.

## Reviewers

@Wikia/social-frontend 