### PR TITLE
SEC-55 | Log all GET /logout requests

### DIFF
--- a/server/app/facets/auth/logout.js
+++ b/server/app/facets/auth/logout.js
@@ -1,9 +1,17 @@
+import Logger from '../../lib/logger';
+
 /**
  * @param {Hapi.Request} request
  * @param {*} reply
  * @returns {void}
  */
 export default function logout(request, reply) {
+	// SEC-55: Check if there is anything using this
+	Logger.warn({
+		message: 'Legacy logout endpoint called via GET',
+		referrer: request.info.referrer
+	});
+
 	const userLogoutURL = '/wiki/Special:UserLogout';
 	reply.redirect(userLogoutURL);
 }


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/SEC-55

## Description
The theory is that nothing is using GET request to /logout handler to log out user, since all clients have been changed to use a POST instead. Let's verify this by logging unwanted GET requests.
