### PR TITLE
MAIN-10913 l remove icon styling from dark theme

### DIFF
--- a/front/main/app/styles/theme/_dark.scss
+++ b/front/main/app/styles/theme/_dark.scss
@@ -231,10 +231,6 @@ body.dark-theme {
 				}
 			}
 
-			.icon {
-				fill: $dark-discussion-actions-color;
-			}
-
 			.has-upvoted {
 				.icon {
 					fill: $dark-upvote-icon-activated-color;


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/MAIN-10913

## Description
Our dark theme css is defining a style which is overriding another style we use to indicate a post is followed. Specifically, it was creating a `fill` style for the selector `.dark-theme .discussion-wrapper .discussion .icon`. That selector is more specific than the one we're using to update `fill` when a post is being followed defined [here](https://github.com/Wikia/mercury/blob/999a02ab50d6b1593e3757a298452c7fa9f3eae3/front/main/app/mixins/theme.js#L124).

Additionally, the `fill` style from our dark theme css is unnecessary, as that same style is defined in our `style-themed.css` in a way which is not overly specific, allowing us to override it when the post is followed.

So I'm just removing the problem style from the dark theme css.

## Reviewers
@katanka