### PR TITLE
IRIS-4179 | Escape the query params

### DIFF
--- a/front/auth/app/common/auth-tracker.js
+++ b/front/auth/app/common/auth-tracker.js
@@ -35,8 +35,7 @@ export default class AuthTracker {
 				window.opener.postMessage(
 					{
 						beforeunload: true,
-						// we're expecting 0 or 1, but it comes from querystring - that's why parseInt
-						forceLogin: Boolean(parseInt(pageParams.forceLogin, 10))
+						forceLogin: pageParams.forceLogin
 					},
 					pageParams.parentOrigin
 				);

--- a/server/app/facets/auth/auth-view.js
+++ b/server/app/facets/auth/auth-view.js
@@ -187,7 +187,8 @@ export function getDefaultContext(request) {
 		};
 
 	if (request.query.forceLogin) {
-		pageParams.forceLogin = request.query.forceLogin;
+		// we're expecting 0 or 1, but it comes from querystring - that's why parseInt
+		pageParams.forceLogin = Boolean(parseInt(pageParams.forceLogin, 10));
 	}
 
 	if (isModal) {

--- a/server/app/facets/auth/auth-view.js
+++ b/server/app/facets/auth/auth-view.js
@@ -166,6 +166,10 @@ export function view(template, context, request, reply, layout = 'auth') {
 	return response;
 }
 
+function encodeForJavaScript(value) {
+	return ESAPI.encoder().encodeForJavaScript(value);
+}
+
 /**
  * @param {Hapi.Request} request
  * @returns {AuthViewContext}
@@ -173,7 +177,7 @@ export function view(template, context, request, reply, layout = 'auth') {
 export function getDefaultContext(request) {
 	const viewType = getViewType(request),
 		isModal = request.query.modal === '1',
-		redirectUrl = ESAPI.encoder().encodeForJavaScript(getRedirectUrl(request)),
+		redirectUrl = encodeForJavaScript(getRedirectUrl(request)),
 		reactivateAccountUrl = resolve(redirectUrl, '/Special:CloseMyAccount/reactivate'),
 		pageParams = {
 			cookieDomain: settings.authCookieDomain,
@@ -188,11 +192,11 @@ export function getDefaultContext(request) {
 
 	if (request.query.forceLogin) {
 		// we're expecting 0 or 1, but it comes from querystring - that's why parseInt
-		pageParams.forceLogin = Boolean(parseInt(pageParams.forceLogin, 10));
+		pageParams.forceLogin = Boolean(parseInt(request.query.forceLogin, 10));
 	}
 
 	if (isModal) {
-		pageParams.parentOrigin = getOrigin(request);
+		pageParams.parentOrigin = encodeForJavaScript(getOrigin(request));
 	}
 
 	/* eslint no-undefined: 0 */


### PR DESCRIPTION
## Links

When HAPI gets context it injects all the variables in the <script> tag. This PR will parse forceLogin (which caused the P2), so only boolean values will be returned. Just to be on the safe side the parentOrigin will additionally get escaped.

* http://wikia-inc.atlassian.net/browse/IRIS-4179
