### PR TITLE
XW | Remove special wikis from weppy sampling

### DIFF
--- a/front/common/utils/track-perf.js
+++ b/front/common/utils/track-perf.js
@@ -30,18 +30,13 @@ function getTracker() {
 		const weppyConfig = M.prop('weppyConfig');
 
 		if (weppyConfig && typeof Weppy === 'function') {
-			// Temporarily sample the wikis used in the performance experiment at 100% (DAT-4275)
-			const samplingRate = weppyConfig.specialWikis.indexOf(Mercury.wiki.id) > -1 ?
-				1 :
-				weppyConfig.samplingRate;
-
 			tracker = Weppy.namespace('mercury');
 
 			tracker.setOptions({
 				aggregationInterval: weppyConfig.aggregationInterval,
 				context,
 				host: weppyConfig.host,
-				sample: samplingRate,
+				sample: weppyConfig.samplingRate,
 				transport: 'url'
 			});
 		} else {

--- a/server/config/settings.base.js
+++ b/server/config/settings.base.js
@@ -322,38 +322,7 @@ export default {
 		enabled: process.env.WIKIA_ENVIRONMENT === 'prod',
 		host: 'http://speed.wikia.net/__rum',
 		samplingRate: 0.1,
-		aggregationInterval: 1000,
-		// Temporarily sample the wikis used in the performance experiment at 100% (DAT-4275)
-		specialWikis: [
-			// marvelcinematicuniverse
-			177996,
-			// walkingdead
-			13346,
-			// dragonage
-			10150,
-			// darksouls
-			208733,
-			// memory-alpha
-			113,
-			// 2007.runescape
-			691244,
-			// bleach
-			3747,
-			// supernatural
-			4428,
-			// warhammer40k
-			501,
-			// arrow
-			250551,
-			// runescape
-			304,
-			// vampirediaries
-			38969,
-			// pt-br.naruto
-			178802,
-			// es.dragonball
-			1744
-		]
+		aggregationInterval: 1000
 	},
 	translationFiles: ['main', 'design-system', 'discussion', 'image-review', 'infobox-builder', 'recent-wiki-activity', 'search']
 };


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/ZZZ-16699
* https://github.com/Wikia/mercury/pull/2598

## Description

These wikis were sampled at 100% because they were using an experimental Mercury instance. We should have cleaned this long time ago but apparently forgot to do that. This is skewing our RUM.

## Reviewers

@hakubo @kvas-damian 