### PR TITLE
SOC-3383 | fix: show Write a reply when removed text while editing reply

### DIFF
--- a/front/main/app/mixins/discussion-editor-configuration.js
+++ b/front/main/app/mixins/discussion-editor-configuration.js
@@ -72,7 +72,7 @@ export default Ember.Mixin.create({
 			closeTrackingAction: trackActions.ReplyEditClose,
 			contentTrackingAction: trackActions.ReplyEditContent,
 			editorLabelKey: 'editor.reply-edit-editor-label',
-			messagePlaceholderKey: 'editor.post-editor-placeholder-text',
+			messagePlaceholderKey: 'editor.reply-editor-placeholder-text',
 			startTrackingAction: trackActions.ReplyEdit,
 			submitMessageKey: 'editor.reply-edit-action-button-label',
 		},


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/SOC-3383

## Description

Show "Write a reply..." while editing reply with no text.

## Reviewers

@Wikia/social-frontend 

