### PR TITLE
Update vignette-js to fix default avatar URLs

### DIFF
--- a/front/main/bower.json
+++ b/front/main/bower.json
@@ -23,7 +23,7 @@
     "sinonjs": "1.17.1",
     "script.js": "2.5.7",
     "tinycolor": "1.3.0",
-    "vignette": "wikia/vignette-js#3c15319ce31c81061958ac881821624ac10f0bb6",
+    "vignette": "wikia/vignette-js#2.7.0",
     "visit-source": "Wikia/visit-source#0.1.1",
     "weppy": "Wikia/weppy#0.9.3",
     "wikia-style-guide": "Wikia/style-guide#v1.9.0",

--- a/front/main/bower.json
+++ b/front/main/bower.json
@@ -23,7 +23,7 @@
     "sinonjs": "1.17.1",
     "script.js": "2.5.7",
     "tinycolor": "1.3.0",
-    "vignette": "wikia/vignette-js#2.6.0",
+    "vignette": "wikia/vignette-js#3c15319ce31c81061958ac881821624ac10f0bb6",
     "visit-source": "Wikia/visit-source#0.1.1",
     "weppy": "Wikia/weppy#0.9.3",
     "wikia-style-guide": "Wikia/style-guide#v1.9.0",


### PR DESCRIPTION
## Links

* https://wikia-inc.atlassian.net/browse/MAIN-11576
* https://github.com/Wikia/vignette-js/pull/35

## Reviewers

@slayful 