### PR TITLE
IRIS-4225 - include redirect param in global nav auth links

### DIFF
--- a/front/main/app/components/design-system/global-navigation-link-authentication.js
+++ b/front/main/app/components/design-system/global-navigation-link-authentication.js
@@ -13,5 +13,8 @@ export default Component.extend({
 
 		return classMap[this.get('model.title.key')] || '';
 	}),
-	href: computed.alias('model.href')
+	currentUrl: null,
+	href: computed('model.href', 'currentUrl', function () {
+		return `${this.get('model.href')}?redirect=${encodeURIComponent(this.get('currentUrl'))}`;
+	})
 });

--- a/front/main/app/controllers/application.js
+++ b/front/main/app/controllers/application.js
@@ -17,6 +17,7 @@ export default Ember.Controller.extend(
 			'isGlobalNavigationPositionFixed',
 			'isGlobalNavigationHeadroomPinnedOrDisabled'
 		),
+		currentUrl: null,
 
 		/**
 		 * @returns {void}
@@ -37,6 +38,12 @@ export default Ember.Controller.extend(
 
 			this._super();
 		},
+
+		onPathChanged: Ember.observer('target.url', function () {
+			Ember.run.next(this, function () {
+				this.set('currentUrl', window.location.href);
+			});
+		}),
 
 		actions: {
 			/**

--- a/front/main/app/templates/application.hbs
+++ b/front/main/app/templates/application.hbs
@@ -13,6 +13,7 @@
 	goToSearchResults=(route-action 'goToSearchResults')
 	toggleDrawer=(action 'toggleDrawer')
 	toggleSmartBanner=(action 'toggleSmartBanner')
+	currentUrl=currentUrl
 }}
 	{{outlet}}
 {{/application-wrapper}}

--- a/front/main/app/templates/components/application-wrapper.hbs
+++ b/front/main/app/templates/components/application-wrapper.hbs
@@ -14,6 +14,7 @@
 		{{design-system.global-navigation
 			isGlobalNavigationPositionFixed=isGlobalNavigationPositionFixed
 			triggerGlobalNavigationHeadroomStateChange=(route-action 'triggerGlobalNavigationHeadroomStateChange')
+			currentUrl=currentUrl
 		}}
 	{{/if}}
 

--- a/front/main/app/templates/components/design-system/global-navigation-account-navigation.hbs
+++ b/front/main/app/templates/components/design-system/global-navigation-account-navigation.hbs
@@ -16,6 +16,7 @@
 					{{design-system.global-navigation-link-authentication
 						model=link
 						trackClick=this.attrs.trackClick
+						currentUrl=currentUrl
 					}}
 				</li>
 			{{/each}}

--- a/front/main/app/templates/components/design-system/global-navigation.hbs
+++ b/front/main/app/templates/components/design-system/global-navigation.hbs
@@ -35,6 +35,7 @@
 			{{design-system.global-navigation-account-navigation
 				model=model.anon
 				trackClick=(action 'trackClick')
+				currentUrl=currentUrl
 			}}
 		{{/if}}
 		{{#if model.user}}


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/IRIS-4225

## Description

Includes a `redirect` query parameter back to the current page when sending users to auth pages from the global nav.

## Reviewers

