### PR TITLE
MAIN-10098: Get apple-touch-icon URL from MW and serve it

### DIFF
--- a/front/main/app/index.html
+++ b/front/main/app/index.html
@@ -31,6 +31,8 @@
 		<link rel="stylesheet" href="/front/main/assets/app.css">
 	{{/if}}
 
+	{{> apple-touch-icon}}
+
 	{{> dns-prefetch}}
 	{{> open-graph-tags}}
 	{{> other-languages-head}}

--- a/server/app/views/_partials/apple-touch-icon.hbs
+++ b/server/app/views/_partials/apple-touch-icon.hbs
@@ -1,0 +1,3 @@
+{{#if wikiVariables.appleTouchIcon}}
+	<link rel="apple-touch-icon" href="{{wikiVariables.appleTouchIcon.url}}" sizes="{{wikiVariables.appleTouchIcon.size}}" />
+{{/if}}


### PR DESCRIPTION
## Links
* https://wikia-inc.atlassian.net/browse/MAIN-10098
* https://developer.apple.com/library/content/documentation/AppleApplications/Reference/SafariWebContent/ConfiguringWebApplications/ConfiguringWebApplications.html
## Description
Apple browsers such as Safari and Mobile Safari issue a request to `/apple-touch-icon.png` (and its different size variants) by default. Since we are not configuring any custom icon URL via a `link` tag (as described in the second link), such requests fail with error 404 and ugly VCL hack is needed to rewrite them into URLs to Wiki.png in Vignette.

This change allows us to get rid of VCL hack by using a single source of truth for apple-touch-icon: the MediaWiki app. URL and size config is fetched from MediaWiki along with the rest of wiki variables and output in a link tag.

Relevant PR in app: https://github.com/Wikia/app/pull/12729

## Reviewers