### PR TITLE
(PLATFORM-3075) Send access token in signout request

### DIFF
--- a/server/app/facets/operations/signout.js
+++ b/server/app/facets/operations/signout.js
@@ -13,7 +13,10 @@ function getContext(request) {
 		url: authUtils.getHeliosInternalUrl(`/token/${token}`),
 		options: {
 			headers: getInternalHeaders(request, {
-				'X-Wikia-UserId': userId
+				// TODO (PLATFORM-3075): remove X-Wikia-UserId once Helios is deployed
+				// leaving for now for backwards compatibility during release
+				'X-Wikia-UserId': userId,
+				'X-Wikia-AccessToken': token
 			}),
 			timeout: settings.helios.timeout
 		},


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/PLATFORM-3075

## Description

Send access token in signout request rather than the UserId header which
will no longer be used going forward.

## Reviewers

@Wikia/core-platform-team @slayful 
