### PR TITLE
ADEN-5009 Center absolute IMA div

### DIFF
--- a/front/main/app/styles/module/_ads.scss
+++ b/front/main/app/styles/module/_ads.scss
@@ -16,10 +16,11 @@ $vpaid-z-index: 10;
 
 @mixin absolute-fill() {
 	height: 100%;
-	left: 0;
+	left: 50%;
 	position: absolute;
 	width: 100%;
 	top: 0;
+	transform: translate(-50%, 0);
 }
 
 %high-impact-close-icon {

--- a/front/main/app/styles/module/_ads.scss
+++ b/front/main/app/styles/module/_ads.scss
@@ -11,16 +11,14 @@ $player-button-size: 24px;
 $player-button-sound-on: 'data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfNCIgZGF0YS1uYW1lPSJMYXllciA0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAyOCAyOCI+PGRlZnM+PHN0eWxlPi5jbHMtMXtmaWxsOiNmZmY7b3BhY2l0eTowLjQ7fS5jbHMtMntmaWxsOiMyMzFmMjA7fTwvc3R5bGU+PC9kZWZzPjx0aXRsZT5zb3VuZF9vbl9idXR0b248L3RpdGxlPjxjaXJjbGUgY2xhc3M9ImNscy0xIiBjeD0iMTMuOTYiIGN5PSIxNC4wNiIgcj0iMTMuNzQiLz48cGF0aCBjbGFzcz0iY2xzLTIiIGQ9Ik0xNiwyLjkzQTEzLjA3LDEzLjA3LDAsMSwxLDIuOTMsMTYsMTMuMDgsMTMuMDgsMCwwLDEsMTYsMi45M00xNiwyQTE0LDE0LDAsMSwwLDMwLDE2LDE0LDE0LDAsMCwwLDE2LDJaIiB0cmFuc2Zvcm09InRyYW5zbGF0ZSgtMiAtMikiLz48ZyBpZD0iUGFnZS0xIj48ZyBpZD0iVmlkZW8tUGxheWVyLVNraW4iPjxnIGlkPSJWaWRlby1Db3B5Ij48ZyBpZD0idm9sdW1lIj48cGF0aCBpZD0iU2hhcGUiIGNsYXNzPSJjbHMtMiIgZD0iTTE0LjI0LDkuMTdsLTMuNzksNC4xMUg2LjgyYy0uNzgsMC0xLC40Ni0xLC44OVYxNy43YTEsMSwwLDAsMCwxLDFoMy42NWwzLjc5LDQuMThhMS4wOSwxLjA5LDAsMCwwLC41My4xNCwxLDEsMCwwLDAsLjUtLjE0LDEsMSwwLDAsMCwuNS0uOVYxMGExLDEsMCwwLDAtLjUtLjksMS4wNiwxLjA2LDAsMCwwLTEsLjA1WiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTIgLTIpIi8+PHBhdGggaWQ9IlNoYXBlLTIiIGRhdGEtbmFtZT0iU2hhcGUiIGNsYXNzPSJjbHMtMiIgZD0iTTE5LjE4LDE5LjMzYTQuMzksNC4zOSwwLDAsMCwwLTYuMTkuNzEuNzEsMCwwLDAtMSwxLDMsMywwLDAsMSwwLDQuMTkuNzEuNzEsMCwwLDAsMSwxWiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTIgLTIpIi8+PHBhdGggaWQ9IlNoYXBlLTMiIGRhdGEtbmFtZT0iU2hhcGUiIGNsYXNzPSJjbHMtMiIgZD0iTTIzLjMsMTYuMjNhNi4xOSw2LjE5LDAsMCwwLTEuODEtNC4zOS43MS43MSwwLDEsMC0xLDEsNC44MSw0LjgxLDAsMCwxLDAsNi43OS43MS43MSwwLDEsMCwxLDEsNi4xOSw2LjE5LDAsMCwwLDEuODEtNC4zOVoiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yIC0yKSIvPjwvZz48L2c+PC9nPjwvZz48L3N2Zz4=';
 $player-button-sound-off: 'data:image/svg+xml;base64,PHN2ZyBpZD0iTGF5ZXJfNF9jb3B5IiBkYXRhLW5hbWU9IkxheWVyIDQgY29weSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB2aWV3Qm94PSIwIDAgMjggMjgiPjxkZWZzPjxzdHlsZT4uY2xzLTF7ZmlsbDojZmZmO29wYWNpdHk6MC40O30uY2xzLTJ7ZmlsbDojMjMxZjIwO308L3N0eWxlPjwvZGVmcz48dGl0bGU+c291bmRfb2ZmX2J1dHRvbjwvdGl0bGU+PGNpcmNsZSBjbGFzcz0iY2xzLTEiIGN4PSIxNC4wNiIgY3k9IjEzLjk2IiByPSIxMy43NCIvPjxwYXRoIGNsYXNzPSJjbHMtMiIgZD0iTTE2LDIuOTNBMTMuMDcsMTMuMDcsMCwxLDEsMi45MywxNiwxMy4wOCwxMy4wOCwwLDAsMSwxNiwyLjkzTTE2LDJBMTQsMTQsMCwxLDAsMzAsMTYsMTQsMTQsMCwwLDAsMTYsMloiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yIC0yKSIvPjxnIGlkPSJQYWdlLTEiPjxnIGlkPSJWaWRlby1QbGF5ZXItU2tpbiI+PGcgaWQ9IlZpZGVvLUNvcHkiPjxnIGlkPSJ2b2x1bWUtb2ZmIj48cGF0aCBpZD0iU2hhcGUiIGNsYXNzPSJjbHMtMiIgZD0iTTE0LjI1LDkuMTdsLTMuNzksNC4xMUg2Ljg0Yy0uNzgsMC0xLC40Ni0xLC44OVYxNy43YTEsMSwwLDAsMCwxLDFoMy42NWwzLjc5LDQuMThhMS4wOSwxLjA5LDAsMCwwLC41My4xNCwxLDEsMCwwLDAsLjUtLjE0LDEsMSwwLDAsMCwuNS0uOVYxMGExLDEsMCwwLDAtLjUtLjksMS4wNiwxLjA2LDAsMCwwLTEsLjA1WiIgdHJhbnNmb3JtPSJ0cmFuc2xhdGUoLTIgLTIpIi8+PHBhdGggaWQ9IkZpbGwtMSIgY2xhc3M9ImNscy0yIiBkPSJNMjIuOTEsMTYuMjFsMy0zYS45Mi45MiwwLDEsMC0xLjMtMS4zbC0zLDMtMy0zYS45Mi45MiwwLDEsMC0xLjMsMS4zbDMsMy0zLDNhLjkyLjkyLDAsMSwwLDEuMywxLjNsMy0zLDMsM2EuOTIuOTIsMCwxLDAsMS4zLTEuM1oiIHRyYW5zZm9ybT0idHJhbnNsYXRlKC0yIC0yKSIvPjwvZz48L2c+PC9nPjwvZz48L3N2Zz4=';
 
-
 $vpaid-z-index: 10;
 
 @mixin absolute-fill() {
 	height: 100%;
-	left: 50%;
+	left: 0;
 	position: absolute;
 	width: 100%;
 	top: 0;
-	transform: translate(-50%, 0);
 }
 
 %high-impact-close-icon {
@@ -75,6 +73,7 @@ $vpaid-z-index: 10;
 		}
 	}
 
+	// TODO: remove below styles
 	.vpaid-container {
 		@include absolute-fill();
 
@@ -99,6 +98,32 @@ $vpaid-z-index: 10;
 			background: #000;
 			margin: 0 auto;
 			pointer-events: auto;
+		}
+	}
+	// End of removal
+
+	.video-overlay {
+		@include absolute-fill();
+	}
+
+	.video-display-wrapper {
+		position: relative;
+
+		video, &.vpaid-enabled > div {
+			@include absolute-fill();
+		}
+
+		&.vpaid-enabled > div {
+			left: 50%;
+			transform: translate(-50%, 0);
+		}
+
+		.video-player {
+			background: #000;
+			left: 50%;
+			margin: 0 auto;
+			pointer-events: auto;
+			transform: translate(-50%, 0);
 		}
 	}
 }


### PR DESCRIPTION
It turns out that we should not override IMA's inline styles because some vpaids are styled base on those defaults. Instead of overriding IMA properties everywhere we can adjust styles for UAP units only and keep defaults for all standalone players.

Connected with: https://github.com/Wikia/app/pull/12765

## Links

* http://wikia-inc.atlassian.net/browse/ADEN-5009
