### PR TITLE
XW-2625 | CMP sections - use class name instead of inline styles

### DIFF
--- a/front/main/app/components/curated-content-section.js
+++ b/front/main/app/components/curated-content-section.js
@@ -3,5 +3,6 @@ import Ember from 'ember';
 const {Component} = Ember;
 
 export default Component.extend({
+	classNames: ['curated-content-section'],
 	classNameBindings: ['shouldBeVisible::hidden']
 });

--- a/front/main/app/components/curated-content-section.js
+++ b/front/main/app/components/curated-content-section.js
@@ -1,0 +1,7 @@
+import Ember from 'ember';
+
+const {Component} = Ember;
+
+export default Component.extend({
+	classNameBindings: ['shouldBeVisible::hidden']
+});

--- a/front/main/app/templates/components/curated-content.hbs
+++ b/front/main/app/templates/components/curated-content.hbs
@@ -1,13 +1,13 @@
 {{! Keep the same HTML structure as in server/app/views/_partials/curated-main-page/curated-content.hbs }}
 {{curated-content-section
 	model=model
-	isVisible=(equal activeLabel null)
+	shouldBeVisible=(equal activeLabel null)
 	openSection=(action 'openSection')
 }}
 {{#each model.items as |item|}}
 	{{#if (equal item.type 'section')}}
 		{{curated-content-section
-			isVisible=(equal activeLabel item.label)
+			shouldBeVisible=(equal activeLabel item.label)
 			model=item
 			openSection=(action 'openSection')
 			closeSection=(action 'closeSection')

--- a/front/main/tests/acceptance/curated-content-test.js
+++ b/front/main/tests/acceptance/curated-content-test.js
@@ -9,7 +9,8 @@ moduleForAcceptance('Acceptance | Curated Main Page', {
 });
 
 test('Open section on Curated Main Page', (assert) => {
-	const firstVisibleItemSelector = '.curated-content-section:not(.hidden) .curated-content-items .item-caption.clamp:first';
+	const firstVisibleItemSelector =
+		'.curated-content-section:not(.hidden) .curated-content-items .item-caption.clamp:first';
 
 	// https://github.com/ember-cli/ember-cli/issues/3719#issuecomment-111279593
 	visit('/');

--- a/front/main/tests/acceptance/curated-content-test.js
+++ b/front/main/tests/acceptance/curated-content-test.js
@@ -9,7 +9,7 @@ moduleForAcceptance('Acceptance | Curated Main Page', {
 });
 
 test('Open section on Curated Main Page', (assert) => {
-	const firstVisibleItemSelector = '.curated-content-items:visible .item-caption.clamp:first';
+	const firstVisibleItemSelector = '.curated-content-section:not(.hidden) .curated-content-items .item-caption.clamp:first';
 
 	// https://github.com/ember-cli/ember-cli/issues/3719#issuecomment-111279593
 	visit('/');

--- a/server/app/views/_partials/curated-main-page/curated-content-section.hbs
+++ b/server/app/views/_partials/curated-main-page/curated-content-section.hbs
@@ -1,5 +1,5 @@
 {{! Keep the same HTML structure as in front/main/app/templates/components/curated-content-section.hbs }}
-<div{{#unless isVisible}} style="display: none"{{/unless}}>
+<div{{#unless isVisible}} class="hidden"{{/unless}}>
 	{{#if model.items}}
 		{{#if model.label}}
 			<div class="curated-content-section__header">

--- a/server/app/views/_partials/curated-main-page/curated-content-section.hbs
+++ b/server/app/views/_partials/curated-main-page/curated-content-section.hbs
@@ -1,5 +1,5 @@
 {{! Keep the same HTML structure as in front/main/app/templates/components/curated-content-section.hbs }}
-<div{{#unless isVisible}} class="hidden"{{/unless}}>
+<div class="curated-content-section{{#unless isVisible}} hidden{{/unless}}">
 	{{#if model.items}}
 		{{#if model.label}}
 			<div class="curated-content-section__header">


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/XW-2625
* more relevant links

## Description

Having class names is easier for writing selenium tests

## Reviewers

Ping @Wikia/x-wing 
