### PR TITLE
ADEN-4803 Fixed Quantcast tracking for consecutive pageviews

### DIFF
--- a/server/app/views/_partials/tracking-quantserve.hbs
+++ b/server/app/views/_partials/tracking-quantserve.hbs
@@ -8,18 +8,16 @@
 				prefix = document.location.protocol === 'https:' ? 'https://secure' : 'http://edge';
 				scriptTag = document.createElement('script');
 				firstScriptInDocument = document.getElementsByTagName('script')[0];
+				window._qevents = window._qevents || [];
 
-				if (window.Mercury && window.Mercury.wiki && window.Mercury.wiki.vertical) {
-					quantcastLabels.unshift(window.Mercury.wiki.vertical);
+				if (window.__qc) {
+					window.__qc.qpixelsent = [];
 				}
 
-				// without this quantserve does not want to track 2+ page view
-				window.__qc = null;
-
-				window._qevents = [{
+				window._qevents.push({
 					qacct: M.prop('tracking.quantserve'),
 					labels: quantcastLabels.join(',')
-				}];
+				});
 
 				scriptTag.async = 1;
 				scriptTag.src = prefix + '.quantserve.com/quant.js?' + Math.random();


### PR DESCRIPTION
ADEN-4803 Fix Quantcast tracking for consecutive page views

## Links
* https://wikia-inc.atlassian.net/browse/ADEN-4803
* https://github.com/Wikia/mobile-wiki/pull/36
* https://github.com/Wikia/mobile-wiki/pull/37
* https://github.com/Wikia/mercury/pull/3118

## Description
Fixes Quantcast tracking for consecutive page views.

## Reviewers
@Wikia/x-wing 
