### PR TITLE
Remove back button from image-review main page

### DIFF
--- a/front/main/app/templates/components/image-review.hbs
+++ b/front/main/app/templates/components/image-review.hbs
@@ -1,6 +1,5 @@
 {{#if model.showSubHeader}}
 	<header class="sub-head">
-		<a {{action this.attrs.openMainPage}} class="sub-head--cancel">{{svg 'back-arrow' role='img' class='icon'}}</a>
 		{{#if model.userCanAuditReviews}}
 			<button {{action this.attrs.openSummary}} class="sub-head--done">
 				Show summary


### PR DESCRIPTION
## Links

https://wikia-inc.atlassian.net/browse/SER-555

## Description

Remove back button from Image-review's main page.

## Reviewers

@Wikia/services-team 

