### PR TITLE
IRIS-1635 | Show image upload errors inside editor

### DIFF
--- a/front/main/app/components/discussion-image-upload-input.js
+++ b/front/main/app/components/discussion-image-upload-input.js
@@ -1,18 +1,9 @@
 import Ember from 'ember';
 
-const {Component, isEmpty, observer} = Ember;
+const {Component, isEmpty} = Ember;
 
 export default Component.extend(
 	{
-		reset: false,
-
-		resetObserver: observer('reset', function () {
-			if (this.get('reset')) {
-				this.$('input').val(null);
-				this.set('reset', false);
-			}
-		}),
-
 		/**
 		 * @param {Event} event
 		 * @returns {void}

--- a/front/main/app/components/discussion-image-upload-input.js
+++ b/front/main/app/components/discussion-image-upload-input.js
@@ -13,13 +13,6 @@ export default Component.extend(
 			if (!isEmpty(input.files)) {
 				this.get('onImageSelected')(input.files);
 			}
-		},
-
-		/**
-		 * @returns {void}
-		 */
-		click() {
-			this.sendAction('click');
-		},
+		}
 	}
 );

--- a/front/main/app/components/discussion-image-upload.js
+++ b/front/main/app/components/discussion-image-upload.js
@@ -10,7 +10,6 @@ export default Component.extend(
 		staticAssets: inject.service(),
 
 		isDragActive: false,
-		resetFileInput: false,
 
 		allowedFileTypes: [
 			'image/jpeg',
@@ -65,22 +64,12 @@ export default Component.extend(
 			this.get('contentImages')
 				.addContentImage(imageFile, this.get('staticAssets'))
 				.catch((err) => {
-					// FIXME this is true on network error so we never show it
-					if (this.get('isDestroyed')) {
-						return;
-					}
-
 					Logger.error('Error uploading image', err);
 
 					if (err.status === 400) {
 						this.handle400Response(err.response);
 					} else {
 						this.showErrorMessage('image-upload.upload-failed');
-					}
-				})
-				.then(() => {
-					if (!this.get('isDestroyed')) {
-						this.set('resetFileInput', true);
 					}
 				});
 		},

--- a/front/main/app/components/discussion-image-upload.js
+++ b/front/main/app/components/discussion-image-upload.js
@@ -32,12 +32,6 @@ export default Component.extend(
 		},
 
 		actions: {
-			/**
-			 * Empty method for the file-input helper required click method.
-			 * @return {void}
-			 */
-			emptyClickForFileInput() {
-			},
 			onImageSelected(files) {
 				this.handleImageSelected(files[0]);
 			},

--- a/front/main/app/components/discussion-image-upload.js
+++ b/front/main/app/components/discussion-image-upload.js
@@ -65,6 +65,7 @@ export default Component.extend(
 			this.get('contentImages')
 				.addContentImage(imageFile, this.get('staticAssets'))
 				.catch((err) => {
+					// FIXME this is true on network error so we never show it
 					if (this.get('isDestroyed')) {
 						return;
 					}
@@ -85,10 +86,7 @@ export default Component.extend(
 		},
 
 		showErrorMessage(msgKey) {
-			this.addAlert({
-				message: this.getErrorMessage(msgKey),
-				type: 'alert'
-			});
+			this.sendAction('showError', msgKey);
 		},
 
 		getErrorMessage(msgKey) {

--- a/front/main/app/components/discussion-image-upload.js
+++ b/front/main/app/components/discussion-image-upload.js
@@ -1,10 +1,8 @@
 import Ember from 'ember';
-import AlertNotificationsMixin from '../mixins/alert-notifications';
 
 const {inject, Component, Logger} = Ember;
 
 export default Component.extend(
-	AlertNotificationsMixin,
 	{
 		classNames: ['discussion-image-upload'],
 		staticAssets: inject.service(),

--- a/front/main/app/mixins/discussion-contribution-controller.js
+++ b/front/main/app/mixins/discussion-contribution-controller.js
@@ -495,7 +495,7 @@ export default Ember.Mixin.create({
 			this.get('model').attributes.saveTextAttribute('guidelines', text).then(() => {
 				track(trackActions.GuidelinesEditSave);
 			}).catch((err) => {
-				this.onContributionError(err, 'editor.save-error-general-error', true);
+				this.onContributionError(editorType, err, 'editor.save-error-general-error');
 			}).then(() => {
 				editorState.set('isLoading', false);
 			});
@@ -518,5 +518,9 @@ export default Ember.Mixin.create({
 				this.get('target').transitionTo('discussion.follow');
 			}
 		},
+
+		showError(editorType, messageKey) {
+			this.setEditorError(editorType, messageKey);
+		}
 	},
 });

--- a/front/main/app/models/discussion/domain/content-images.js
+++ b/front/main/app/models/discussion/domain/content-images.js
@@ -45,6 +45,10 @@ const DiscussionContentImages = Object.extend(
 						url,
 						width
 					});
+				})
+				.catch((err) => {
+					this.get('images').removeObject(image);
+					throw err;
 				});
 		},
 

--- a/front/main/app/templates/components/discussion-feed.hbs
+++ b/front/main/app/templates/components/discussion-feed.hbs
@@ -11,6 +11,7 @@
 			isLoading=editorState.isLoading
 			isVisible=editorState.isOpen
 			setEditorActive=(action this.attrs.setEditorActive)
+			showError=(action this.attrs.showError 'contributeEditor')
 	}}
 {{/if}}
 {{#modal-dialog
@@ -32,6 +33,7 @@
 			isEdit=true
 			isLoading=editEditorState.isLoading
 			setEditorActive=(action this.attrs.setEditorActive)
+			showError=(action this.attrs.showError 'editEditor')
 	}}
 {{/modal-dialog}}
 
@@ -78,6 +80,7 @@
 			postsDisplayed=model.entities.length
 			report=(action this.attrs.report)
 			setEditorActive=(action this.attrs.setEditorActive)
+			showError=(action this.attrs.showError 'contributeEditor')
 			shareTooltipSeen=shareTooltipSeen
 			stickEditorToGlobalNav=stickEditorToGlobalNav
 			totalPosts=model.postCount

--- a/front/main/app/templates/components/discussion-forum-wrapper.hbs
+++ b/front/main/app/templates/components/discussion-forum-wrapper.hbs
@@ -10,7 +10,7 @@
 		isActive=editorState.isOpen
 		isLoading=editorState.isLoading
 		setEditorActive=(action this.attrs.setEditorActive)
-		showError=(action this.attrs.showError 'contributeEditor')
+		showError=(action this.attrs.showError)
 	}}
 {{/if}}
 {{#unless isFollowedPostsView}}

--- a/front/main/app/templates/components/discussion-forum-wrapper.hbs
+++ b/front/main/app/templates/components/discussion-forum-wrapper.hbs
@@ -10,6 +10,7 @@
 		isActive=editorState.isOpen
 		isLoading=editorState.isLoading
 		setEditorActive=(action this.attrs.setEditorActive)
+		showError=(action this.attrs.showError 'contributeEditor')
 	}}
 {{/if}}
 {{#unless isFollowedPostsView}}

--- a/front/main/app/templates/components/discussion-image-upload-input.hbs
+++ b/front/main/app/templates/components/discussion-image-upload-input.hbs
@@ -3,4 +3,3 @@
 	<span>{{i18n 'image-upload.add-image' ns='discussion'}}</span>
 	<input style="display:none" type="file" accept="image/*"/>
 </label>
-

--- a/front/main/app/templates/components/discussion-image-upload.hbs
+++ b/front/main/app/templates/components/discussion-image-upload.hbs
@@ -6,6 +6,5 @@
 	{{discussion-image-upload-input
 		click=(action 'emptyClickForFileInput')
 		onImageSelected=(action 'onImageSelected')
-		reset=resetFileInput
 	}}
 {{/if}}

--- a/front/main/app/templates/components/discussion-image-upload.hbs
+++ b/front/main/app/templates/components/discussion-image-upload.hbs
@@ -4,7 +4,6 @@
 	</div>
 {{else}}
 	{{discussion-image-upload-input
-		click=(action 'emptyClickForFileInput')
 		onImageSelected=(action 'onImageSelected')
 	}}
 {{/if}}

--- a/front/main/app/templates/components/discussion-inline-editor.hbs
+++ b/front/main/app/templates/components/discussion-inline-editor.hbs
@@ -92,6 +92,7 @@
 				{{#if showImageUpload}}
 					{{discussion-image-upload
 						contentImages=contentImages
+						showError=(action this.attrs.showError)
 					}}
 				{{/if}}
 			</div>

--- a/front/main/app/templates/components/discussion-post.hbs
+++ b/front/main/app/templates/components/discussion-post.hbs
@@ -94,6 +94,7 @@
 				isLoading=editorState.isLoading
 				isReply=true
 				setEditorActive=(action this.attrs.setEditorActive)
+				showError=(action this.attrs.showError 'contributeEditor')
 			}}
 		{{/if}}
 		{{#if responsive.isMobile}}

--- a/front/main/app/templates/components/discussion-standalone-editor.hbs
+++ b/front/main/app/templates/components/discussion-standalone-editor.hbs
@@ -93,6 +93,7 @@
 		{{#if showImageUpload}}
 			{{discussion-image-upload
 				contentImages=contentImages
+				showError=(action this.attrs.showError)
 			}}
 		{{/if}}
 	{{/if}}

--- a/front/main/app/templates/discussion/follow.hbs
+++ b/front/main/app/templates/discussion/follow.hbs
@@ -26,6 +26,7 @@
 		setEditorActive=(action 'setEditorActive')
 		setSortBy=(action 'setSortBy')
 		shareTooltipSeen=shareTooltipSeen
+		showError=(action 'showError')
 		stickEditorToGlobalNav=stickEditorToGlobalNav
 		undeletePost=(action 'undeletePost')
 		unlockPost=(action 'unlockPost')

--- a/front/main/app/templates/discussion/forum.hbs
+++ b/front/main/app/templates/discussion/forum.hbs
@@ -25,6 +25,7 @@
 		setEditorActive=(action 'setEditorActive')
 		setSortBy=(action 'setSortBy')
 		shareTooltipSeen=shareTooltipSeen
+		showError=(action 'showError')
 		stickEditorToGlobalNav=stickEditorToGlobalNav
 		undeletePost=(action 'undeletePost')
 		unlockPost=(action 'unlockPost')

--- a/front/main/app/templates/discussion/post.hbs
+++ b/front/main/app/templates/discussion/post.hbs
@@ -11,6 +11,7 @@
 		isReply=true
 		isVisible=editorState.isOpen
 		setEditorActive=(action 'setEditorActive')
+		showError=(action 'showError')
 	}}
 {{/if}}
 
@@ -33,6 +34,7 @@
 		isEdit=true
 		isLoading=editEditorState.isLoading
 		setEditorActive=(action 'setEditorActive')
+		showError=(action 'showError')
 	}}
 {{/modal-dialog}}
 
@@ -63,6 +65,7 @@
 		report=(action 'report')
 		showFollowingTooltip=showFollowingTooltip
 		setEditorActive=(action 'setEditorActive')
+		showError=(action 'showError')
 		undeletePost=(action 'undeletePost')
 		undeleteReply=(action 'undeleteReply')
 		unlockPost=(action 'unlockPost')

--- a/front/main/app/templates/discussion/post.hbs
+++ b/front/main/app/templates/discussion/post.hbs
@@ -11,7 +11,7 @@
 		isReply=true
 		isVisible=editorState.isOpen
 		setEditorActive=(action 'setEditorActive')
-		showError=(action 'showError')
+		showError=(action 'showError' 'contributeEditor')
 	}}
 {{/if}}
 
