### PR TITLE
IRIS-3826 - remove dependency on threads:move permission to edit categories

### DIFF
--- a/front/main/app/mixins/discussion-editor-category-picker.js
+++ b/front/main/app/mixins/discussion-editor-category-picker.js
@@ -39,18 +39,12 @@ export default Ember.Mixin.create({
 		return !this.get('hasOneCategory') && this.get('isActivePostEditor') && !this.get('cannotEditCategory');
 	}),
 
-	categoryPickerDisabled: Ember.computed('isEdit', 'currentUser.permissions', function () {
-		return this.get('isEdit') && !this.get('currentUser.permissions.discussions.canChangePostCategory');
-	}),
-
 	categoryPickerClassname:
-		Ember.computed('category', 'categoryPickerDisabled', 'shouldShowCategoryPicker', function () {
+		Ember.computed('category', 'shouldShowCategoryPicker', function () {
 			let classname = '';
 
 			if (!this.get('shouldShowCategoryPicker')) {
 				classname += 'hidden';
-			} else if (this.get('categoryPickerDisabled')) {
-				classname += 'disabled';
 			}
 
 			if (this.get('category') !== null) {


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/IRIS-3826

## Description
Rely on the `canMove` attribute returned from discussions instead of the `threads:move` permission to decide whether a user can edit categories on a post.

## Reviewers

Use `@` mentions here. Alternatively, assign the pull request to a person.
