### PR TITLE
IRIS-5013 | Use thumbnails for avatars

### DIFF
--- a/front/main/app/components/discussion-reply-editor-entry-point.js
+++ b/front/main/app/components/discussion-reply-editor-entry-point.js
@@ -1,13 +1,15 @@
 import Ember from 'ember';
 import DiscussionStickyComponentMixin from '../mixins/discussion-sticky-component';
 
-const {Component} = Ember;
+const {Component, inject} = Ember;
 
 export default Component.extend(
 	DiscussionStickyComponentMixin,
 	{
 		classNames: ['discussion-reply-editor-entry-point'],
 		containerSelector: '.discussion-editor-entry-point-container',
+
+		currentUser: inject.service(),
 
 		click() {
 			this.sendAction('setEditorActive', 'contributeEditor', true);

--- a/front/main/app/components/user-avatar.js
+++ b/front/main/app/components/user-avatar.js
@@ -1,4 +1,5 @@
 import Ember from 'ember';
+import Thumbnailer from 'common/modules/thumbnailer';
 import {isAnonymousUser} from '../utils/user-utils';
 
 const {Component, computed} = Ember;
@@ -6,27 +7,40 @@ const {Component, computed} = Ember;
 export default Component.extend({
 	classNames: ['user-avatar'],
 
+	userId: null,
+	size: 30,
+
 	profileName: computed('username', function () {
 		const userName = this.get('username') || '';
 
 		return userName.trim();
 	}),
 
-	userId: null,
-	/**
-	 * Returns link to the post author's user page
-	 * @returns {string}
-	 */
 	profileUrl: computed('profileName', function () {
 		return M.buildUrl({
 			namespace: 'User',
 			title: this.get('profileName'),
 		});
 	}),
-	displayName: Ember.computed('profileName', 'userId', function () {
+
+	displayName: computed('profileName', 'userId', function () {
 		return isAnonymousUser(this.get('userId')) ? i18n.t('app.username-anonymous') : this.get('profileName');
 	}),
-	shouldWrapInHref: Ember.computed('userId', function () {
+
+	shouldWrapInHref: computed('userId', function () {
 		return !isAnonymousUser(this.get('userId'));
+	}),
+
+	avatarThumbnail: computed('avatarUrl', 'size', function () {
+		const size = this.get('size');
+
+		return Thumbnailer.getThumbURL(
+			this.get('avatarUrl'),
+			{
+				mode: Thumbnailer.mode.fixedAspectRatioDown,
+				height: size,
+				width: size
+			}
+		);
 	})
 });

--- a/front/main/app/templates/components/discussion-contributors.hbs
+++ b/front/main/app/templates/components/discussion-contributors.hbs
@@ -5,6 +5,7 @@
 			badgePermission=contributor.badgePermission
 			username=contributor.name
 			userId=contributor.id
+			size=30
 		}}
 	{{/track-click}}
 {{else}}

--- a/front/main/app/templates/components/discussion-inline-editor.hbs
+++ b/front/main/app/templates/components/discussion-inline-editor.hbs
@@ -17,6 +17,7 @@
 		{{user-avatar
 			avatarUrl=currentUser.avatarPath
 			shouldWrapInHref=false
+			size=40
 		}}
 		{{#if showOverlayMessage}}
 			{{discussion-editor-overlay-message

--- a/front/main/app/templates/components/discussion-post-card-detail.hbs
+++ b/front/main/app/templates/components/discussion-post-card-detail.hbs
@@ -14,6 +14,7 @@
 				avatarUrl=author.avatarUrl
 				badgePermission=author.badgePermission
 				displayProfileName=true
+				size=42
 				username=author.name
 				userId=author.id
 		}}

--- a/front/main/app/templates/components/discussion-post-card-reply.hbs
+++ b/front/main/app/templates/components/discussion-post-card-reply.hbs
@@ -24,6 +24,7 @@
 			displayProfileName=true
 			username=author.name
 			userId=author.id
+			size=30
 		}}
 		<span class="timestamp" title="{{timestamp-to-date post.creationTimestamp}}">
 			&bull; {{time-ago post.creationTimestamp}}

--- a/front/main/app/templates/components/discussion-reply-editor-entry-point.hbs
+++ b/front/main/app/templates/components/discussion-reply-editor-entry-point.hbs
@@ -2,6 +2,7 @@
 	{{user-avatar
 		avatarUrl=currentUser.avatarPath
 		shouldWrapInHref=false
+		size=30
 	}}
 
 	<div class="discussion-editor-entry-point-content">

--- a/front/main/app/templates/components/discussion-report-details-user-list.hbs
+++ b/front/main/app/templates/components/discussion-report-details-user-list.hbs
@@ -12,6 +12,7 @@
 				displayProfileName=true
 				username=user.name
 				userId=user.id
+				size=42
 			}}
 		</li>
 	{{/each}}

--- a/front/main/app/templates/components/discussion-user-activity-list.hbs
+++ b/front/main/app/templates/components/discussion-user-activity-list.hbs
@@ -7,6 +7,7 @@
 				displayProfileName=false
 				username=item.userInfo.name
 				userId=item.userInfo.id
+				size=42
 			}}
 			<div class="username">
 				<a href="{{item.userInfo.profileUrl}}">{{item.userInfo.name}}</a>

--- a/front/main/app/templates/components/left-rail-details.hbs
+++ b/front/main/app/templates/components/left-rail-details.hbs
@@ -1,9 +1,10 @@
 {{#if users}}
 	{{user-avatar
 		avatarUrl=userProfile.avatarUrl
-		shouldWrapInHref=true
-		username=userName
 		click=(action 'trackAvatarClick')
+		username=userName
+		shouldWrapInHref=true
+		size=90
 	}}
 {{else}}
 	<div class="discussion-left-rail__circle">

--- a/front/main/app/templates/components/user-avatar.hbs
+++ b/front/main/app/templates/components/user-avatar.hbs
@@ -2,14 +2,14 @@
 	{{#if shouldWrapInHref}}
 		<a class="user-avatar__link" href="{{profileUrl}}" title="{{displayName}}">
 			{{#if avatarUrl}}
-				<img class="user-avatar__image" src="{{avatarUrl}}" alt="Avatar">
+				<img class="user-avatar__image" src="{{avatarThumbnail}}" alt="Avatar">
 			{{else}}
 				{{svg 'avatar' viewBox='0 0 40 40' class='icon user-avatar__image'}}
 			{{/if}}
 		</a>
 	{{else}}
 		{{#if avatarUrl}}
-			<img class="user-avatar__image" src="{{avatarUrl}}" title="{{displayName}}" alt="Avatar">
+			<img class="user-avatar__image" src="{{avatarThumbnail}}" title="{{displayName}}" alt="Avatar">
 		{{else}}
 			{{svg 'avatar' viewBox='0 0 40 40' class='icon user-avatar__image'}}
 		{{/if}}

--- a/front/main/app/templates/components/wds-avatar-stack.hbs
+++ b/front/main/app/templates/components/wds-avatar-stack.hbs
@@ -1,9 +1,10 @@
 {{#each avatars as |avatar|}}
 	<div class="wds-avatar-stack__avatar">
 		{{user-avatar
-				avatarUrl=avatar.avatarUrl
-				username=avatar.name
-				userId=avatar.id
+			avatarUrl=avatar.avatarUrl
+			username=avatar.name
+			userId=avatar.id
+			size=30
 		}}
 	</div>
 {{/each}}

--- a/front/main/app/templates/components/wikia-user-profile.hbs
+++ b/front/main/app/templates/components/wikia-user-profile.hbs
@@ -11,8 +11,9 @@
 
 	<header class="wikia-user-profile__header-wrapper">
 		{{user-avatar
-				username=username
-				avatarUrl=currentUser.avatarPath
+			avatarUrl=currentUser.avatarPath
+			size=94
+			username=username
 		}}
 		<h4 class="wikia-user-profile__username">{{username}}</h4>
 	</header>


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/IRIS-5013

## Description

Use thumbnails instead of full-size images. Doesn't work for default wiki avatars like http://images.wikia.com/messaging/images/e/e5/Avatar4.jpg.

I chose the sizes based on CSS.

## Reviewers

@slayful 