### PR TITLE
IRIS-1620 | Hide open graph when there is content image

### DIFF
--- a/front/main/app/components/discussion-guidelines-editor.js
+++ b/front/main/app/components/discussion-guidelines-editor.js
@@ -8,7 +8,6 @@ export default DiscussionStandaloneEditor.extend({
 	isReply: false,
 	openGraph: null,
 	shouldShowCategoryPicker: false,
-	showsOpenGraphCard: false,
 
 	layoutName: 'components/discussion-standalone-editor',
 

--- a/front/main/app/components/discussion-inline-editor.js
+++ b/front/main/app/components/discussion-inline-editor.js
@@ -72,14 +72,12 @@ export default DiscussionMultipleInputsEditor.extend(
 				if (!this.get('submitDisabled')) {
 					const newDiscussionEntityData = {
 						body: this.get('content'),
-						creatorId: this.get('currentUser.userId'),
-						siteId: Mercury.wiki.id,
-						title: this.get('title'),
 						contentImages: this.get('contentImages').toData(),
+						creatorId: this.get('currentUser.userId'),
+						openGraph: this.get('openGraph'),
+						siteId: Mercury.wiki.id,
+						title: this.get('title')
 					};
-					if (this.get('showsOpenGraphCard')) {
-						newDiscussionEntityData.openGraph = this.get('openGraph');
-					}
 
 					this.get('create')(newDiscussionEntityData, {newCategoryId: this.get('category.id')});
 				}

--- a/front/main/app/components/discussion-post-card-detail.js
+++ b/front/main/app/components/discussion-post-card-detail.js
@@ -22,8 +22,8 @@ export default DiscussionPostCardBaseComponent.extend(
 		// Whether the component is displayed on the post details discussion page
 		isDetailsView: false,
 
-		showOpenGraphCard: computed('post.contentImages.images', 'post.openGraph', function () {
-			return Ember.isEmpty(this.get('post.contentImages.images')) && Boolean(this.get('post.openGraph'));
+		showOpenGraphCard: computed('post.contentImages.images.@each', 'post.openGraph', function () {
+			return !this.get('post.contentImages').hasImages() && Boolean(this.get('post.openGraph'));
 		}),
 
 		// URL passed to the ShareFeatureComponent for sharing a post

--- a/front/main/app/components/discussion-standalone-editor.js
+++ b/front/main/app/components/discussion-standalone-editor.js
@@ -70,10 +70,9 @@ export default DiscussionMultipleInputsEditor.extend(
 
 			this.setProperties({
 				content: editEntity.get('rawContent'),
-				openGraph: editEntity.get('openGraph'),
-				showsOpenGraphCard: Boolean(editEntity.get('openGraph')),
-				title: editEntity.get('title'),
 				contentImages: editEntity.get('contentImages').copy(),
+				openGraph: editEntity.get('openGraph'),
+				title: editEntity.get('title'),
 			});
 
 			this.focusFirstTextareaWhenRendered();
@@ -141,11 +140,12 @@ export default DiscussionMultipleInputsEditor.extend(
 						body: this.get('content'),
 						title: this.get('title')
 					};
+					const openGraph = this.get('openGraph');
 					let actionName,
 						editedEntity;
 
-					if (this.get('showsOpenGraphCard')) {
-						discussionEntityData.openGraph = this.get('openGraph');
+					if (openGraph) {
+						discussionEntityData.openGraph = openGraph;
 					}
 
 					if (this.get('contentImages')) {

--- a/front/main/app/mixins/discussion-editor-opengraph.js
+++ b/front/main/app/mixins/discussion-editor-opengraph.js
@@ -116,7 +116,10 @@ export default Mixin.create({
 	},
 
 	setOpenGraphProperties(url) {
-		if (this.get('openGraph') || this.get('contentImages').hasImages()) {
+		if (
+			this.get('openGraph') ||
+			this.get('contentImages').hasImages()
+		) {
 			return;
 		}
 

--- a/front/main/app/models/discussion/domain/content-images.js
+++ b/front/main/app/models/discussion/domain/content-images.js
@@ -20,7 +20,7 @@ const DiscussionContentImages = Object.extend(
 		}),
 
 		hasImages() {
-			return this.get('images.length');
+			return this.get('images.length') > 0;
 		},
 
 		setImages(images) {

--- a/front/main/app/templates/components/discussion-inline-editor.hbs
+++ b/front/main/app/templates/components/discussion-inline-editor.hbs
@@ -76,7 +76,7 @@
 						readonly=isReadonly
 					}}
 				</label>
-				{{#if showsOpenGraphCard}}
+				{{#if showOpenGraphCard}}
 					{{discussion-open-graph
 						close=(action 'removeOpenGraph')
 						isLoading=isOpenGraphLoading

--- a/front/main/app/templates/components/discussion-standalone-editor.hbs
+++ b/front/main/app/templates/components/discussion-standalone-editor.hbs
@@ -75,7 +75,7 @@
 				value=content
 			}}
 		</label>
-		{{#if showsOpenGraphCard}}
+		{{#if showOpenGraphCard}}
 			{{discussion-open-graph
 				close=(action 'removeOpenGraph')
 				isLoading=isOpenGraphLoading


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/IRIS-1620

## Description

A content image has priority over an open graph. Save both to service, it's handled by mobile apps as expected.

## Reviewers

@slayful 