### PR TITLE
IRIS-4934 | Fix and simplify post image thumbnailing process

### DIFF
--- a/front/main/app/components/discussion-post-image.js
+++ b/front/main/app/components/discussion-post-image.js
@@ -42,7 +42,7 @@ export default Component.extend(
 		srcset: computed('crop', 'image', function () {
 			const image = this.get('image');
 
-			if (!image.url) {
+			if (!image || !image.url) {
 				return '';
 			}
 

--- a/front/main/app/components/discussion-post-image.js
+++ b/front/main/app/components/discussion-post-image.js
@@ -86,6 +86,11 @@ export default Component.extend(
 			return sources;
 		},
 
+		/**
+		 * Crop to 16:9 aspect ratio
+		 * @param {Object} image
+		 * @returns {Array}
+		 */
 		getCroppedSources(image) {
 			const sources = [];
 

--- a/front/main/app/components/discussion-post-image.js
+++ b/front/main/app/components/discussion-post-image.js
@@ -27,7 +27,7 @@ export default Component.extend(
 		/**
 		 * @public
 		 */
-		crop: false,
+		shouldCrop: false,
 
 		/**
 		 * @public
@@ -39,14 +39,14 @@ export default Component.extend(
 		 */
 		image: null,
 
-		srcset: computed('crop', 'image', function () {
+		srcset: computed('shouldCrop', 'image', function () {
 			const image = this.get('image');
 
 			if (!image || !image.url) {
 				return '';
 			}
 
-			const sources = this.get('crop') ? this.getCroppedSources(image) : this.getUncroppedSources(image);
+			const sources = this.get('shouldCrop') ? this.getCroppedSources(image) : this.getUncroppedSources(image);
 
 			return sources.join(', ');
 		}),

--- a/front/main/app/components/discussion-post-image.js
+++ b/front/main/app/components/discussion-post-image.js
@@ -4,7 +4,8 @@ const SCALE_WIDTH = 'scale-to-width-down',
 	ZOOM_CROP = 'zoom-crop-down',
 	{
 		Component,
-		computed
+		computed,
+		String
 	} = Ember;
 
 export default Component.extend(
@@ -50,8 +51,26 @@ export default Component.extend(
 			return sources.join(', ');
 		}),
 
-		// On desktop image width is limited by column width, on mobile it can take almost 100% of viewport width
+		/**
+		 * Desktop image width is limited by column width,
+		 * on mobile it can take almost 100% of viewport width
+		 * Browsers will pick the best image based on this info
+		 */
 		sizes: '(min-width: 1575px) 640px, (min-width: 1064px) 520px, 100vw',
+
+		/**
+		 * Using 100vw in sizes attribute causes images to be upscaled if too small
+		 * Prevent it
+		 */
+		wrapperStyle: computed('image.width', function () {
+			return String.htmlSafe(`max-width: ${this.get('image.width')}px`);
+		}),
+
+		actions: {
+			remove() {
+				this.sendAction('removeImage', this.get('image'));
+			}
+		},
 
 		getUncroppedSources(image) {
 			const sources = [];
@@ -82,12 +101,6 @@ export default Component.extend(
 			sources.push(`${image.url}/${ZOOM_CROP}/width/${image.width}/height/${height} ${image.width}w`);
 
 			return sources;
-		},
-
-		actions: {
-			remove() {
-				this.sendAction('removeImage', this.get('image'));
-			}
 		}
 	}
 );

--- a/front/main/app/templates/components/discussion-post-card-detail.hbs
+++ b/front/main/app/templates/components/discussion-post-card-detail.hbs
@@ -85,7 +85,7 @@
 		{{#if post.contentImages.images}}
 			<a href="{{href-to 'discussion.post' post.threadId}}">
 				{{discussion-post-images
-					cropImages=responsive.isMobile
+					shouldCrop=responsive.isMobile
 					images=post.contentImages.images
 				}}
 			</a>

--- a/front/main/app/templates/components/discussion-post-card-reply.hbs
+++ b/front/main/app/templates/components/discussion-post-card-reply.hbs
@@ -62,7 +62,7 @@
 	{{/if}}
 	{{#if post.contentImages.images}}
 		{{discussion-post-images
-			cropImages=cropImages
+			shouldCrop=shouldCropImages
 			images=post.contentImages.images
 			mode=imagesDisplayMode
 		}}

--- a/front/main/app/templates/components/discussion-post-image.hbs
+++ b/front/main/app/templates/components/discussion-post-image.hbs
@@ -8,12 +8,7 @@
 			}}
 		</div>
 	{{else}}
-		<picture>
-			{{#each displayedSources as |source|}}
-				<source media="{{source.media}}" srcset="{{source.src}}">
-			{{/each}}
-			<img class="post-image-inner-image" alt="{{alt}}" src="{{image.url}}" srcset="{{srcset}}" style={{croppedStyle}}>
-		</picture>
+		<img class="post-image-inner-image" alt="{{alt}}" src="{{image.url}}" srcset="{{srcset}}" sizes="{{sizes}}">
 	{{/if}}
 
 	{{#if editorToolsVisible}}

--- a/front/main/app/templates/components/discussion-post-image.hbs
+++ b/front/main/app/templates/components/discussion-post-image.hbs
@@ -1,4 +1,4 @@
-<div class="post-image-editor-tools-wrapper">
+<div class="post-image-editor-tools-wrapper" style={{wrapperStyle}}>
 	{{#if image.isUploading}}
 		<div class="image-placeholder">
 			{{wds-spinner
@@ -8,7 +8,11 @@
 			}}
 		</div>
 	{{else}}
-		<img class="post-image-inner-image" alt="{{alt}}" src="{{image.url}}" srcset="{{srcset}}" sizes="{{sizes}}">
+		<img class="post-image-inner-image"
+			 alt="{{alt}}"
+			 src="{{image.url}}"
+			 srcset="{{srcset}}"
+			 sizes="{{sizes}}">
 	{{/if}}
 
 	{{#if editorToolsVisible}}

--- a/front/main/app/templates/components/discussion-post-images.hbs
+++ b/front/main/app/templates/components/discussion-post-images.hbs
@@ -12,7 +12,7 @@
 		{{discussion-post-image
 			alt='Post image'
 			class='post-image'
-			crop=cropImages
+			shouldCrop=shouldCrop
 			editorToolsVisible=areEditorToolsVisible
 			image=image
 			removeImage=(action 'removeImage')

--- a/front/main/app/templates/components/discussion-post.hbs
+++ b/front/main/app/templates/components/discussion-post.hbs
@@ -40,7 +40,7 @@
 		{{discussion-post-card-reply
 			approve=(action this.attrs.approve)
 			author=entity.createdBy
-			cropImages=false
+			shouldCropImages=false
 			delete=(action this.attrs.deleteReply)
 			imagesDisplayMode='full'
 			isDetailsView=true

--- a/front/main/app/templates/components/discussion-reported-posts-wrapper.hbs
+++ b/front/main/app/templates/components/discussion-reported-posts-wrapper.hbs
@@ -12,7 +12,7 @@
 		{{discussion-post-card-reply
 			approve=(action this.attrs.approve)
 			author=entity.createdBy
-			cropImages=responsive.isMobile
+			shouldCropImages=responsive.isMobile
 			delete=(action this.attrs.deleteReply)
 			imagesDisplayMode='compact'
 			isParentDeleted=model.isDeleted

--- a/front/main/app/templates/components/discussion-user-list-wrapper.hbs
+++ b/front/main/app/templates/components/discussion-user-list-wrapper.hbs
@@ -12,7 +12,7 @@
 		{{discussion-post-card-reply
 			approve=(action this.attrs.approve)
 			author=entity.createdBy
-			cropImages=responsive.isMobile
+			shouldCropImages=responsive.isMobile
 			delete=(action this.attrs.deleteReply)
 			imagesDisplayMode='compact'
 			isParentDeleted=model.isDeleted

--- a/front/main/tests/unit/components/discussion-post-image-test.js
+++ b/front/main/tests/unit/components/discussion-post-image-test.js
@@ -1,0 +1,77 @@
+import {moduleForComponent, test} from 'ember-qunit';
+
+moduleForComponent('discussion-post-image', 'Unit | Component | discussion post image', {
+	unit: true
+});
+
+test('uncropped sources', function (assert) {
+	const component = this.subject(),
+		cases = [
+			{
+				image: {
+					url: 'img.png',
+					width: 500,
+					height: 500
+				},
+				expected: [
+					'img.png/scale-to-width-down/420 420w',
+					'img.png 500w'
+				]
+			},
+			{
+				image: {
+					url: 'img.png',
+					width: 2000,
+					height: 500
+				},
+				expected: [
+					'img.png/scale-to-width-down/420 420w',
+					'img.png/scale-to-width-down/520 520w',
+					'img.png/scale-to-width-down/640 640w',
+					'img.png/scale-to-width-down/767 767w',
+					'img.png/scale-to-width-down/1063 1063w',
+					'img.png 2000w'
+				]
+			}
+		];
+
+	cases.forEach((testCase) => {
+		assert.deepEqual(component.getUncroppedSources(testCase.image), testCase.expected);
+	});
+});
+
+test('cropped sources', function (assert) {
+	const component = this.subject(),
+		cases = [
+			{
+				image: {
+					url: 'img.png',
+					width: 500,
+					height: 500
+				},
+				expected: [
+					'img.png/zoom-crop-down/width/420/height/236 420w',
+					'img.png/zoom-crop-down/width/500/height/281 500w'
+				]
+			},
+			{
+				image: {
+					url: 'img.png',
+					width: 2000,
+					height: 500
+				},
+				expected: [
+					'img.png/zoom-crop-down/width/420/height/236 420w',
+					'img.png/zoom-crop-down/width/520/height/292 520w',
+					'img.png/zoom-crop-down/width/640/height/360 640w',
+					'img.png/zoom-crop-down/width/767/height/431 767w',
+					'img.png/zoom-crop-down/width/1063/height/597 1063w',
+					'img.png/zoom-crop-down/width/2000/height/1125 2000w'
+				]
+			}
+		];
+
+	cases.forEach((testCase) => {
+		assert.deepEqual(component.getCroppedSources(testCase.image), testCase.expected);
+	});
+});

--- a/front/main/tests/unit/components/discussion-post-image-test.js
+++ b/front/main/tests/unit/components/discussion-post-image-test.js
@@ -4,7 +4,7 @@ moduleForComponent('discussion-post-image', 'Unit | Component | discussion post 
 	unit: true
 });
 
-test('uncropped sources', function (assert) {
+test('uncropped sources for post image are returned as expected', function (assert) {
 	const component = this.subject(),
 		cases = [
 			{
@@ -40,7 +40,7 @@ test('uncropped sources', function (assert) {
 	});
 });
 
-test('cropped sources', function (assert) {
+test('cropped sources for post image are returned as expected', function (assert) {
 	const component = this.subject(),
 		cases = [
 			{


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/IRIS-4934
* https://stackoverflow.com/questions/44991155/prevent-upscaling-with-scrset

## Description

Use `<img srcset>` instead of `<picture><source></picture>`. It's simpler as the browser handles pixel ratio by itself. 

## Reviewers

@slayful 