### PR TITLE
XW-2995 | i18next update from 1.7.4 to 1.11.5

### DIFF
--- a/front/auth/bower.json
+++ b/front/auth/bower.json
@@ -4,7 +4,7 @@
   "license": "MIT",
   "private": true,
   "dependencies": {
-    "i18next": "1.7.4",
+    "i18next": "1.11.5",
     "jquery": "2.1.4",
     "loader.js": "3.5.0",
     "crypto-js": "3.1.6",

--- a/front/main/bower.json
+++ b/front/main/bower.json
@@ -14,7 +14,7 @@
     "foundation": "5.5.1",
     "hammerjs": "2.0.4",
     "headroom.js": "0.7.0",
-    "i18next": "1.7.4",
+    "i18next": "1.11.2",
     "jquery": "2.1.4",
     "jquery.cookie": "1.4.1",
     "numeral": "1.5.3",

--- a/front/main/bower.json
+++ b/front/main/bower.json
@@ -14,7 +14,7 @@
     "foundation": "5.5.1",
     "hammerjs": "2.0.4",
     "headroom.js": "0.7.0",
-    "i18next": "1.11.2",
+    "i18next": "1.11.5",
     "jquery": "2.1.4",
     "jquery.cookie": "1.4.1",
     "numeral": "1.5.3",

--- a/front/main/npm-shrinkwrap.json
+++ b/front/main/npm-shrinkwrap.json
@@ -19,7 +19,7 @@
       "dev": true
     },
     "ajv": {
-      "version": "4.11.4",
+      "version": "4.11.5",
       "dev": true,
       "dependencies": {
         "json-stable-stringify": {
@@ -133,7 +133,7 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.9.5",
+      "version": "0.9.6",
       "dev": true
     },
     "async": {
@@ -141,7 +141,7 @@
       "dev": true
     },
     "async-disk-cache": {
-      "version": "1.0.9",
+      "version": "1.2.2",
       "dev": true,
       "dependencies": {
         "mkdirp": {
@@ -149,7 +149,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.4.0",
+          "version": "3.5.0",
           "dev": true
         }
       }
@@ -167,7 +167,7 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "6.7.6",
+      "version": "6.7.7",
       "dev": true
     },
     "aws-sign2": {
@@ -410,7 +410,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.4.0",
+          "version": "3.5.0",
           "dev": true
         }
       }
@@ -432,7 +432,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.4.0",
+          "version": "3.5.0",
           "dev": true
         },
         "walk-sync": {
@@ -494,7 +494,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.4.0",
+          "version": "3.5.0",
           "dev": true
         }
       }
@@ -508,7 +508,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.4.0",
+          "version": "3.5.0",
           "dev": true
         }
       }
@@ -522,7 +522,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.4.0",
+          "version": "3.5.0",
           "dev": true
         }
       }
@@ -608,7 +608,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.4.0",
+          "version": "3.5.0",
           "dev": true
         },
         "walk-sync": {
@@ -634,7 +634,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.4.0",
+          "version": "3.5.0",
           "dev": true
         }
       }
@@ -644,7 +644,7 @@
       "dev": true,
       "dependencies": {
         "rsvp": {
-          "version": "3.4.0",
+          "version": "3.5.0",
           "dev": true
         }
       }
@@ -658,7 +658,7 @@
           "dev": true,
           "dependencies": {
             "rsvp": {
-              "version": "3.4.0",
+              "version": "3.5.0",
               "dev": true
             }
           }
@@ -700,7 +700,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.4.0",
+          "version": "3.5.0",
           "dev": true
         }
       }
@@ -714,7 +714,7 @@
       "dev": true,
       "dependencies": {
         "rsvp": {
-          "version": "3.4.0",
+          "version": "3.5.0",
           "dev": true
         },
         "walk-sync": {
@@ -802,7 +802,7 @@
       "dev": true
     },
     "caniuse-db": {
-      "version": "1.0.30000634",
+      "version": "1.0.30000636",
       "dev": true
     },
     "capture-stack-trace": {
@@ -946,7 +946,7 @@
           "dev": true
         },
         "recast": {
-          "version": "0.11.22",
+          "version": "0.11.23",
           "dev": true
         }
       }
@@ -1001,7 +1001,13 @@
     },
     "connect": {
       "version": "3.6.0",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "debug": {
+          "version": "2.6.1",
+          "dev": true
+        }
+      }
     },
     "console-browserify": {
       "version": "1.1.0",
@@ -1152,7 +1158,7 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.1",
+      "version": "2.6.3",
       "dev": true
     },
     "decamelize": {
@@ -1271,7 +1277,7 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.2.6",
+      "version": "1.2.7",
       "dev": true
     },
     "ember-ajax": {
@@ -1331,7 +1337,7 @@
           }
         },
         "rsvp": {
-          "version": "3.4.0",
+          "version": "3.5.0",
           "dev": true
         },
         "underscore.string": {
@@ -1429,7 +1435,7 @@
       "dev": true,
       "dependencies": {
         "rsvp": {
-          "version": "3.4.0",
+          "version": "3.5.0",
           "dev": true
         }
       }
@@ -1599,7 +1605,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.4.0",
+          "version": "3.5.0",
           "dev": true
         },
         "source-map": {
@@ -1715,7 +1721,7 @@
           }
         },
         "clone": {
-          "version": "2.1.0",
+          "version": "2.1.1",
           "dev": true
         },
         "ember-cli-babel": {
@@ -1763,7 +1769,7 @@
           }
         },
         "clone": {
-          "version": "2.1.0",
+          "version": "2.1.1",
           "dev": true
         },
         "ember-cli-babel": {
@@ -1847,7 +1853,7 @@
           "dev": true
         },
         "recast": {
-          "version": "0.11.22",
+          "version": "0.11.23",
           "dev": true
         }
       }
