### PR TITLE
(PLATFORM-2766) Bump vignette-js to v2.3.0

### DIFF
--- a/front/main/bower.json
+++ b/front/main/bower.json
@@ -23,7 +23,7 @@
     "sinonjs": "1.17.1",
     "script.js": "2.5.7",
     "tinycolor": "1.3.0",
-    "vignette": "wikia/vignette-js#2.2.1",
+    "vignette": "wikia/vignette-js#2.3.0",
     "visit-source": "Wikia/visit-source#0.1.1",
     "weppy": "Wikia/weppy#0.9.3",
     "wikia-style-guide": "Wikia/style-guide#v1.9.0",


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/PLATFORM-2766
* https://github.com/Wikia/vignette-js/pull/29

## Description

Bump vignette-js to v2.3.0 to support .us and .pl devbox domains.

## Reviewers

@rogatty 
