### PR TITLE
Discussions | Improving error messages in console

### DIFF
--- a/front/main/app/routes/discussion/base.js
+++ b/front/main/app/routes/discussion/base.js
@@ -89,18 +89,21 @@ export default Ember.Route.extend(
 			/**
 			 * Handler for a rejected model (or a throw from within model)
 			 *
-			 * @param {Ember.Object} model
+			 * @param {Ember.Object} routeError
 			 * @param {Ember.Transition} transition
 			 *
 			 * @returns {boolean}
 			 */
-			error(model, transition) {
+			error(routeError, transition) {
 				this.controllerFor('application').set('noMargins', true);
 
-				// Model is the only place we can use to send the transition to the
-				// error subroute, and try to retry it from an error component
-				if (model) {
-					model.set('error.transition', transition);
+				/* If routeError is a model loading error, let it through to the
+					error subroute handlers. If not, rethrow it
+				 */
+				if (Ember.typeOf(routeError) === 'instance' && routeError.error) {
+					routeError.set('error.transition', transition);
+				} else {
+					throw routeError;
 				}
 
 				return true;


### PR DESCRIPTION
## Description

1) When there's a model loading error (4xx, 5xx from the backend etc.) it's ok to proceed with the error subroute
2) If any other kind of error has been thrown, and caught by catch() blocks, we should rethrow immediately in error() callback to improve verbosity of logs.

Now, instead of "model.set is not a function" for all the non-Ember errors we'll actually see the proper error message.

## Reviewers

@Wikia/social-frontend 
