### PR TITLE
(PLATFORM-2925) Use proxies for login routes in auth pages

### DIFF
--- a/front/auth/app/common/login.js
+++ b/front/auth/app/common/login.js
@@ -50,6 +50,7 @@ export default class Login {
 
 		this.usernameInput = form.elements.username;
 		this.passwordInput = form.elements.password;
+		this.crumbInput = form.elements.crumb;
 		this.urlHelper = new UrlHelper();
 
 		if (window.location.search) {
@@ -68,7 +69,7 @@ export default class Login {
 	 */
 	onSubmit(event) {
 		const xhr = new XMLHttpRequest(),
-			postData = this.getCredentials(),
+			postData = this.getFormData(),
 			submitButton = this.form.querySelector('button'),
 			enableSubmitButton = () => {
 				submitButton.disabled = false;
@@ -157,10 +158,11 @@ export default class Login {
 	/**
 	 * @returns {LoginCredentials}
 	 */
-	getCredentials() {
+	getFormData() {
 		return {
 			username: this.usernameInput.value,
-			password: this.passwordInput.value
+			password: this.passwordInput.value,
+			crumb: this.crumbInput.value
 		};
 	}
 

--- a/front/auth/app/facebook/facebook-login.js
+++ b/front/auth/app/facebook/facebook-login.js
@@ -131,7 +131,8 @@ export default class FacebookLogin {
 	getHeliosInfoFromFBToken(facebookAuthData) {
 		const facebookTokenXhr = new XMLHttpRequest(),
 			data = {
-				fb_access_token: facebookAuthData.accessToken
+				fb_access_token: facebookAuthData.accessToken,
+				crumb: this.loginButton.getAttribute('data-crumb')
 			},
 			url = this.loginButton.getAttribute('data-helios-facebook-uri');
 

--- a/front/auth/views/_partials/auth/signin.hbs
+++ b/front/auth/views/_partials/auth/signin.hbs
@@ -1,9 +1,9 @@
 {{#if heliosFacebookConnectURL}}
-	<form id="{{formId}}" action="{{heliosLoginURL}}" method="POST" data-heliosFacebookConnectURL="{{heliosFacebookConnectURL}}">
+	<form id="{{formId}}" action="{{signinPostURL}}" method="POST" data-heliosFacebookConnectURL="{{heliosFacebookConnectURL}}">
 {{else}}
-	<form id="{{formId}}" action="{{heliosLoginURL}}" method="POST">
+	<form id="{{formId}}" action="{{signinPostURL}}" method="POST">
 	{{#if hasMobileFacebookSection}}
-		<a class="button signup-provider-facebook" href="#" data-helios-facebook-uri="{{{heliosFacebookURL}}}">
+		<a class="button signup-provider-facebook" href="#" data-crumb="{{crumb}}" data-helios-facebook-uri="{{signinFacebookURL}}">
 			<span>{{i18n 'auth:common.connect-with-facebook'}}</span>
 		</a>
 
@@ -28,5 +28,6 @@
 		<span class="input-icon password-toggler"></span>
 		<a class="forgotten-password" href="{{{forgotPasswordHref}}}" tabindex="-1">{{i18n "auth:signin.forgot-password"}}</a>
 	</div>
+	<input type="hidden" id="crumb" name="crumb" value="{{crumb}}" />
 	<button id="loginSubmit" type="submit" class="form-submit" disabled><span>{{i18n submitText}}</span></button>
 </form>

--- a/front/auth/views/auth/desktop/register.hbs
+++ b/front/auth/views/auth/desktop/register.hbs
@@ -3,7 +3,7 @@
 		<h6>{{i18n 'auth:common.connect-account-header'}}</h6>
 		<ul class="signup-providers">
 			<li>
-				<a class="button signup-provider-facebook" href="#" data-helios-facebook-uri="{{{heliosFacebookURL}}}">
+				<a class="button signup-provider-facebook" href="#" data-crumb="{{crumb}}" data-helios-facebook-uri="{{signinFacebookURL}}">
 					<span>{{i18n 'auth:common.connect-with-facebook'}}</span>
 				</a>
 			</li>

--- a/front/auth/views/auth/desktop/signin.hbs
+++ b/front/auth/views/auth/desktop/signin.hbs
@@ -3,7 +3,7 @@
 		<h6>{{i18n 'auth:common.connect-account-header'}}</h6>
 		<ul class="signup-providers">
 			<li>
-				<a class="button signup-provider-facebook" href="#" data-helios-facebook-uri="{{{heliosFacebookURL}}}">
+				<a class="button signup-provider-facebook" href="#" data-crumb="{{crumb}}" data-helios-facebook-uri="{{signinFacebookURL}}">
 					<span>{{i18n 'auth:common.connect-with-facebook'}}</span>
 				</a>
 			</li>

--- a/front/auth/views/auth/mobile/join-page.hbs
+++ b/front/auth/views/auth/mobile/join-page.hbs
@@ -9,7 +9,7 @@
 <div class="auth-options">
 	<ul class="signup-providers">
 		<li>
-			<a class="button signup-provider-facebook" href="#" data-helios-facebook-uri="{{{heliosFacebookURL}}}">
+			<a class="button signup-provider-facebook" href="#" data-crumb="{{crumb}}" data-helios-facebook-uri="{{signinFacebookURL}}">
 				<span>{{i18n 'auth:common.connect-with-facebook'}}</span>
 			</a>
 		</li>

--- a/server/app/app.js
+++ b/server/app/app.js
@@ -9,6 +9,7 @@ import fs from 'fs';
 import h2o2 from 'h2o2';
 import handlebars from 'handlebars';
 import {Server} from 'hapi';
+import crumb from 'crumb';
 import i18next from 'hapi-i18next';
 import inert from 'inert';
 import path from 'path';
@@ -241,6 +242,12 @@ plugins = [
 	},
 	{
 		register: vision
+	},
+	{
+		register: crumb,
+		options: {
+			skip: (request, reply) => request.path.search('^\/(signin|join|register)$') === -1
+		}
 	}
 ];
 

--- a/server/app/facets/auth/join.js
+++ b/server/app/facets/auth/join.js
@@ -10,7 +10,7 @@ import {format} from 'url';
  * @extends {AuthViewContext}
  * @property {string} loginRoute
  * @property {string} signupHref
- * @property {string} heliosFacebookURL
+ * @property {string} signinFacebookURL
  * @property {number} [facebookAppId]
  */
 
@@ -29,7 +29,7 @@ export default function get(request, reply) {
 			signupHref: authUtils.getRegisterUrl(request),
 			bodyClasses: 'splash join-page',
 			pageType: 'join-page',
-			heliosFacebookURL: authUtils.getHeliosUrl('/facebook/token'),
+			signinFacebookURL: '/signin?method=facebook',
 			pageParams: {
 				facebookAppId: settings.facebook.appId
 			}

--- a/server/app/facets/auth/register.js
+++ b/server/app/facets/auth/register.js
@@ -16,7 +16,7 @@ import {parse} from 'url';
  * @property {string} [heliosRegistrationURL]
  * @property {*} [i18nContext]
  * @property {string} [termsOfUseLink]
- * @property {string} heliosFacebookURL
+ * @property {string} signinFacebookURL
  */
 
 /**
@@ -132,7 +132,7 @@ function getEmailRegistrationPage(request, reply) {
 				'auth:join.sign-up-with-email' :
 				'auth:register.desktop-header',
 			heliosRegistrationURL: authUtils.getUserRegistrationUrl('/users'),
-			heliosFacebookURL: authUtils.getHeliosUrl('/facebook/token'),
+			signinFacebookURL: '/signin?method=facebook',
 			title: (viewType === authView.VIEW_TYPE_MOBILE) ?
 				'auth:join.sign-up-with-email' :
 				'auth:register.desktop-header',

--- a/server/app/facets/operations/signin.js
+++ b/server/app/facets/operations/signin.js
@@ -1,0 +1,84 @@
+import Wreck from 'wreck';
+import {getHeliosInternalUrl} from '../../lib/auth-utils';
+import {getInternalHeaders} from '../../lib/utils';
+import settings from '../../../config/settings';
+import Logger from '../../lib/logger';
+
+function getSigninContext(username, password, request) {
+	return {
+		url: getHeliosInternalUrl('/token'),
+		options: {
+			headers: getInternalHeaders(request, {
+				'Content-type': 'application/x-www-form-urlencoded',
+				'X-Wikia-Internal-Request': '1'
+			}),
+			timeout: settings.helios.timeout,
+			payload: `username=${username}&password=${password}`
+		},
+	};
+}
+
+function getFacebookSigninContext(fbAccessToken, request) {
+	return {
+		url: getHeliosInternalUrl('/facebook/token'),
+		options: {
+			headers: getInternalHeaders(request, {
+				'Content-type': 'application/x-www-form-urlencoded',
+				'X-Wikia-Internal-Request': '1'
+			}),
+			timeout: settings.helios.timeout,
+			payload: `fb_access_token=${fbAccessToken}`
+		},
+	};
+}
+
+/**
+ * @param {string} username
+ * @param {string} password
+ * @param {string} targetUsername
+ * @param {Hapi.Request} request
+ * @returns {Promise}
+ */
+export function signinUser(username, password, request) {
+	const context = getSigninContext(username, password, request);
+	return new Promise((resolve, reject) => {
+		Wreck.post(context.url, context.options, (error, response, payload) => {
+			if (response && response.statusCode === 200) {
+				resolve({
+					payload: new Buffer(payload).toString('utf8')
+				});
+			} else {
+				Logger.error({
+					url: context.url,
+					error,
+				}, 'Error from Helios token endpoint.');
+				reject({
+					response,
+					payload: new Buffer(payload).toString('utf8')
+				});
+			}
+		});
+	});
+}
+
+export function signinFacebookUser(fbAccessToken, request) {
+	const context = getFacebookSigninContext(fbAccessToken, request);
+	return new Promise((resolve, reject) => {
+		Wreck.post(context.url, context.options, (error, response, payload) => {
+			if (response && response.statusCode === 200) {
+				resolve({
+					payload: new Buffer(payload).toString('utf8')
+				});
+			} else {
+				Logger.error({
+					url: context.url,
+					error,
+				}, 'Error from Helios Facebook token endpoint.');
+				reject({
+					response,
+					payload: new Buffer(payload).toString('utf8')
+				});
+			}
+		});
+	});
+}

--- a/server/app/routes.js
+++ b/server/app/routes.js
@@ -12,7 +12,7 @@ import {validateRedirect} from './facets/auth/auth-view';
 import * as forgotPasswordHandler from './facets/auth/forgot-password';
 import registerHandler from './facets/auth/register';
 import * as resetPasswordHandler from './facets/auth/reset-password';
-import signinHandler from './facets/auth/signin';
+import * as signinHandler from './facets/auth/signin';
 import * as piggybackHandler from './facets/auth/piggyback';
 import confirmEmailHandler from './facets/auth/confirm-email';
 import showApplication from './facets/show-application';
@@ -91,7 +91,19 @@ let routes,
 		{
 			method: 'GET',
 			path: '/signin',
-			handler: signinHandler,
+			handler: signinHandler.get,
+			config: {
+				pre: [
+					{
+						method: validateRedirect
+					}
+				]
+			}
+		},
+		{
+			method: 'POST',
+			path: '/signin',
+			handler: signinHandler.post,
 			config: {
 				pre: [
 					{

--- a/server/package.json
+++ b/server/package.json
@@ -17,6 +17,7 @@
     "bunyan": "1.8.1",
     "bunyan-prettystream": "0.1.3",
     "bunyan-syslog": "mcavage/node-bunyan-syslog#9bdb9eb62a763c7d30e032a619138032d5ff8771",
+    "crumb": "5.0.0",
     "deep-extend": "0.3.3",
     "h2o2": "4.0.2",
     "handlebars": "4.0.5",


### PR DESCRIPTION
Use proxies for login routes in auth pages and implement crumb
for CSRF protection.

## Links

* http://wikia-inc.atlassian.net/browse/JIRA-123
* more relevant links

## Description

A description written using complete sentences of the changes being made and any context necessary to understand them.

## Reviewers

Use `@` mentions here. Alternatively, assign the pull request to a person.
