### PR TITLE
SOC-3310 | remove overflow: hidden on mobile-full-screen class

### DIFF
--- a/front/main/app/styles/state/_full-screen.scss
+++ b/front/main/app/styles/state/_full-screen.scss
@@ -1,7 +1,6 @@
 @media #{$mobile-range} {
 	.mobile-full-screen {
 		height: 100%;
-		overflow: hidden;
 		position: fixed;
 
 		.site-head {


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/SOC-3310

## Description

Remove overflow: hidden on mobile-full-screen class. 

## Reviewers

@Wikia/social-frontend 