### PR TITLE
(PLATFORM-2856) Bump vignette-js version

### DIFF
--- a/front/main/bower.json
+++ b/front/main/bower.json
@@ -23,7 +23,7 @@
     "sinonjs": "1.17.1",
     "script.js": "2.5.7",
     "tinycolor": "1.3.0",
-    "vignette": "wikia/vignette-js#2.3.0",
+    "vignette": "wikia/vignette-js#2.5.0",
     "visit-source": "Wikia/visit-source#0.1.1",
     "weppy": "Wikia/weppy#0.9.3",
     "wikia-style-guide": "Wikia/style-guide#v1.9.0",

--- a/server/npm-shrinkwrap.json
+++ b/server/npm-shrinkwrap.json
@@ -2806,8 +2806,8 @@
     },
     "vignette": {
       "version": "2.4.0",
-      "from": "git://github.com/Wikia/vignette-js#2.4.0",
-      "resolved": "git://github.com/Wikia/vignette-js#efdc8d7b1ff27649c846ea18ae1c91f9c6ac06fb"
+      "from": "git://github.com/Wikia/vignette-js#2.5.0",
+      "resolved": "git://github.com/Wikia/vignette-js#1b14c518837fafd3794bc969e77fea76e58a685a"
     },
     "vision": {
       "version": "3.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -30,7 +30,7 @@
     "node-uuid": "1.4.7",
     "node-esapi": "0.0.1",
     "numeral": "2.0.4",
-    "vignette": "Wikia/vignette-js#2.4.0",
+    "vignette": "Wikia/vignette-js#2.5.0",
     "vision": "3.0.0",
     "wreck": "6.3.0"
   }


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/PLATFORM-2856

## Description

Bump vignette-js version to remove client-side detection of WebP support.

## Reviewers

/cc @Wikia/core-platform-team 
