### PR TITLE
IRIS-3887 - add undelete button to deleted post top note

### DIFF
--- a/front/main/app/components/discussion-post-card-top-note.js
+++ b/front/main/app/components/discussion-post-card-top-note.js
@@ -11,7 +11,8 @@ export default Component.extend({
 	canModerate: computed.readOnly('post.userData.permissions.canModerate'),
 	isLocked: computed.readOnly('post.isLocked'),
 	showButtons: computed('isReported', 'post.isDeleted', 'canModerate', function () {
-		return (this.get('isReported') || this.get('post.isDeleted')) && this.get('canModerate');
+		return (this.get('isReported') || this.get('post.isDeleted'))
+				&& this.get('canModerate');
 	}),
 	modalDialog: inject.service(),
 
@@ -189,7 +190,7 @@ export default Component.extend({
 		},
 
 		/**
-		 * Unelete item
+		 * Undelete item
 		 * @param {Object} item - post or reply
 		 * @returns {void}
 		 */

--- a/front/main/app/components/discussion-post-card-top-note.js
+++ b/front/main/app/components/discussion-post-card-top-note.js
@@ -10,7 +10,9 @@ export default Component.extend({
 	canDelete: computed.readOnly('post.userData.permissions.canDelete'),
 	canModerate: computed.readOnly('post.userData.permissions.canModerate'),
 	isLocked: computed.readOnly('post.isLocked'),
-	showButtons: computed.and('isReported', 'canModerate'),
+	showButtons: computed('isReported', 'post.isDeleted', 'canModerate', function () {
+		return (this.get('isReported') || this.get('post.isDeleted')) && this.get('canModerate');
+	}),
 	modalDialog: inject.service(),
 
 	isReportDetailsVisible: false,
@@ -184,6 +186,15 @@ export default Component.extend({
 				confirmButtonText: i18n.t('main.modal-dialog-delete', {ns: 'discussion'}),
 				confirmCallback: (() => this.get('delete')(item)),
 			});
+		},
+
+		/**
+		 * Unelete item
+		 * @param {Object} item - post or reply
+		 * @returns {void}
+		 */
+		undelete(item) {
+			this.get('undelete')(item);
 		},
 
 		/**

--- a/front/main/app/styles/module/_discussion.scss
+++ b/front/main/app/styles/module/_discussion.scss
@@ -114,7 +114,7 @@ body.discussions {
 	}
 
 	&.undelete {
-		padding: 10px;
+		padding: 11px;
 	}
 
 	&.locked {

--- a/front/main/app/styles/module/_discussion.scss
+++ b/front/main/app/styles/module/_discussion.scss
@@ -97,17 +97,24 @@ body.discussions {
 	}
 
 	&.validate,
-	&.reported-delete {
+	&.reported-delete,
+	&.undelete{
 		height: 40px;
 		width: 40px;
 	}
 
-	&.validate {
+	&.validate,
+	&.undelete {
 		fill: $discussion-submit-icon-color;
 	}
 
-	&.reported-delete {
+	&.reported-delete,
+	&.undelete {
 		margin-right: $post-card-right-icon-margin;
+	}
+
+	&.undelete {
+		padding: 10px;
 	}
 
 	&.locked {
@@ -407,7 +414,7 @@ body.discussions {
 		}
 
 		&.is-parent-deleted .icon:not(.delete),
-		&.is-deleted .icon:not(.delete) {
+		&.is-deleted .icon:not(.delete):not(.undelete) {
 			fill: $discussion-deleted-actions-color;
 		}
 

--- a/front/main/app/styles/theme/_dark.scss
+++ b/front/main/app/styles/theme/_dark.scss
@@ -163,6 +163,12 @@ body.dark-theme {
 				}
 			}
 
+			&.is-deleted {
+				.icon:not(.delete):not(.undelete) {
+					fill: $dark-discussion-deleted-actions-color;
+				}
+			}
+
 			&.is-highlighted {
 				background-color: $dark-discussion-post-card-linked-background;
 			}

--- a/front/main/app/templates/components/discussion-post-card-detail.hbs
+++ b/front/main/app/templates/components/discussion-post-card-detail.hbs
@@ -4,6 +4,7 @@
 			{{discussion-post-card-top-note
 					approve=(action this.attrs.approve)
 					delete=(action this.attrs.delete)
+					undelete=(action this.attrs.undelete)
 					isReported=isReported
 					post=post
 					threadCreatorName=post.threadCreatedBy.name

--- a/front/main/app/templates/components/discussion-post-card-reply.hbs
+++ b/front/main/app/templates/components/discussion-post-card-reply.hbs
@@ -3,6 +3,7 @@
 		{{discussion-post-card-top-note
 			approve=(action this.attrs.approve)
 			delete=(action this.attrs.delete)
+			undelete=(action this.attrs.undelete)
 			isReply=true
 			isReported=isReported
 			post=post

--- a/front/main/app/templates/components/discussion-post-card-top-note.hbs
+++ b/front/main/app/templates/components/discussion-post-card-top-note.hbs
@@ -18,11 +18,13 @@
 {{/if}}
 {{#if showButtons}}
 	<div class="actions columns large-4 small-4">
-		{{#if canModerate}}
+		{{#if post.isDeleted}}
+			<a class="undelete-link" {{action 'undelete' post}}>{{svg 'undo' class='icon undelete'}}</a>
+		{{else}}
 			<a class="validate-link" {{action 'approve' post isReply}}>{{svg 'checkmark' class='icon validate'}}</a>
-		{{/if}}
-		{{#if canDelete}}
-			<a class="delete-link" {{action 'delete' post isReply}}>{{svg 'trash' class='icon reported-delete'}}</a>
+			{{#if canDelete}}
+				<a class="delete-link" {{action 'delete' post isReply}}>{{svg 'trash' class='icon reported-delete'}}</a>
+			{{/if}}
 		{{/if}}
 	</div>
 {{/if}}

--- a/front/main/app/templates/components/discussion-post-card-top-note.hbs
+++ b/front/main/app/templates/components/discussion-post-card-top-note.hbs
@@ -19,7 +19,7 @@
 {{#if showButtons}}
 	<div class="actions columns large-4 small-4">
 		{{#if post.isDeleted}}
-			<a class="undelete-link" {{action 'undelete' post}}>{{svg 'undo' class='icon undelete'}}</a>
+			<a class="undelete-link" {{action 'undelete' post}}>{{svg 'wds-icons-trash-open-small' viewBox='0 0 18 18' class='icon undelete'}}</a>
 		{{else}}
 			<a class="validate-link" {{action 'approve' post isReply}}>{{svg 'checkmark' class='icon validate'}}</a>
 			{{#if canDelete}}


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/IRIS-3887

## Description

Adds an undelete button to the top note of deleted posts and replies.

## Reviewers

Use `@` mentions here. Alternatively, assign the pull request to a person.