@@ -1937,28 +1943,52 @@
       "dev": true
     },
     "es5-ext": {
-      "version": "0.10.12",
+      "version": "0.10.14",
       "dev": true
     },
     "es6-iterator": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.1",
+      "dev": true,
+      "dependencies": {
+        "d": {
+          "version": "1.0.0",
+          "dev": true
+        }
+      }
     },
     "es6-map": {
       "version": "0.1.4",
       "dev": true
     },
     "es6-set": {
-      "version": "0.1.4",
-      "dev": true
+      "version": "0.1.5",
+      "dev": true,
+      "dependencies": {
+        "d": {
+          "version": "1.0.0",
+          "dev": true
+        }
+      }
     },
     "es6-symbol": {
-      "version": "3.1.0",
-      "dev": true
+      "version": "3.1.1",
+      "dev": true,
+      "dependencies": {
+        "d": {
+          "version": "1.0.0",
+          "dev": true
+        }
+      }
     },
     "es6-weak-map": {
-      "version": "2.0.1",
-      "dev": true
+      "version": "2.0.2",
+      "dev": true,
+      "dependencies": {
+        "d": {
+          "version": "1.0.0",
+          "dev": true
+        }
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -1999,8 +2029,14 @@
       "dev": true
     },
     "event-emitter": {
-      "version": "0.3.4",
-      "dev": true
+      "version": "0.3.5",
+      "dev": true,
+      "dependencies": {
+        "d": {
+          "version": "1.0.0",
+          "dev": true
+        }
+      }
     },
     "eventemitter3": {
       "version": "1.2.0",
@@ -2040,7 +2076,13 @@
     },
     "express": {
       "version": "4.15.2",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "debug": {
+          "version": "2.6.1",
+          "dev": true
+        }
+      }
     },
     "extend": {
       "version": "3.0.0",
@@ -2083,7 +2125,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.4.0",
+          "version": "3.5.0",
           "dev": true
         },
         "source-map": {
@@ -2130,7 +2172,13 @@
     },
     "finalhandler": {
       "version": "1.0.0",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "debug": {
+          "version": "2.6.1",
+          "dev": true
+        }
+      }
     },
     "find-up": {
       "version": "1.1.2",
@@ -2523,7 +2571,7 @@
       "dev": true
     },
     "is-buffer": {
-      "version": "1.1.4",
+      "version": "1.1.5",
       "dev": true
     },
     "is-builtin-module": {
@@ -2709,8 +2757,14 @@
       "dev": true
     },
     "jsprim": {
-      "version": "1.3.1",
-      "dev": true
+      "version": "1.4.0",
+      "dev": true,
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0",
+          "dev": true
+        }
+      }
     },
     "kind-of": {
       "version": "3.1.0",
@@ -2745,7 +2799,7 @@
       "dev": true,
       "dependencies": {
         "rsvp": {
-          "version": "3.4.0",
+          "version": "3.5.0",
           "dev": true
         }
       }
@@ -2999,7 +3053,7 @@
       "dev": true
     },
     "memory-streams": {
-      "version": "0.1.1",
+      "version": "0.1.2",
       "dev": true,
       "dependencies": {
         "isarray": {
@@ -3086,7 +3140,13 @@
     },
     "morgan": {
       "version": "1.8.1",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "debug": {
+          "version": "2.6.1",
+          "dev": true
+        }
+      }
     },
     "mout": {
       "version": "1.0.0",
@@ -3117,7 +3177,7 @@
       "dev": true
     },
     "node-gyp": {
-      "version": "3.5.0",
+      "version": "3.6.0",
       "dev": true,
       "dependencies": {
         "glob": {
@@ -3139,7 +3199,7 @@
       "dev": true
     },
     "node-notifier": {
-      "version": "5.0.2",
+      "version": "5.1.2",
       "dev": true
     },
     "node-sass": {
@@ -4397,7 +4457,7 @@
       "dev": true,
       "dependencies": {
         "rsvp": {
-          "version": "3.4.0",
+          "version": "3.5.0",
           "dev": true
         }
       }
@@ -4475,7 +4535,7 @@
       "dev": true
     },
     "readable-stream": {
-      "version": "2.2.3",
+      "version": "2.2.6",
       "dev": true
     },
     "readline2": {
@@ -4571,13 +4631,9 @@
       "dev": true
     },
     "request": {
-      "version": "2.80.0",
+      "version": "2.81.0",
       "dev": true,
       "dependencies": {
-        "qs": {
-          "version": "6.3.2",
-          "dev": true
-        },
         "uuid": {
           "version": "3.0.1",
           "dev": true
@@ -4688,7 +4744,13 @@
     },
     "send": {
       "version": "0.15.1",
-      "dev": true
+      "dev": true,
+      "dependencies": {
+        "debug": {
+          "version": "2.6.1",
+          "dev": true
+        }
+      }
     },
     "serve-static": {
       "version": "1.12.1",
@@ -4859,7 +4921,7 @@
       }
     },
     "stable": {
-      "version": "0.1.5",
+      "version": "0.1.6",
       "dev": true
     },
     "statuses": {
@@ -5083,11 +5145,11 @@
       }
     },
     "tsutils": {
-      "version": "1.2.2",
+      "version": "1.3.0",
       "dev": true
     },
     "tunnel-agent": {
-      "version": "0.4.3",
+      "version": "0.6.0",
       "dev": true
     },
     "tweetnacl": {
@@ -5112,7 +5174,7 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "2.8.10",
+      "version": "2.8.13",
       "dev": true,
       "dependencies": {
         "window-size": {
@@ -5308,7 +5370,7 @@
       "dev": true
     },
     "yallist": {
-      "version": "2.0.0",
+      "version": "2.1.2",
       "dev": true
     },
     "yam": {

--- a/front/main/npm-shrinkwrap.json
+++ b/front/main/npm-shrinkwrap.json
@@ -19,7 +19,7 @@
       "dev": true
     },
     "ajv": {
-      "version": "4.11.5",
+      "version": "4.11.4",
       "dev": true,
       "dependencies": {
         "json-stable-stringify": {
@@ -133,7 +133,7 @@
       "dev": true
     },
     "ast-types": {
-      "version": "0.9.6",
+      "version": "0.9.5",
       "dev": true
     },
     "async": {
@@ -141,7 +141,7 @@
       "dev": true
     },
     "async-disk-cache": {
-      "version": "1.2.2",
+      "version": "1.0.9",
       "dev": true,
       "dependencies": {
         "mkdirp": {
@@ -149,7 +149,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.5.0",
+          "version": "3.4.0",
           "dev": true
         }
       }
@@ -167,7 +167,7 @@
       "dev": true
     },
     "autoprefixer": {
-      "version": "6.7.7",
+      "version": "6.7.6",
       "dev": true
     },
     "aws-sign2": {
@@ -410,7 +410,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.5.0",
+          "version": "3.4.0",
           "dev": true
         }
       }
@@ -432,7 +432,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.5.0",
+          "version": "3.4.0",
           "dev": true
         },
         "walk-sync": {
@@ -494,7 +494,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.5.0",
+          "version": "3.4.0",
           "dev": true
         }
       }
@@ -508,7 +508,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.5.0",
+          "version": "3.4.0",
           "dev": true
         }
       }
@@ -522,7 +522,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.5.0",
+          "version": "3.4.0",
           "dev": true
         }
       }
