### PR TITLE
IRIS-3818 - don't allow titles that are only whitespace

### DIFF
--- a/front/main/app/components/discussion-editor.js
+++ b/front/main/app/components/discussion-editor.js
@@ -72,7 +72,7 @@ export default Ember.Component.extend(
 		failsPostConstraints() {
 			if (!this.get('isReply') && !this.get('isGuidelinesEditor')) { // is a post
 				return !this.get('category.id') || // does not have a category
-					this.getWithDefault('title.length', 0) === 0; // does not have a title
+					this.getWithDefault('title', '').trim().length === 0; // does not have a title
 			}
 			return false;
 		},


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/IRIS-3818

## Description

Make sure that discussion post titles contain non-whitespace characters.


## Reviewers

