### PR TITLE
SOC-3267 | No page param is a proper page param

### DIFF
--- a/front/main/app/mixins/discussion-forum-actions-route.js
+++ b/front/main/app/mixins/discussion-forum-actions-route.js
@@ -26,7 +26,7 @@ export default Ember.Mixin.create(
 		 *
 		 * @param pageParam
 		 */
-		isProperPageParam(pageParam) {
+		isProperPageParam(pageParam = 1) {
 			return Number(pageParam) > 0;
 		},
 


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/SOC-3267

## Description

"Undefined" is actually a proper page param - it is an implicit page number for the first page. Editor was malfunctioning because we do transition from 'trending' to 'latest' before adding a post and in this case, after failing the isProperPageParam check, the transition would abort and instead refresh the whole route.

## Reviewers

@Wikia/social-frontend
