### PR TITLE
SOC-3258 | Use full url instead of / for anchor

### DIFF
--- a/front/main/app/components/discussion-community-unit.js
+++ b/front/main/app/components/discussion-community-unit.js
@@ -50,6 +50,8 @@ export default Ember.Component.extend({
 		}
 	}),
 
+	wikiHomeLink: window.location.origin,
+
 	actions: {
 
 		/**

--- a/front/main/app/templates/components/discussion-community-unit.hbs
+++ b/front/main/app/templates/components/discussion-community-unit.hbs
@@ -22,7 +22,7 @@
 	</a>
 {{/if}}
 {{#if displayWikiaHomeLink}}
-	<a href="/" class="wikia-home-link active-element-theme-color" {{action 'clickWikiaHomeLink' on='mouseDown' preventDefault=false}}>
+	<a href="{{wikiHomeLink}}" class="wikia-home-link active-element-theme-color" {{action 'clickWikiaHomeLink' on='mouseDown' preventDefault=false}}>
 		{{svg 'home-small' role='img' class='icon wikia-home'}}
 		<span>{{wikiHomeLinkText}}</span>
 	</a>


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/SOC-3258

## Description

Seems like the href-to helper messes up links with just "/" in them.

## Reviewers
@Wikia/social-frontend

