### PR TITLE
Fix Jenkins workspace path

### DIFF
--- a/tasks/jenkins/mercury-pr-checks.sh
+++ b/tasks/jenkins/mercury-pr-checks.sh
@@ -6,7 +6,7 @@ set -o pipefail
 mkdir jenkins || rm -rf jenkins/* && true
 echo "githubToken=Authorization: token $GITHUB_TOKEN" > jenkins/params
 echo "githubUrl=https://api.github.com/repos/Wikia/mercury/statuses/$GIT_COMMIT" >> jenkins/params
-dependenciesDir="/var/lib/jenkins/workspace/Mercury-UPDATE-dependencies"
+dependenciesDir="/var/lib/jenkins/workspace/mercury-update-dependencies"
 
 # $1 - context
 # $2 - state


### PR DESCRIPTION
That's how it's called now:
http://jenkins.wikia-prod:8080/view/Mercury-test/view/Mercury%20Background%20Tasks/job/mercury-update-dependencies/

@latata @kvas-damian 