@@ -608,7 +608,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.5.0",
+          "version": "3.4.0",
           "dev": true
         },
         "walk-sync": {
@@ -634,7 +634,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.5.0",
+          "version": "3.4.0",
           "dev": true
         }
       }
@@ -644,7 +644,7 @@
       "dev": true,
       "dependencies": {
         "rsvp": {
-          "version": "3.5.0",
+          "version": "3.4.0",
           "dev": true
         }
       }
@@ -658,7 +658,7 @@
           "dev": true,
           "dependencies": {
             "rsvp": {
-              "version": "3.5.0",
+              "version": "3.4.0",
               "dev": true
             }
           }
@@ -700,7 +700,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.5.0",
+          "version": "3.4.0",
           "dev": true
         }
       }
@@ -714,7 +714,7 @@
       "dev": true,
       "dependencies": {
         "rsvp": {
-          "version": "3.5.0",
+          "version": "3.4.0",
           "dev": true
         },
         "walk-sync": {
@@ -802,7 +802,7 @@
       "dev": true
     },
     "caniuse-db": {
-      "version": "1.0.30000636",
+      "version": "1.0.30000634",
       "dev": true
     },
     "capture-stack-trace": {
@@ -946,7 +946,7 @@
           "dev": true
         },
         "recast": {
-          "version": "0.11.23",
+          "version": "0.11.22",
           "dev": true
         }
       }
@@ -1001,13 +1001,7 @@
     },
     "connect": {
       "version": "3.6.0",
-      "dev": true,
-      "dependencies": {
-        "debug": {
-          "version": "2.6.1",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "console-browserify": {
       "version": "1.1.0",
@@ -1158,7 +1152,7 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.3",
+      "version": "2.6.1",
       "dev": true
     },
     "decamelize": {
@@ -1277,7 +1271,7 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.2.7",
+      "version": "1.2.6",
       "dev": true
     },
     "ember-ajax": {
@@ -1337,7 +1331,7 @@
           }
         },
         "rsvp": {
-          "version": "3.5.0",
+          "version": "3.4.0",
           "dev": true
         },
         "underscore.string": {
@@ -1435,7 +1429,7 @@
       "dev": true,
       "dependencies": {
         "rsvp": {
-          "version": "3.5.0",
+          "version": "3.4.0",
           "dev": true
         }
       }
@@ -1605,7 +1599,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.5.0",
+          "version": "3.4.0",
           "dev": true
         },
         "source-map": {
@@ -1721,7 +1715,7 @@
           }
         },
         "clone": {
-          "version": "2.1.1",
+          "version": "2.1.0",
           "dev": true
         },
         "ember-cli-babel": {
@@ -1769,7 +1763,7 @@
           }
         },
         "clone": {
-          "version": "2.1.1",
+          "version": "2.1.0",
           "dev": true
         },
         "ember-cli-babel": {
@@ -1853,7 +1847,7 @@
           "dev": true
         },
         "recast": {
-          "version": "0.11.23",
+          "version": "0.11.22",
           "dev": true
         }
       }
