### PR TITLE
Parse payload JSON to make sure requested-closure-date gets user id

### DIFF
--- a/server/app/facets/auth/piggyback.js
+++ b/server/app/facets/auth/piggyback.js
@@ -74,7 +74,7 @@ export function post(request, reply) {
 			if (accessToken && accessToken.length) {
 				reply.state('access_token', accessToken);
 			}
-			reply({payload}).code(HttpStatus.OK);
+			reply(payload).code(HttpStatus.OK);
 		}).catch(data => {
 			const errors = translateError(data, (error) => {
 				let errorHandler = 'server-error';

--- a/server/app/facets/auth/piggyback.js
+++ b/server/app/facets/auth/piggyback.js
@@ -69,11 +69,12 @@ export function post(request, reply) {
 
 	piggybackAsUser(username, password, targetUsername, request)
 		.then(data => {
-			const accessToken = JSON.parse(data.payload).access_token;
+			const payload = JSON.parse(data.payload);
+			const accessToken = payload.access_token;
 			if (accessToken && accessToken.length) {
 				reply.state('access_token', accessToken);
 			}
-			reply({payload: data.payload}).code(HttpStatus.OK);
+			reply({payload}).code(HttpStatus.OK);
 		}).catch(data => {
 			const errors = translateError(data, (error) => {
 				let errorHandler = 'server-error';

--- a/server/app/facets/auth/reset-password.js
+++ b/server/app/facets/auth/reset-password.js
@@ -105,7 +105,7 @@ export function post(request, reply) {
 		updatePasswordFor(username, password, token, request)
 			.then(data => {
 				reply({
-					payload: data.payload
+					payload: JSON.parse(data.payload)
 				}).code(200);
 			}).catch(data => {
 				const errors = translateError(data, (error) => {

--- a/server/app/facets/auth/reset-password.js
+++ b/server/app/facets/auth/reset-password.js
@@ -104,9 +104,7 @@ export function post(request, reply) {
 	} else {
 		updatePasswordFor(username, password, token, request)
 			.then(data => {
-				reply({
-					payload: JSON.parse(data.payload)
-				}).code(200);
+				reply(JSON.parse(data.payload)).code(200);
 			}).catch(data => {
 				const errors = translateError(data, (error) => {
 					let errorHandler = 'server-error';

--- a/server/app/facets/auth/signin.js
+++ b/server/app/facets/auth/signin.js
@@ -112,10 +112,10 @@ function doSignin(request, reply) {
 			if (accessToken && accessToken.length) {
 				reply.state('access_token', accessToken);
 			}
-			reply({payload}).code(HttpStatus.OK);
+			reply(payload).code(HttpStatus.OK);
 		}).catch(data => {
 			const payload = JSON.parse(data.payload);
-			reply({payload}).code(data.response.statusCode);
+			reply(payload).code(data.response.statusCode);
 		});
 }
 
@@ -130,11 +130,11 @@ function doFacebookSignin(request, reply) {
 			if (accessToken && accessToken.length) {
 				reply.state('access_token', accessToken);
 			}
-			reply({payload}).code(HttpStatus.OK);
+			reply(payload).code(HttpStatus.OK);
 		}).catch(data => {
 			const payload = JSON.parse(data.payload);
 
-			reply({payload}).code(data.response.statusCode);
+			reply(payload).code(data.response.statusCode);
 		});
 }
 

--- a/server/app/facets/auth/signin.js
+++ b/server/app/facets/auth/signin.js
@@ -106,13 +106,16 @@ function doSignin(request, reply) {
 
 	signinUser(username, password, request)
 		.then(data => {
-			const accessToken = JSON.parse(data.payload).access_token;
+			const payload = JSON.parse(data.payload);
+			const accessToken = payload.access_token;
+
 			if (accessToken && accessToken.length) {
 				reply.state('access_token', accessToken);
 			}
-			reply({payload: data.payload}).code(HttpStatus.OK);
+			reply({payload}).code(HttpStatus.OK);
 		}).catch(data => {
-			reply({payload: data.payload}).code(data.response.statusCode);
+			const payload = JSON.parse(data.payload);
+			reply({payload}).code(data.response.statusCode);
 		});
 }
 
@@ -121,13 +124,17 @@ function doFacebookSignin(request, reply) {
 
 	signinFacebookUser(fbAccessToken, request)
 		.then(data => {
-			const accessToken = JSON.parse(data.payload).access_token;
+			const payload = JSON.parse(data.payload);
+			const accessToken = payload.access_token;
+
 			if (accessToken && accessToken.length) {
 				reply.state('access_token', accessToken);
 			}
-			reply({payload: data.payload}).code(HttpStatus.OK);
+			reply({payload}).code(HttpStatus.OK);
 		}).catch(data => {
-			reply({payload: data.payload}).code(data.response.statusCode);
+			const payload = JSON.parse(data.payload);
+
+			reply({payload}).code(data.response.statusCode);
 		});
 }
 


### PR DESCRIPTION
## Links

* https://kibana5.wikia-inc.com/goto/b0f9cbca59264ff26706acbc4eca3fbd

## Description

We were passing a stringified object from server to client and then treat it as an object, see https://github.com/Wikia/mercury/blob/09935dee9800bc3e87364a5e60c6e7929e97ce6a/front/auth/app/common/login.js#L128
Because of that, we were sending request to `/user-preference/undefined/global/requested-closure-date`

## Reviewers

@slayful 