@@ -34,7 +34,7 @@
 		isEdit=true
 		isLoading=editEditorState.isLoading
 		setEditorActive=(action 'setEditorActive')
-		showError=(action 'showError')
+		showError=(action 'showError' 'editEditor')
 	}}
 {{/modal-dialog}}
 

--- a/front/main/app/templates/discussion/reported-posts.hbs
+++ b/front/main/app/templates/discussion/reported-posts.hbs
@@ -17,7 +17,7 @@
 		isEdit=true
 		isLoading=editEditorState.isLoading
 		setEditorActive=(action 'setEditorActive')
-		showError=(action 'showError')
+		showError=(action 'showError' 'editEditor')
 	}}
 {{/modal-dialog}}
 

--- a/front/main/app/templates/discussion/reported-posts.hbs
+++ b/front/main/app/templates/discussion/reported-posts.hbs
@@ -17,6 +17,7 @@
 		isEdit=true
 		isLoading=editEditorState.isLoading
 		setEditorActive=(action 'setEditorActive')
+		showError=(action 'showError')
 	}}
 {{/modal-dialog}}
 

--- a/front/main/app/templates/discussion/user.hbs
+++ b/front/main/app/templates/discussion/user.hbs
@@ -17,7 +17,7 @@
 		isEdit=true
 		isLoading=editEditorState.isLoading
 		setEditorActive=(action 'setEditorActive')
-		showError=(action 'showError')
+		showError=(action 'showError' 'editEditor')
 	}}
 {{/modal-dialog}}
 

--- a/front/main/app/templates/discussion/user.hbs
+++ b/front/main/app/templates/discussion/user.hbs
@@ -17,6 +17,7 @@
 		isEdit=true
 		isLoading=editEditorState.isLoading
 		setEditorActive=(action 'setEditorActive')
+		showError=(action 'showError')
 	}}
 {{/modal-dialog}}
 


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/IRIS-1635

## Description

Use editor errors instead of global `alert-notifications`.
Remove input reset from `discussion-image-upload` as the component is destroyed when the upload starts.

## Reviewers

@slayful 
/cc @bkoval @kvas-damian 