@@ -1943,52 +1937,28 @@
       "dev": true
     },
     "es5-ext": {
-      "version": "0.10.14",
+      "version": "0.10.12",
       "dev": true
     },
     "es6-iterator": {
-      "version": "2.0.1",
-      "dev": true,
-      "dependencies": {
-        "d": {
-          "version": "1.0.0",
-          "dev": true
-        }
-      }
+      "version": "2.0.0",
+      "dev": true
     },
     "es6-map": {
       "version": "0.1.4",
       "dev": true
     },
     "es6-set": {
-      "version": "0.1.5",
-      "dev": true,
-      "dependencies": {
-        "d": {
-          "version": "1.0.0",
-          "dev": true
-        }
-      }
+      "version": "0.1.4",
+      "dev": true
     },
     "es6-symbol": {
-      "version": "3.1.1",
-      "dev": true,
-      "dependencies": {
-        "d": {
-          "version": "1.0.0",
-          "dev": true
-        }
-      }
+      "version": "3.1.0",
+      "dev": true
     },
     "es6-weak-map": {
-      "version": "2.0.2",
-      "dev": true,
-      "dependencies": {
-        "d": {
-          "version": "1.0.0",
-          "dev": true
-        }
-      }
+      "version": "2.0.1",
+      "dev": true
     },
     "escape-html": {
       "version": "1.0.3",
@@ -2029,14 +1999,8 @@
       "dev": true
     },
     "event-emitter": {
-      "version": "0.3.5",
-      "dev": true,
-      "dependencies": {
-        "d": {
-          "version": "1.0.0",
-          "dev": true
-        }
-      }
+      "version": "0.3.4",
+      "dev": true
     },
     "eventemitter3": {
       "version": "1.2.0",
@@ -2076,13 +2040,7 @@
     },
     "express": {
       "version": "4.15.2",
-      "dev": true,
-      "dependencies": {
-        "debug": {
-          "version": "2.6.1",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "extend": {
       "version": "3.0.0",
@@ -2125,7 +2083,7 @@
           "dev": true
         },
         "rsvp": {
-          "version": "3.5.0",
+          "version": "3.4.0",
           "dev": true
         },
         "source-map": {
@@ -2172,13 +2130,7 @@
     },
     "finalhandler": {
       "version": "1.0.0",
-      "dev": true,
-      "dependencies": {
-        "debug": {
-          "version": "2.6.1",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "find-up": {
       "version": "1.1.2",
@@ -2571,7 +2523,7 @@
       "dev": true
     },
     "is-buffer": {
-      "version": "1.1.5",
+      "version": "1.1.4",
       "dev": true
     },
     "is-builtin-module": {
@@ -2757,14 +2709,8 @@
       "dev": true
     },
     "jsprim": {
-      "version": "1.4.0",
-      "dev": true,
-      "dependencies": {
-        "assert-plus": {
-          "version": "1.0.0",
-          "dev": true
-        }
-      }
+      "version": "1.3.1",
+      "dev": true
     },
     "kind-of": {
       "version": "3.1.0",
@@ -2799,7 +2745,7 @@
       "dev": true,
       "dependencies": {
         "rsvp": {
-          "version": "3.5.0",
+          "version": "3.4.0",
           "dev": true
         }
       }
@@ -3053,7 +2999,7 @@
       "dev": true
     },
     "memory-streams": {
-      "version": "0.1.2",
+      "version": "0.1.1",
       "dev": true,
       "dependencies": {
         "isarray": {
@@ -3140,13 +3086,7 @@
     },
     "morgan": {
       "version": "1.8.1",
-      "dev": true,
-      "dependencies": {
-        "debug": {
-          "version": "2.6.1",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "mout": {
       "version": "1.0.0",
@@ -3177,7 +3117,7 @@
       "dev": true
     },
     "node-gyp": {
-      "version": "3.6.0",
+      "version": "3.5.0",
       "dev": true,
       "dependencies": {
         "glob": {
@@ -3199,7 +3139,7 @@
       "dev": true
     },
     "node-notifier": {
-      "version": "5.1.2",
+      "version": "5.0.2",
       "dev": true
     },
     "node-sass": {
@@ -4457,7 +4397,7 @@
       "dev": true,
       "dependencies": {
         "rsvp": {
-          "version": "3.5.0",
+          "version": "3.4.0",
           "dev": true
         }
       }
@@ -4535,7 +4475,7 @@
       "dev": true
     },
     "readable-stream": {
-      "version": "2.2.6",
+      "version": "2.2.3",
       "dev": true
     },
     "readline2": {
@@ -4631,9 +4571,13 @@
       "dev": true
     },
     "request": {
-      "version": "2.81.0",
+      "version": "2.80.0",
       "dev": true,
       "dependencies": {
+        "qs": {
+          "version": "6.3.2",
+          "dev": true
+        },
         "uuid": {
           "version": "3.0.1",
           "dev": true
@@ -4744,13 +4688,7 @@
     },
     "send": {
       "version": "0.15.1",
-      "dev": true,
-      "dependencies": {
-        "debug": {
-          "version": "2.6.1",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "serve-static": {
       "version": "1.12.1",
@@ -4921,7 +4859,7 @@
       }
     },
     "stable": {
-      "version": "0.1.6",
+      "version": "0.1.5",
       "dev": true
     },
     "statuses": {
@@ -5145,11 +5083,11 @@
       }
     },
     "tsutils": {
-      "version": "1.3.0",
+      "version": "1.2.2",
       "dev": true
     },
     "tunnel-agent": {
-      "version": "0.6.0",
+      "version": "0.4.3",
       "dev": true
     },
     "tweetnacl": {
@@ -5174,7 +5112,7 @@
       "dev": true
     },
     "uglify-js": {
-      "version": "2.8.13",
+      "version": "2.8.10",
       "dev": true,
       "dependencies": {
         "window-size": {
@@ -5370,7 +5308,7 @@
       "dev": true
     },
     "yallist": {
-      "version": "2.1.2",
+      "version": "2.0.0",
       "dev": true
     },
     "yam": {

--- a/front/main/tests/acceptance/curated-content-editor-test.js
+++ b/front/main/tests/acceptance/curated-content-editor-test.js
@@ -54,9 +54,9 @@ test('navigating to section on /main/edit', (assert) => {
 			'Section 1',
 			'Check section description'
 		);
-		assert.equal(
-			find('.curated-content-section-details--count').text(),
-			'app.curated-content-editor-items-count',
+		// we just check the length, not text value because of bug in i18next - it returns not-found string when there are no translations loaded
+		assert.ok(
+			find('.curated-content-section-details--count').text().length > 0,
 			'Check section items count'
 		);
 		assert.equal(

--- a/front/main/tests/acceptance/curated-content-editor-test.js
+++ b/front/main/tests/acceptance/curated-content-editor-test.js
@@ -54,7 +54,8 @@ test('navigating to section on /main/edit', (assert) => {
 			'Section 1',
 			'Check section description'
 		);
-		// we just check the length, not text value because of bug in i18next - it returns not-found string when there are no translations loaded
+		// we just check the length, not text value because of bug in i18next
+		// it returns not-found string when there are no translations loaded
 		assert.ok(
 			find('.curated-content-section-details--count').text().length > 0,
 			'Check section items count'

--- a/front/main/tests/index.html
+++ b/front/main/tests/index.html
@@ -57,6 +57,8 @@
 		M.tracker.Internal.trackPageView = function () {};
 
 		M.prop('environment', 'test', true);
+		// i18n tries to download translations asynchronously when translations are empty, so we add empty object for "en" key
+		M.prop('translations', {"en": {}});
 	</script>
 
 </head>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -921,7 +921,7 @@
       "dev": true
     },
     "caniuse-db": {
-      "version": "1.0.30000634",
+      "version": "1.0.30000636",
       "dev": true
     },
     "caseless": {
@@ -945,7 +945,7 @@
       "dev": true
     },
     "clap": {
-      "version": "1.1.2",
+      "version": "1.1.3",
       "dev": true
     },
     "cli-color": {
@@ -1362,12 +1362,18 @@
       "dev": true
     },
     "es5-ext": {
-      "version": "0.10.13",
+      "version": "0.10.14",
       "dev": true
     },
     "es6-iterator": {
-      "version": "2.0.0",
-      "dev": true
+      "version": "2.0.1",
+      "dev": true,
+      "dependencies": {
+        "d": {
+          "version": "1.0.0",
+          "dev": true
+        }
+      }
     },
     "es6-map": {
       "version": "0.1.4",
@@ -1378,16 +1384,34 @@
       "dev": true
     },
     "es6-set": {
-      "version": "0.1.4",
-      "dev": true
+      "version": "0.1.5",
+      "dev": true,
+      "dependencies": {
+        "d": {
+          "version": "1.0.0",
+          "dev": true
+        }
+      }
     },
     "es6-symbol": {
-      "version": "3.1.0",
-      "dev": true
+      "version": "3.1.1",
+      "dev": true,
+      "dependencies": {
+        "d": {
+          "version": "1.0.0",
+          "dev": true
+        }
+      }
     },
     "es6-weak-map": {
-      "version": "2.0.1",
-      "dev": true
+      "version": "2.0.2",
+      "dev": true,
+      "dependencies": {
+        "d": {
+          "version": "1.0.0",
+          "dev": true
+        }
+      }
     },
     "escape-html": {
       "version": "1.0.3",
@@ -1503,8 +1527,14 @@
       "dev": true
     },
     "event-emitter": {
-      "version": "0.3.4",
-      "dev": true
+      "version": "0.3.5",
+      "dev": true,
+      "dependencies": {
+        "d": {
+          "version": "1.0.0",
+          "dev": true
+        }
+      }
     },
     "event-stream": {
       "version": "3.3.4",
@@ -1761,6 +1791,580 @@
     "fs.realpath": {
       "version": "1.0.0",
       "dev": true
+    },
+    "fsevents": {
+      "version": "1.1.1",
+      "dev": true,
+      "optional": true,
+      "dependencies": {
+        "abbrev": {
+          "version": "1.1.0",
+          "dev": true,
+          "optional": true
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "2.2.1",
+          "dev": true,
+          "optional": true
+        },
+        "aproba": {
+          "version": "1.1.1",
+          "dev": true,
+          "optional": true
+        },
+        "are-we-there-yet": {
+          "version": "1.1.2",
+          "dev": true,
+          "optional": true
+        },
+        "asn1": {
+          "version": "0.2.3",
+          "dev": true,
+          "optional": true
+        },
+        "assert-plus": {
+          "version": "0.2.0",
+          "dev": true,
+          "optional": true
+        },
+        "asynckit": {
+          "version": "0.4.0",
+          "dev": true,
+          "optional": true
+        },
+        "aws-sign2": {
+          "version": "0.6.0",
+          "dev": true,
+          "optional": true
+        },
+        "aws4": {
+          "version": "1.6.0",
+          "dev": true,
+          "optional": true
+        },
+        "balanced-match": {
+          "version": "0.4.2",
+          "dev": true
+        },
+        "bcrypt-pbkdf": {
+          "version": "1.0.1",
+          "dev": true,
+          "optional": true
+        },
+        "block-stream": {
+          "version": "0.0.9",
+          "dev": true
+        },
+        "boom": {
+          "version": "2.10.1",
+          "dev": true
+        },
+        "brace-expansion": {
+          "version": "1.1.6",
+          "dev": true
+        },
+        "buffer-shims": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "caseless": {
+          "version": "0.11.0",
+          "dev": true,
+          "optional": true
+        },
+        "chalk": {
+          "version": "1.1.3",
+          "dev": true,
+          "optional": true
+        },
+        "code-point-at": {
+          "version": "1.1.0",
+          "dev": true
+        },
+        "combined-stream": {
+          "version": "1.0.5",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.9.0",
+          "dev": true,
+          "optional": true
+        },
+        "concat-map": {
+          "version": "0.0.1",
+          "dev": true
+        },
+        "console-control-strings": {
+          "version": "1.1.0",
+          "dev": true
+        },
+        "core-util-is": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "cryptiles": {
+          "version": "2.0.5",
+          "dev": true,
+          "optional": true
+        },
+        "dashdash": {
+          "version": "1.14.1",
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "debug": {
+          "version": "2.2.0",
+          "dev": true,
+          "optional": true
+        },
+        "deep-extend": {
+          "version": "0.4.1",
+          "dev": true,
+          "optional": true
+        },
+        "delayed-stream": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "delegates": {
+          "version": "1.0.0",
+          "dev": true,
+          "optional": true
+        },
+        "ecc-jsbn": {
+          "version": "0.1.1",
+          "dev": true,
+          "optional": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "dev": true,
+          "optional": true
+        },
+        "extend": {
+          "version": "3.0.0",
+          "dev": true,
+          "optional": true
+        },
+        "extsprintf": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "forever-agent": {
+          "version": "0.6.1",
+          "dev": true,
+          "optional": true
+        },
+        "form-data": {
+          "version": "2.1.2",
+          "dev": true,
+          "optional": true
+        },
+        "fs.realpath": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "fstream": {
+          "version": "1.0.10",
+          "dev": true
+        },
+        "fstream-ignore": {
+          "version": "1.0.5",
+          "dev": true,
+          "optional": true
+        },
+        "gauge": {
+          "version": "2.7.3",
+          "dev": true,
+          "optional": true
+        },
+        "generate-function": {
+          "version": "2.0.0",
+          "dev": true,
+          "optional": true
+        },
+        "generate-object-property": {
+          "version": "1.2.0",
+          "dev": true,
+          "optional": true
+        },
+        "getpass": {
+          "version": "0.1.6",
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "glob": {
+          "version": "7.1.1",
+          "dev": true
+        },
+        "graceful-fs": {
+          "version": "4.1.11",
+          "dev": true
+        },
+        "graceful-readlink": {
+          "version": "1.0.1",
+          "dev": true,
+          "optional": true
+        },
+        "har-validator": {
+          "version": "2.0.6",
+          "dev": true,
+          "optional": true
+        },
+        "has-ansi": {
+          "version": "2.0.0",
+          "dev": true,
+          "optional": true
+        },
+        "has-unicode": {
+          "version": "2.0.1",
+          "dev": true,
+          "optional": true
+        },
+        "hawk": {
+          "version": "3.1.3",
+          "dev": true,
+          "optional": true
+        },
+        "hoek": {
+          "version": "2.16.3",
+          "dev": true
+        },
+        "http-signature": {
+          "version": "1.1.1",
+          "dev": true,
+          "optional": true
+        },
+        "inflight": {
+          "version": "1.0.6",
+          "dev": true
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "dev": true
+        },
+        "ini": {
+          "version": "1.3.4",
+          "dev": true,
+          "optional": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "is-my-json-valid": {
+          "version": "2.15.0",
+          "dev": true,
+          "optional": true
+        },
+        "is-property": {
+          "version": "1.0.2",
+          "dev": true,
+          "optional": true
+        },
+        "is-typedarray": {
+          "version": "1.0.0",
+          "dev": true,
+          "optional": true
+        },
+        "isarray": {
+          "version": "1.0.0",
+          "dev": true
+        },
+        "isstream": {
+          "version": "0.1.2",
+          "dev": true,
+          "optional": true
+        },
+        "jodid25519": {
+          "version": "1.0.2",
+          "dev": true,
+          "optional": true
+        },
+        "jsbn": {
+          "version": "0.1.1",
+          "dev": true,
+          "optional": true
+        },
+        "json-schema": {
+          "version": "0.2.3",
+          "dev": true,
+          "optional": true
+        },
+        "json-stringify-safe": {
+          "version": "5.0.1",
+          "dev": true,
+          "optional": true
+        },
+        "jsonpointer": {
+          "version": "4.0.1",
+          "dev": true,
+          "optional": true
+        },
+        "jsprim": {
+          "version": "1.3.1",
+          "dev": true,
+          "optional": true
+        },
+        "mime-db": {
+          "version": "1.26.0",
+          "dev": true
+        },
+        "mime-types": {
+          "version": "2.1.14",
+          "dev": true
+        },
+        "minimatch": {
+          "version": "3.0.3",
+          "dev": true
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "dev": true
+        },
+        "ms": {
+          "version": "0.7.1",
+          "dev": true,
+          "optional": true
+        },
+        "node-pre-gyp": {
+          "version": "0.6.33",
+          "dev": true,
+          "optional": true
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "dev": true,
+          "optional": true
+        },
+        "npmlog": {
+          "version": "4.0.2",
+          "dev": true,
+          "optional": true
+        },
+        "number-is-nan": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "oauth-sign": {
+          "version": "0.8.2",
+          "dev": true,
+          "optional": true
+        },
+        "object-assign": {
+          "version": "4.1.1",
+          "dev": true,
+          "optional": true
+        },
+        "once": {
+          "version": "1.4.0",
+          "dev": true
+        },
+        "path-is-absolute": {
+          "version": "1.0.1",
+          "dev": true
+        },
+        "pinkie": {
+          "version": "2.0.4",
+          "dev": true,
+          "optional": true
+        },
+        "pinkie-promise": {
+          "version": "2.0.1",
+          "dev": true,
+          "optional": true
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "dev": true
+        },
+        "punycode": {
+          "version": "1.4.1",
+          "dev": true,
+          "optional": true
+        },
+        "qs": {
+          "version": "6.3.1",
+          "dev": true,
+          "optional": true
+        },
+        "rc": {
+          "version": "1.1.7",
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "minimist": {
+              "version": "1.2.0",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "readable-stream": {
+          "version": "2.2.2",
+          "dev": true,
+          "optional": true
+        },
+        "request": {
+          "version": "2.79.0",
+          "dev": true,
+          "optional": true
+        },
+        "rimraf": {
+          "version": "2.5.4",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
+          "dev": true,
+          "optional": true
+        },
+        "set-blocking": {
+          "version": "2.0.0",
+          "dev": true,
+          "optional": true
+        },
+        "signal-exit": {
+          "version": "3.0.2",
+          "dev": true,
+          "optional": true
+        },
+        "sntp": {
+          "version": "1.0.9",
+          "dev": true,
+          "optional": true
+        },
+        "sshpk": {
+          "version": "1.10.2",
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "assert-plus": {
+              "version": "1.0.0",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "stringstream": {
+          "version": "0.0.5",
+          "dev": true,
+          "optional": true
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "dev": true
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "dev": true,
+          "optional": true
+        },
+        "supports-color": {
+          "version": "2.0.0",
+          "dev": true,
+          "optional": true
+        },
+        "tar": {
+          "version": "2.2.1",
+          "dev": true
+        },
+        "tar-pack": {
+          "version": "3.3.0",
+          "dev": true,
+          "optional": true,
+          "dependencies": {
+            "once": {
+              "version": "1.3.3",
+              "dev": true,
+              "optional": true
+            },
+            "readable-stream": {
+              "version": "2.1.5",
+              "dev": true,
+              "optional": true
+            }
+          }
+        },
+        "tough-cookie": {
+          "version": "2.3.2",
+          "dev": true,
+          "optional": true
+        },
+        "tunnel-agent": {
+          "version": "0.4.3",
+          "dev": true,
+          "optional": true
+        },
+        "tweetnacl": {
+          "version": "0.14.5",
+          "dev": true,
+          "optional": true
+        },
+        "uid-number": {
+          "version": "0.0.6",
+          "dev": true,
+          "optional": true
+        },
+        "util-deprecate": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "uuid": {
+          "version": "3.0.1",
+          "dev": true,
+          "optional": true
+        },
+        "verror": {
+          "version": "1.3.6",
+          "dev": true,
+          "optional": true
+        },
+        "wide-align": {
+          "version": "1.1.0",
+          "dev": true,
+          "optional": true
+        },
+        "wrappy": {
+          "version": "1.0.2",
+          "dev": true
+        },
+        "xtend": {
+          "version": "4.0.1",
+          "dev": true,
+          "optional": true
+        }
+      }
     },
     "fstream": {
       "version": "1.0.11",
@@ -2551,7 +3155,7 @@
       "dev": true
     },
     "ignore": {
-      "version": "3.2.4",
+      "version": "3.2.6",
       "dev": true
     },
     "imurmurhash": {
@@ -3405,7 +4009,7 @@
       "dev": true
     },
     "node-gyp": {
-      "version": "3.5.0",
+      "version": "3.6.0",
       "dev": true,
       "dependencies": {
         "glob": {
@@ -3414,6 +4018,10 @@
         },
         "minimatch": {
           "version": "3.0.3",
+          "dev": true
+        },
+        "semver": {
+          "version": "5.3.0",
           "dev": true
         }
       }
@@ -3945,7 +4553,7 @@
       "dev": true
     },
     "readable-stream": {
-      "version": "2.2.3",
+      "version": "2.2.6",
       "dev": true
     },
     "readdirp": {
@@ -4299,7 +4907,7 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.4.12",
+      "version": "0.4.13",
       "dev": true
     },
     "sparkles": {
@@ -4497,8 +5105,14 @@
       "dev": true
     },
     "timers-ext": {
-      "version": "0.1.0",
-      "dev": true
+      "version": "0.1.1",
+      "dev": true,
+      "dependencies": {
+        "next-tick": {
+          "version": "1.0.0",
+          "dev": true
+        }
+      }
     },
     "tiny-emitter": {
       "version": "1.1.0",

--- a/server/npm-shrinkwrap.json
+++ b/server/npm-shrinkwrap.json
@@ -15,7 +15,7 @@
       "version": "3.1.0"
     },
     "ajv": {
-      "version": "4.11.4"
+      "version": "4.11.5"
     },
     "align-text": {
       "version": "0.1.4"
@@ -341,7 +341,10 @@
       }
     },
     "i18next": {
-      "version": "1.7.10"
+      "version": "1.10.6"
+    },
+    "i18next-client": {
+      "version": "1.10.3"
     },
     "iconv-lite": {
       "version": "0.4.13"
@@ -358,7 +361,7 @@
       "optional": true
     },
     "is-buffer": {
-      "version": "1.1.4"
+      "version": "1.1.5"
     },
     "is-typedarray": {
       "version": "1.0.0"
@@ -402,7 +405,12 @@
       "version": "0.0.0"
     },
     "jsprim": {
-      "version": "1.3.1"
+      "version": "1.4.0",
+      "dependencies": {
+        "assert-plus": {
+          "version": "1.0.0"
+        }
+      }
     },
     "keygrip": {
       "version": "1.0.1"
@@ -585,13 +593,13 @@
       "version": "1.4.1"
     },
     "qs": {
-      "version": "6.3.2"
+      "version": "6.4.0"
     },
     "repeat-string": {
       "version": "1.6.1"
     },
     "request": {
-      "version": "2.80.0",
+      "version": "2.81.0",
       "dependencies": {
         "uuid": {
           "version": "3.0.1"
@@ -605,6 +613,9 @@
     "rimraf": {
       "version": "2.4.5",
       "optional": true
+    },
+    "safe-buffer": {
+      "version": "5.0.1"
     },
     "safe-json-stringify": {
       "version": "1.0.4",
@@ -643,7 +654,7 @@
       "version": "0.0.3"
     },
     "tunnel-agent": {
-      "version": "0.4.3"
+      "version": "0.6.0"
     },
     "tweetnacl": {
       "version": "0.14.5",
@@ -653,7 +664,7 @@
       "version": "0.3.2"
     },
     "uglify-js": {
-      "version": "2.8.10",
+      "version": "2.8.13",
       "optional": true,
       "dependencies": {
         "source-map": {
@@ -684,7 +695,7 @@
       "version": "1.0.1"
     },
     "whatwg-url": {
-      "version": "4.5.0",
+      "version": "4.6.0",
       "dependencies": {
         "webidl-conversions": {
           "version": "3.0.1"

--- a/server/package.json
+++ b/server/package.json
@@ -23,7 +23,7 @@
     "hapi": "9.5.1",
     "hapi-i18next": "hakubo/hapi-i18next#93fec46bb9b44c7f143140542fc1b7a65b250819",
     "hoek": "2.12.0",
-    "i18next": "1.7.10",
+    "i18next": "1.10.6",
     "inert": "3.2.0",
     "jsdom": "9.11.0",
     "mobile-detect": "1.3.5",


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/XW-2995

## Description
i18next upgraded

in front and auth upgraded to 1.11.5
in server just to 1.10.6 as there was no 1.11.x versions available in npm

## Reviewers

@Wikia/x-wing 
