### PR TITLE
SOC-3778 | change "User activity" to "Discussion Insights"

### DIFF
--- a/front/common/public/locales/en/discussion.json
+++ b/front/common/public/locales/en/discussion.json
@@ -145,7 +145,7 @@
     "no-followed-posts-text": "Hit the “Follow” icon at the bottom of any post to fill your list with discussions that matter most to you. We’ll put them here and notify you of new activity.",
     "find-posts-to-follow": "Find posts to follow",
     "reported-content": "Reported Content",
-    "user-activity": "User Activity",
+    "user-activity": "Discussions Insights",
     "moderator-tools": "Moderator Tools"
   },
   "user-activity":{
@@ -163,7 +163,7 @@
     "posts": "posts",
     "not-processed": "not processed",
     "actions": "actions",
-    "hero-unit-subtitle": "User Activity",
+    "hero-unit-subtitle": "Discussions Insights",
     "no-activity-yet": "No activity yet."
   },
   "editor": {

--- a/front/main/app/router.js
+++ b/front/main/app/router.js
@@ -114,7 +114,7 @@ Router.map(function () {
 			path: 'm'
 		}, function () {
 			this.route('user-activity', {
-				path: '/ua'
+				path: '/insights'
 			}, function () {
 				this.route('posts');
 				this.route('reports');


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/SOC-3778

## Description

 change "User activity" to "Discussion Insights"

## Reviewers

@Wikia/social-frontend 
