### PR TITLE
SEC-55 | Use POST instead of GET for /logout on connection error

### DIFF
--- a/front/auth/app/facebook/facebook-connect.js
+++ b/front/auth/app/facebook/facebook-connect.js
@@ -125,7 +125,7 @@ export default class FacebookConnect extends Login {
 				this.authLogger.xhrError(facebookConnectXhr);
 
 				// Logout user on connection error
-				logoutXhr.open('GET', '/logout', true);
+				logoutXhr.open('POST', '/logout', true);
 				logoutXhr.send();
 			}
 		};


### PR DESCRIPTION
## Links

* http://wikia-inc.atlassian.net/browse/SEC-55

## Description
Use POST instead of GET to log out user if an error occurs during the Facebook connect phase
